### PR TITLE
feat: add clickable deep links to dashboard in bot messages

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -26,18 +26,19 @@ export async function handleCommand(
   args: string,
   messageThreadId?: number,
   baseUrl?: string,
+  publicUrl?: string,
 ): Promise<void> {
   await ctx.metrics.write(METRIC_NAMES.commandsHandled, 1);
 
   switch (command) {
     case "status":
-      await handleStatus(ctx, token, chatId, messageThreadId);
+      await handleStatus(ctx, token, chatId, messageThreadId, publicUrl);
       break;
     case "issues":
-      await handleIssues(ctx, token, chatId, args, messageThreadId, baseUrl);
+      await handleIssues(ctx, token, chatId, args, messageThreadId, publicUrl || baseUrl);
       break;
     case "agents":
-      await handleAgents(ctx, token, chatId, messageThreadId);
+      await handleAgents(ctx, token, chatId, messageThreadId, publicUrl);
       break;
     case "approve":
       await handleApprove(ctx, token, chatId, args, messageThreadId, baseUrl);
@@ -61,11 +62,16 @@ export async function handleCommand(
   }
 }
 
+function isExternalUrl(url?: string): boolean {
+  return !!url && url.startsWith("https://");
+}
+
 async function handleStatus(
   ctx: PluginContext,
   token: string,
   chatId: string,
   messageThreadId?: number,
+  publicUrl?: string,
 ): Promise<void> {
   await sendChatAction(ctx, token, chatId);
 
@@ -83,9 +89,14 @@ async function handleStatus(
       `${escapeMarkdownV2("📋")} Recent issues: *${escapeMarkdownV2(String(issues.length))}* \\(${escapeMarkdownV2(String(doneIssues.length))} done\\)`,
     ];
 
+    const inlineKeyboard = isExternalUrl(publicUrl)
+      ? [[{ text: "Open Dashboard ↗", url: publicUrl! }]]
+      : undefined;
+
     await sendMessage(ctx, token, chatId, lines.join("\n"), {
       parseMode: "MarkdownV2",
       messageThreadId,
+      inlineKeyboard,
     });
   } catch {
     await sendMessage(ctx, token, chatId, escapeMarkdownV2("📊") + " *Paperclip Status*\n\n" + escapeMarkdownV2("Could not fetch status. Make sure this chat is linked to a company with /connect."), {
@@ -155,6 +166,7 @@ async function handleAgents(
   token: string,
   chatId: string,
   messageThreadId?: number,
+  publicUrl?: string,
 ): Promise<void> {
   await sendChatAction(ctx, token, chatId);
 
@@ -167,11 +179,17 @@ async function handleAgents(
       return;
     }
 
+    const hasLinks = isExternalUrl(publicUrl);
     const statusEmoji: Record<string, string> = { active: "🟢", error: "🔴", paused: "🟡", idle: "⚪", running: "🔵" };
     const lines = [escapeMarkdownV2("🤖") + " *Agents*", ""];
     for (const agent of agents) {
       const emoji = statusEmoji[agent.status] ?? "⚪";
-      lines.push(`${escapeMarkdownV2(emoji)} *${escapeMarkdownV2(agent.name)}* \\- ${escapeMarkdownV2(agent.status)}`);
+      if (hasLinks) {
+        const url = `${publicUrl}/agents/${agent.id}`;
+        lines.push(`${escapeMarkdownV2(emoji)} [${escapeMarkdownV2(agent.name)}](${url}) \\- ${escapeMarkdownV2(agent.status)}`);
+      } else {
+        lines.push(`${escapeMarkdownV2(emoji)} *${escapeMarkdownV2(agent.name)}* \\- ${escapeMarkdownV2(agent.status)}`);
+      }
     }
 
     await sendMessage(ctx, token, chatId, lines.join("\n"), {

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -23,12 +23,30 @@ function code(s: string): string {
 
 export type IssueLinksOpts = { baseUrl?: string; issuePrefix?: string };
 
+function isExternalUrl(url?: string): boolean {
+  return !!url && url.startsWith("https://");
+}
+
 function issueLink(identifier: string, opts?: IssueLinksOpts): string {
   if (opts?.baseUrl && opts?.issuePrefix) {
     const url = `${opts.baseUrl}/${opts.issuePrefix}/issues/${identifier}`;
     return `[${esc(identifier)}](${url})`;
   }
   return bold(identifier);
+}
+
+function issueButton(identifier: string, opts?: IssueLinksOpts): { text: string; url: string } | null {
+  if (opts?.baseUrl && opts?.issuePrefix && isExternalUrl(opts.baseUrl)) {
+    return { text: `Open ${identifier} ↗`, url: `${opts.baseUrl}/${opts.issuePrefix}/issues/${identifier}` };
+  }
+  return null;
+}
+
+function agentButton(agentId: string, label: string, publicUrl?: string): { text: string; url: string } | null {
+  if (publicUrl && isExternalUrl(publicUrl)) {
+    return { text: label, url: `${publicUrl}/agents/${agentId}` };
+  }
+  return null;
 }
 
 export function formatIssueCreated(event: PluginEvent, opts?: IssueLinksOpts): FormattedMessage {
@@ -57,9 +75,13 @@ export function formatIssueCreated(event: PluginEvent, opts?: IssueLinksOpts): F
     lines.push(`\n${esc(">")} ${esc(desc)}`);
   }
 
+  const button = issueButton(identifier, opts);
   return {
     text: lines.join("\n"),
-    options: { parseMode: "MarkdownV2" },
+    options: {
+      parseMode: "MarkdownV2",
+      ...(button ? { inlineKeyboard: [[button]] } : {}),
+    },
   };
 }
 
@@ -68,12 +90,16 @@ export function formatIssueDone(event: PluginEvent, opts?: IssueLinksOpts): Form
   const identifier = String(p.identifier ?? event.entityId);
   const title = String(p.title ?? "");
 
+  const button = issueButton(identifier, opts);
   return {
     text: [
       `${esc("✅")} ${bold("Issue Completed")}: ${issueLink(identifier, opts)}`,
       `${bold(title)} ${esc("is now done.")}`,
     ].join("\n"),
-    options: { parseMode: "MarkdownV2" },
+    options: {
+      parseMode: "MarkdownV2",
+      ...(button ? { inlineKeyboard: [[button]] } : {}),
+    },
   };
 }
 
@@ -109,51 +135,95 @@ export function formatApprovalCreated(event: PluginEvent, opts?: IssueLinksOpts)
     }
   }
 
+  const keyboard: Array<Array<{ text: string; callback_data?: string; url?: string }>> = [
+    [
+      { text: "Approve", callback_data: `approve_${approvalId}` },
+      { text: "Reject", callback_data: `reject_${approvalId}` },
+    ],
+  ];
+
+  // Add deep link to the first linked issue if available
+  if (linkedIssues.length > 0) {
+    const firstIssueId = String(linkedIssues[0]!.identifier ?? "");
+    if (firstIssueId) {
+      const btn = issueButton(firstIssueId, opts);
+      if (btn) keyboard.push([btn]);
+    }
+  }
+
   return {
     text: lines.join("\n"),
     options: {
       parseMode: "MarkdownV2",
-      inlineKeyboard: [
-        [
-          { text: "Approve", callback_data: `approve_${approvalId}` },
-          { text: "Reject", callback_data: `reject_${approvalId}` },
-        ],
-      ],
+      inlineKeyboard: keyboard,
     },
   };
 }
 
-export function formatAgentError(event: PluginEvent): FormattedMessage {
+export function formatAgentError(event: PluginEvent, opts?: IssueLinksOpts): FormattedMessage {
   const p = event.payload as Payload;
-  const agentName = String(p.agentName ?? p.name ?? event.entityId);
+  const agentId = String(p.agentId ?? event.entityId);
+  const agentName = String(p.agentName ?? p.name ?? agentId);
   const errorMessage = String(p.error ?? p.message ?? "Unknown error");
 
+  const btn = agentButton(agentId, "View Agent ↗", opts?.baseUrl);
   return {
     text: [
       `${esc("❌")} ${bold("Agent Error")}`,
       `${bold(agentName)} ${esc("encountered an error")}`,
       `\n${code(truncateAtWord(errorMessage, 500))}`,
     ].join("\n"),
-    options: { parseMode: "MarkdownV2" },
+    options: {
+      parseMode: "MarkdownV2",
+      ...(btn ? { inlineKeyboard: [[btn]] } : {}),
+    },
   };
 }
 
-export function formatAgentRunStarted(event: PluginEvent): FormattedMessage {
+export function formatAgentRunStarted(event: PluginEvent, opts?: IssueLinksOpts): FormattedMessage {
   const p = event.payload as Payload;
-  const agentName = String(p.agentName ?? event.entityId);
+  const agentId = String(p.agentId ?? event.entityId);
+  const agentName = String(p.agentName ?? agentId);
+  const runId = p.runId ? String(p.runId) : null;
+
+  const buttons: Array<{ text: string; url: string }> = [];
+  if (opts?.baseUrl && isExternalUrl(opts.baseUrl)) {
+    const url = runId
+      ? `${opts.baseUrl}/agents/${agentId}/runs/${runId}`
+      : `${opts.baseUrl}/agents/${agentId}`;
+    buttons.push({ text: "View Run ↗", url });
+  }
 
   return {
     text: `${esc("▶️")} ${bold(agentName)} ${esc("started a new run")}`,
-    options: { parseMode: "MarkdownV2", disableNotification: true },
+    options: {
+      parseMode: "MarkdownV2",
+      disableNotification: true,
+      ...(buttons.length > 0 ? { inlineKeyboard: [buttons] } : {}),
+    },
   };
 }
 
-export function formatAgentRunFinished(event: PluginEvent): FormattedMessage {
+export function formatAgentRunFinished(event: PluginEvent, opts?: IssueLinksOpts): FormattedMessage {
   const p = event.payload as Payload;
-  const agentName = String(p.agentName ?? event.entityId);
+  const agentId = String(p.agentId ?? event.entityId);
+  const agentName = String(p.agentName ?? agentId);
+  const runId = p.runId ? String(p.runId) : null;
+
+  const buttons: Array<{ text: string; url: string }> = [];
+  if (opts?.baseUrl && isExternalUrl(opts.baseUrl)) {
+    const url = runId
+      ? `${opts.baseUrl}/agents/${agentId}/runs/${runId}`
+      : `${opts.baseUrl}/agents/${agentId}`;
+    buttons.push({ text: "View Run ↗", url });
+  }
 
   return {
     text: `${esc("⏹️")} ${bold(agentName)} ${esc("completed successfully")}`,
-    options: { parseMode: "MarkdownV2", disableNotification: true },
+    options: {
+      parseMode: "MarkdownV2",
+      disableNotification: true,
+      ...(buttons.length > 0 ? { inlineKeyboard: [buttons] } : {}),
+    },
   };
 }

--- a/src/media-pipeline.ts
+++ b/src/media-pipeline.ts
@@ -9,6 +9,7 @@ type MediaConfig = {
   briefAgentId: string;
   briefAgentChatIds: string[];
   transcriptionApiKeyRef: string;
+  publicUrl?: string;
 };
 
 type TelegramMediaMessage = {
@@ -89,6 +90,11 @@ export async function handleMediaMessage(
         reason: "media_intake",
       });
 
+      const hasPublicUrl = config.publicUrl && config.publicUrl.startsWith("https://");
+      const inlineKeyboard = hasPublicUrl
+        ? [[{ text: "View Run ↗", url: `${config.publicUrl}/agents/${config.briefAgentId}/runs/${runId}` }]]
+        : undefined;
+
       await sendMessage(
         ctx,
         token,
@@ -98,6 +104,7 @@ export async function handleMediaMessage(
           parseMode: "MarkdownV2",
           messageThreadId: threadId,
           replyToMessageId: msg.message_id,
+          inlineKeyboard,
         },
       );
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -173,7 +173,7 @@ const plugin = definePlugin({
           if (data.ok && data.result) {
             for (const update of data.result) {
               lastUpdateId = Math.max(lastUpdateId, update.update_id);
-              await handleUpdate(ctx, token, config, update, baseUrl);
+              await handleUpdate(ctx, token, config, update, baseUrl, publicUrl);
             }
           }
         } catch (err) {
@@ -689,6 +689,7 @@ async function handleUpdate(
   config: TelegramConfig,
   update: TelegramUpdate,
   baseUrl: string,
+  publicUrl?: string,
 ): Promise<void> {
   if (update.callback_query) {
     await handleCallbackQuery(ctx, token, update.callback_query, baseUrl);
@@ -709,6 +710,7 @@ async function handleUpdate(
       briefAgentId: config.briefAgentId ?? "",
       briefAgentChatIds: config.briefAgentChatIds ?? [],
       transcriptionApiKeyRef: config.transcriptionApiKeyRef ?? "",
+      publicUrl,
     }, companyId);
     if (handled) return;
   }
@@ -745,7 +747,7 @@ async function handleUpdate(
     if (handledCustom) return;
 
     // Built-in commands
-    await handleCommand(ctx, token, chatId, command, args, threadId, baseUrl);
+    await handleCommand(ctx, token, chatId, command, args, threadId, baseUrl, publicUrl);
     return;
   }
 


### PR DESCRIPTION
## Summary

Bot messages now include Telegram inline keyboard URL buttons that link directly to the Paperclip dashboard, so users can tap to jump to issues, agents, and runs from mobile instead of seeing useless UUIDs.

- **`/status` command**: adds "Open Dashboard" button linking to the dashboard home
- **`/agents` command**: agent names become clickable links to their dashboard pages
- **`/issues` command**: now uses `publicUrl` (instead of internal API URL) for issue links
- **Issue notifications** (created/done): adds "Open <ID>" button linking to the issue
- **Approval notifications**: adds issue deep link button alongside Approve/Reject buttons
- **Agent error notifications**: adds "View Agent" button
- **Agent run started/finished**: adds "View Run" button (links to specific run when runId is available)
- **Media pipeline**: "Media sent to Brief Agent" message adds "View Run" button

### Safety

Buttons only appear when `paperclipPublicUrl` is a valid `https://` URL. If the config value is empty, localhost, or http-only, no buttons are added and behavior is unchanged.

### Files changed

| File | Changes |
|------|---------|
| `src/formatters.ts` | Added `isExternalUrl`, `issueButton`, `agentButton` helpers; all 6 formatters now return inline keyboards |
| `src/commands.ts` | `/status` gets dashboard button, `/agents` gets clickable agent names, `/issues` prefers publicUrl |
| `src/media-pipeline.ts` | Brief agent run message gets "View Run" button; `MediaConfig` extended with `publicUrl` |
| `src/worker.ts` | Threads `publicUrl` through to `handleUpdate`, commands, and media pipeline |

## Test plan

- [ ] Set `paperclipPublicUrl` to a valid `https://` URL and verify buttons appear on all notification types
- [ ] Leave `paperclipPublicUrl` empty and verify no buttons appear (no regression)
- [ ] Test `/status`, `/agents`, `/issues` commands and verify links are tappable
- [ ] Verify approval notifications still show Approve/Reject callback buttons alongside new URL button
- [ ] Send media to intake channel and verify "View Run" button appears on the confirmation message