### PR TITLE
fix: add format: secret-ref to bot token and transcription API key fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,13 +104,24 @@ curl -X POST http://127.0.0.1:3100/api/plugins/install \
   -d '{"packageName":"paperclip-plugin-telegram"}'
 ```
 
-### 4. Configure
+### 4. Store your bot token as a Paperclip secret
+
+The bot token field requires a Paperclip secret reference (a UUID), not the raw token.
+
+1. In Paperclip, go to **Settings → Secrets → Create new secret**
+2. Paste your Telegram bot token as the secret value and save
+3. Copy the UUID of the created secret
+4. Use that UUID in the `telegramBotTokenRef` field below
+
+Do the same for `transcriptionApiKeyRef` if you want Whisper transcription.
+
+### 5. Configure
 
 In your Paperclip instance settings, configure:
 
 | Setting | Required | Description |
 |---------|----------|-------------|
-| `telegramBotTokenRef` | Yes | Secret reference to your bot token |
+| `telegramBotTokenRef` | Yes | Secret UUID for your bot token (see step 4) |
 | `defaultChatId` | Yes | Chat ID for notifications |
 | `approvalsChatId` | No | Separate chat for approvals |
 | `errorsChatId` | No | Separate chat for errors |
@@ -128,7 +139,7 @@ In your Paperclip instance settings, configure:
 | `maxSuggestionsPerHourPerCompany` | No | Rate limit for proactive suggestions (default: 10) |
 | `watchDeduplicationWindowMs` | No | Window before same watch+entity can re-fire (default: 86400000 / 24h) |
 
-### 5. Add bot to group (optional)
+### 6. Add bot to group (optional)
 
 If using a group chat:
 1. Add the bot to your Telegram group
@@ -174,6 +185,20 @@ When a user replies to a bot notification, the plugin looks up which Paperclip e
 | Custom commands | No | Importable multi-step workflows |
 | Proactive suggestions | No | Watch conditions with built-in sales templates |
 | Architecture | Monorepo example | Standalone npm package |
+
+## Migration
+
+### v0.2.1
+
+The `telegramBotTokenRef` and `transcriptionApiKeyRef` fields now require a Paperclip secret reference (a UUID), not the raw token value. If you previously entered your raw bot token in the field, follow these steps to migrate:
+
+1. Go to **Settings → Secrets → Create new secret**
+2. Paste your Telegram bot token as the secret value and save
+3. Copy the resulting UUID
+4. Open **Plugin Settings for Telegram Bot** and paste the UUID into "Telegram Bot Token"
+5. Save and restart the plugin
+
+The plugin will fail to activate if a raw token (non-UUID) is entered in the field.
 
 ## Development
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,5 @@
 export const PLUGIN_ID = "paperclip-plugin-telegram";
-export const PLUGIN_VERSION = "0.2.0";
+export const PLUGIN_VERSION = "0.2.1";
 
 export const DEFAULT_CONFIG = {
   telegramBotTokenRef: "",

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -39,9 +39,10 @@ const manifest: PaperclipPluginManifestV1 = {
     properties: {
       telegramBotTokenRef: {
         type: "string",
+        format: "secret-ref",
         title: "Telegram Bot Token (secret reference)",
         description:
-          "Reference to the Telegram Bot token stored in your secret provider. Get one from @BotFather.",
+          "Secret UUID for your Telegram Bot token. Create the secret in Settings → Secrets, then paste its UUID here. Get a token from @BotFather.",
         default: DEFAULT_CONFIG.telegramBotTokenRef,
       },
       defaultChatId: {
@@ -176,8 +177,9 @@ const manifest: PaperclipPluginManifestV1 = {
       },
       transcriptionApiKeyRef: {
         type: "string",
+        format: "secret-ref",
         title: "Transcription API Key (secret reference)",
-        description: "Reference to OpenAI API key for Whisper transcription of voice/audio messages.",
+        description: "Secret UUID for your OpenAI API key used for Whisper transcription. Create the secret in Settings → Secrets, then paste its UUID here.",
         default: DEFAULT_CONFIG.transcriptionApiKeyRef,
       },
       maxSuggestionsPerHourPerCompany: {


### PR DESCRIPTION
## Summary

- `telegramBotTokenRef` and `transcriptionApiKeyRef` in `src/manifest.ts` were missing `"format": "secret-ref"`
- This caused plugin activation to fail with: `Invalid secret reference: <bot token>`
- Adds `format: "secret-ref"` to both fields, updates descriptions, bumps to v0.2.1

## Root Cause

`collectSecretRefPaths()` in `plugin-secrets-handler.ts` walks `instanceConfigSchema` looking for `propSchema.format === "secret-ref"`. Without the annotation:
1. The UI rendered a plain text input (unmaksed) — users entered raw tokens, not UUIDs
2. The field paths weren't collected → scope check failed even for valid UUIDs
3. `ctx.secrets.resolve()` received the raw token, `isUuid()` threw `InvalidSecretRefError`

## Changes

- `src/manifest.ts`: Added `format: "secret-ref"` to `telegramBotTokenRef` and `transcriptionApiKeyRef`; updated descriptions to guide users to paste a secret UUID
- `src/constants.ts`: Bumped `PLUGIN_VERSION` from `0.2.0` to `0.2.1`
- `README.md`: Added step 4 ("Store your bot token as a Paperclip secret") to Setup; renumbered steps; added v0.2.1 migration note

## No worker changes needed

The worker already calls `ctx.secrets.resolve(config.telegramBotTokenRef)` correctly — it was always designed to receive a UUID. The manifest was never annotated.

## Post-Deploy Monitoring & Validation

- **What to monitor**: Plugin activation logs for `Invalid secret reference` errors
- **Expected healthy behavior**: Zero activation failures after users re-configure with secret UUIDs
- **Failure signal**: Continued `InvalidSecretRefError` → user entered raw token instead of UUID; refer them to README migration note
- **Breaking change**: Users who previously entered raw bot tokens must re-configure (create a secret, enter its UUID). Migration instructions added to README.

## Related

- Same issue exists in `mvanhorn/paperclip-plugin-discord` (`discordBotTokenRef`) — separate fix coming
- Reported by gsxdsm on Discord

🤖 Generated with Claude Sonnet 4.6 via Claude Code (https://claude.com/claude-code) + Compound Engineering v2.45.0