### PR TITLE
fix: use connect_topic for Telegram forum topic mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This is that plugin.
 - `/approve <id>` - Approve a pending approval
 - `/help` - Display all available commands
 - `/connect <company>` - Link this chat to a Paperclip company
-- `/connect-topic <project>` - Map a forum topic to a Paperclip project
+- `/connect_topic <project-name> <topic-id>` - Map a forum topic to a Paperclip project
 - `/acp spawn <agent>` - Start a new agent session in the current thread
 - `/acp status` - Check ACP session status
 - `/acp cancel` - Cancel a running ACP session
@@ -120,7 +120,7 @@ This is that plugin.
 - Includes: tasks completed/created, active agents, in-progress/review/blocked issues
 
 ### Forum topic routing
-- Map Telegram forum topics to Paperclip projects via `/connect-topic`
+- Map Telegram forum topics to Paperclip projects via `/connect_topic`
 - Notifications for a project are routed to its mapped topic
 - Requires a group with forum topics enabled
 

--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -79,7 +79,7 @@ type StepResult = {
 
 const BUILTIN_COMMANDS = new Set([
   "status", "issues", "agents", "approve", "help",
-  "connect", "connect-topic", "acp", "commands",
+  "connect", "connect_topic", "acp", "commands",
 ]);
 
 // --- Command registry ---

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -14,6 +14,8 @@ export const BOT_COMMANDS: BotCommand[] = [
   { command: "agents", description: "List agents with current status" },
   { command: "approve", description: "Approve a pending request by ID" },
   { command: "help", description: "Show available commands" },
+  { command: "connect", description: "Link this chat to a Paperclip company" },
+  { command: "connect_topic", description: "Map a project to a forum topic" },
   { command: "acp", description: "Manage agent sessions (spawn, status, cancel, close)" },
   { command: "commands", description: "Manage custom workflow commands (list, import, run, delete)" },
 ];
@@ -49,7 +51,7 @@ export async function handleCommand(
     case "connect":
       await handleConnect(ctx, token, chatId, args, messageThreadId);
       break;
-    case "connect-topic":
+    case "connect_topic":
       await handleConnectTopic(ctx, token, chatId, args, messageThreadId);
       break;
     case "acp":
@@ -262,9 +264,6 @@ async function handleHelp(
     ...BOT_COMMANDS.map(
       (cmd) => `/${escapeMarkdownV2(cmd.command)} \\- ${escapeMarkdownV2(cmd.description)}`,
     ),
-    "",
-    `/${escapeMarkdownV2("connect")} \\- ${escapeMarkdownV2("Link this chat to a Paperclip company")}`,
-    `/${escapeMarkdownV2("connect-topic")} \\- ${escapeMarkdownV2("Map a project to a forum topic")}`,
   ];
 
   await sendMessage(ctx, token, chatId, lines.join("\n"), {

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -126,9 +126,12 @@ describe("handleCommand", () => {
 
   it("/connect stores company mapping", async () => {
     const ctx = mockCtx();
+    (ctx.companies as unknown) = {
+      list: vi.fn().mockResolvedValue([{ id: "co-1", name: "MyCompany" }]),
+    };
     await handleCommand(ctx, "token", "123", "connect", "MyCompany");
     expect(stateStore["chat_123"]).toEqual(
-      expect.objectContaining({ companyName: "MyCompany" }),
+      expect.objectContaining({ companyId: "co-1", companyName: "MyCompany" }),
     );
   });
 
@@ -209,5 +212,7 @@ describe("BOT_COMMANDS", () => {
     expect(names).toContain("agents");
     expect(names).toContain("approve");
     expect(names).toContain("help");
+    expect(names).toContain("connect");
+    expect(names).toContain("connect_topic");
   });
 });


### PR DESCRIPTION
## Summary
- replace the invalid `/connect-topic` Telegram command with `/connect_topic`
- register `connect` and `connect_topic` in `BOT_COMMANDS` so Telegram can expose them as native bot commands
- update help text and README usage to match the valid command name
- extend the command test expectations for the registered command list

## Why
Telegram bot command names only allow lowercase letters, digits, and underscores. Because the plugin advertised and handled `/connect-topic`, Telegram treated it as invalid even though `/help` still showed it. This switches the forum-topic mapping command to a valid native Telegram command name so it can actually be used in chats.

## Test Plan
- `npm run build` ✅
- `npm test -- tests/commands.test.ts` ⚠️ still has 2 pre-existing `/issues` failures unrelated to this command-name fix
- full `npm test` also still has unrelated pre-existing failures in commands/media pipeline tests
