### PR TITLE
fix: /connect sets outbound company→chat mapping for notifications

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -290,9 +290,16 @@ async function handleConnect(
     return;
   }
 
+  // Inbound: chat → company (for commands like /status)
   await ctx.state.set(
     { scopeKind: "instance", stateKey: `chat_${chatId}` },
     { companyId: match.id, companyName: match.name ?? input, linkedAt: new Date().toISOString() },
+  );
+
+  // Outbound: company → chat (for notifications)
+  await ctx.state.set(
+    { scopeKind: "company", scopeId: match.id, stateKey: "telegram-chat" },
+    chatId,
   );
 
   await sendMessage(


### PR DESCRIPTION
## Summary
- When `/connect` links a chat to a company, also stores the reverse mapping (`company → chat`) so Paperclip can look up which Telegram chat to send notifications to for a given company.
- Without this, inbound commands work but proactive notifications (issue completed, approval needed, etc.) can't route to the correct chat.

## Changes
- Adds an outbound `state.set` call with `scopeKind: "company"` and `stateKey: "telegram-chat"` alongside the existing inbound `chat → company` mapping.