### PR TITLE
fix: parse pi_local native session output for Telegram responses

### DIFF
--- a/src/acp-bridge.ts
+++ b/src/acp-bridge.ts
@@ -547,8 +547,14 @@ export async function routeMessageToAgent(
               if (msg.startsWith("{")) {
                 try {
                   const parsed = JSON.parse(msg);
-                  // Collect only assistant text content
-                  if (parsed.type === "assistant" && parsed.message?.content) {
+                  // Collect assistant text content from both Claude and Pi output formats.
+                  // Claude emits: { type: "assistant", message: { content: [...] } }
+                  // Pi emits:     { type: "message_end", message: { role: "assistant", content: [...] } }
+                  const isClaudeAssistant = parsed.type === "assistant" && parsed.message?.content;
+                  const isPiAssistant = parsed.type === "message_end"
+                    && parsed.message?.role === "assistant"
+                    && Array.isArray(parsed.message.content);
+                  if (isClaudeAssistant || isPiAssistant) {
                     const textParts = (parsed.message.content as any[])
                       .filter((c: any) => c.type === "text" && c.text)
                       .map((c: any) => c.text);


### PR DESCRIPTION
## Summary
- The native session event handler only recognized Claude's streaming format (`{ type: "assistant", message: { content: [...] } }`), so `pi_local` agent responses were silently dropped — users only saw "Run completed" instead of the actual response.
- Pi emits `{ type: "message_end", message: { role: "assistant", content: [...] } }` for completed assistant messages. This adds detection for that format alongside the existing Claude format.

## What changed
- `src/acp-bridge.ts`: Extended the chunk parser in the native session `onEvent` handler to match both Claude and Pi output structures.

## Test plan
- [ ] Spawn a `pi_local` CEO agent via Telegram `/acp spawn CEO`
- [ ] Send a message and verify the actual agent response appears (not just "Run completed")
- [ ] Verify `claude_local` agents still respond correctly (no regression)