### PR TITLE
fix: reduce Telegram long polling timeout to prevent RPC bridge race

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -162,7 +162,7 @@ const plugin = definePlugin({
       while (pollingActive) {
         try {
           const res = await ctx.http.fetch(
-            `${TELEGRAM_API}/bot${token}/getUpdates?offset=${lastUpdateId + 1}&timeout=30&allowed_updates=["message","callback_query"]`,
+            `${TELEGRAM_API}/bot${token}/getUpdates?offset=${lastUpdateId + 1}&timeout=10&allowed_updates=["message","callback_query"]`,
             { method: "GET" },
           );
           const data = (await res.json()) as {


### PR DESCRIPTION
## Problem

The Telegram `getUpdates` long polling call uses `timeout=30` (seconds), which matches the Paperclip host's RPC bridge timeout of 30000ms exactly. Since the `http.fetch` host handler needs additional time beyond the raw HTTP request (DNS resolution, SSRF validation, response serialization), the RPC bridge timeout fires before the Telegram response arrives on nearly every poll cycle. This produces:

```
JsonRpcCallError: Worker→host call "http.fetch" timed out after 30000ms
```

The plugin is effectively non-functional because every poll cycle errors out.

## Fix

Reduce the Telegram `getUpdates` `timeout` parameter from 30 to 10 seconds. This keeps the long polling benefit (Telegram holds the connection and pushes updates immediately when available) while staying well within the 30s RPC bridge limit, leaving ~20s of headroom for bridge overhead.