### PR TITLE
fix: use native fetch for voice transcription to avoid RPC bridge binary corruption

### DIFF
--- a/src/media-pipeline.ts
+++ b/src/media-pipeline.ts
@@ -167,42 +167,38 @@ async function transcribeAudio(
   fileId: string,
   transcriptionApiKeyRef: string,
 ): Promise<string | null> {
-  // 1. Get file path from Telegram
+  // 1. Get file path from Telegram (JSON response — ctx.http.fetch works fine for this)
   const fileRes = await ctx.http.fetch(
     `${TELEGRAM_API}/bot${botToken}/getFile?file_id=${fileId}`,
     { method: "GET" },
   );
-  const fileData = (await fileRes.json()) as {
-    ok: boolean;
-    result?: { file_path: string };
-  };
-
+  const fileData = (await fileRes.json()) as { ok: boolean; result?: { file_path?: string } };
   if (!fileData.ok || !fileData.result?.file_path) {
     ctx.logger.error("Failed to get file path from Telegram", { fileId });
     return null;
   }
 
-  // 2. Download the file
+  // 2. Download binary audio using native fetch (bypasses RPC bridge UTF-8 corruption)
   const downloadUrl = `${TELEGRAM_API}/file/bot${botToken}/${fileData.result.file_path}`;
-  const audioRes = await ctx.http.fetch(downloadUrl, { method: "GET" });
-  const audioBlob = await audioRes.blob();
+  const audioRes = await fetch(downloadUrl);
+  const audioBuffer = Buffer.from(await audioRes.arrayBuffer());
 
-  // 3. Send to Whisper API
+  // 3. Resolve the OpenAI API key from Paperclip secrets
   const apiKey = await ctx.secrets.resolve(transcriptionApiKeyRef);
+
+  // 4. Build multipart form data manually (native FormData + Blob works in Node 18+)
   const formData = new FormData();
-  formData.append("file", audioBlob, "audio.ogg");
+  formData.append("file", new Blob([audioBuffer], { type: "audio/ogg" }), "audio.ogg");
   formData.append("model", "whisper-1");
 
-  const whisperRes = await ctx.http.fetch(
-    "https://api.openai.com/v1/audio/transcriptions",
-    {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-      },
-      body: formData,
+  // 5. Send to Whisper API using native fetch (FormData can't be serialized through RPC bridge)
+  const whisperRes = await fetch("https://api.openai.com/v1/audio/transcriptions", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
     },
-  );
+    body: formData,
+  });
 
   const whisperData = (await whisperRes.json()) as { text?: string };
   return whisperData.text ?? null;


### PR DESCRIPTION
## Summary

- **Problem**: `ctx.http.fetch()` goes through Paperclip's RPC bridge, which serializes response bodies as UTF-8 strings (`Buffer.toString("utf8")`). This corrupts binary audio data when downloading voice messages from Telegram. Additionally, `FormData` request bodies become `"[object FormData]"` when serialized through the bridge, breaking the Whisper API upload.
- **Fix**: Use native Node.js `fetch()` (available in Node 18+) for the two operations that handle binary data: downloading audio from Telegram and uploading multipart form data to the Whisper API.
- **Kept as-is**: `ctx.http.fetch` for the `getFile` JSON API call (JSON serialization works fine through RPC) and `ctx.secrets.resolve` for API key retrieval.

## What changed in `transcribeAudio()`

| Step | Before | After | Why |
|------|--------|-------|-----|
| 1. Get file path | `ctx.http.fetch` | `ctx.http.fetch` | JSON response — RPC serialization is fine |
| 2. Download audio | `ctx.http.fetch` → `.blob()` | native `fetch` → `Buffer.from(arrayBuffer)` | Binary data gets corrupted by RPC bridge UTF-8 encoding |
| 3. Resolve API key | `ctx.secrets.resolve` | `ctx.secrets.resolve` | String — RPC is fine |
| 4-5. Upload to Whisper | `ctx.http.fetch` with `FormData` body | native `fetch` with `FormData` + `Blob` | `FormData` can't be serialized through RPC bridge |

## Test plan

- [ ] Send a voice message in a Telegram chat monitored by the plugin
- [ ] Verify transcription text appears in the reply
- [ ] Confirm no errors in plugin logs related to binary data or FormData serialization
- [ ] Test with audio files of varying lengths (short <5s, medium 30s, long >60s)