### PR TITLE
fix: resolve company name to UUID in /connect command

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -263,47 +263,60 @@ async function handleConnect(
   messageThreadId?: number,
 ): Promise<void> {
   if (!companyArg.trim()) {
-    await sendMessage(ctx, token, chatId, "Usage: /connect <company-name-or-id>", {
-      messageThreadId,
-    });
+    try {
+      const companies = await ctx.companies.list();
+      const names = companies.map((c) => c.name || c.id).join(", ");
+      await sendMessage(ctx, token, chatId, `Usage: /connect <company-name>\nAvailable: ${names || "none"}`, { messageThreadId });
+    } catch {
+      await sendMessage(ctx, token, chatId, "Usage: /connect <company-name>", { messageThreadId });
+    }
     return;
   }
 
-  const input = companyArg.trim();
-  const companies = await ctx.companies.list();
-  // Match by ID, name (case-insensitive), or shortname prefix
-  const match = companies.find(
-    (c) =>
-      c.id === input ||
-      c.name?.toLowerCase() === input.toLowerCase(),
-  );
+  try {
+    const input = companyArg.trim();
+    const companies = await ctx.companies.list();
+    const match = companies.find(
+      (c) =>
+        c.id === input ||
+        c.name?.toLowerCase() === input.toLowerCase(),
+    );
 
-  if (!match) {
-    const available = companies.map((c) => c.name || c.id).join(", ");
+    if (!match) {
+      const names = companies.map((c) => c.name || c.id).join(", ");
+      await sendMessage(
+        ctx,
+        token,
+        chatId,
+        `Company "${input}" not found. Available: ${names || "none"}`,
+        { messageThreadId },
+      );
+      return;
+    }
+
+    await ctx.state.set(
+      { scopeKind: "instance", stateKey: `chat_${chatId}` },
+      { companyId: match.id, companyName: match.name ?? input, linkedAt: new Date().toISOString() },
+    );
+
     await sendMessage(
       ctx,
       token,
       chatId,
-      `Company not found: "${input}". Available: ${available}`,
+      `${escapeMarkdownV2("🔗")} ${escapeMarkdownV2("Linked this chat to company:")} *${escapeMarkdownV2(match.name ?? input)}*`,
+      { parseMode: "MarkdownV2", messageThreadId },
+    );
+
+    ctx.logger.info("Chat linked to company", { chatId, companyId: match.id, companyName: match.name });
+  } catch (err) {
+    await sendMessage(
+      ctx,
+      token,
+      chatId,
+      `Failed to connect: ${err instanceof Error ? err.message : String(err)}`,
       { messageThreadId },
     );
-    return;
   }
-
-  await ctx.state.set(
-    { scopeKind: "instance", stateKey: `chat_${chatId}` },
-    { companyId: match.id, companyName: match.name ?? input, linkedAt: new Date().toISOString() },
-  );
-
-  await sendMessage(
-    ctx,
-    token,
-    chatId,
-    `${escapeMarkdownV2("🔗")} ${escapeMarkdownV2("Linked this chat to company:")} *${escapeMarkdownV2(match.name ?? input)}*`,
-    { parseMode: "MarkdownV2", messageThreadId },
-  );
-
-  ctx.logger.info("Chat linked to company", { chatId, companyId: match.id, companyName: match.name });
 }
 
 export async function handleConnectTopic(


### PR DESCRIPTION
## Summary

The `/connect` command stores the company name as a string, but SDK methods like `agents.list`, `issues.list`, and `companies.get` expect a company UUID. This causes `"invalid input syntax for type uuid"` errors when using `/status`, `/issues`, and `/agents` after connecting.

**Changes:**

- `/connect` with no arguments now lists available companies from the API, making it easier to discover the correct company name
- Wrapped the company lookup and state persistence in try/catch so network errors or SDK failures return a clear error message instead of an unhandled exception
- Graceful fallback in the no-args path: if `companies.list()` fails, still shows the basic usage message

The core UUID resolution (`resolveCompanyId` preferring `companyId` over `companyName`) and the company lookup logic were already addressed in 631c6e5. This PR improves the remaining rough edges: discoverability and error resilience.

## Test plan

- [ ] Run `/connect` with no arguments — should list available companies
- [ ] Run `/connect InvalidName` — should show "not found" with available companies
- [ ] Run `/connect <valid-name>` — should link and store UUID
- [ ] Run `/status` after linking — should work without UUID errors
- [ ] Disconnect network during `/connect` — should show "Failed to connect" message