### PR TITLE
feat: include latest comment in issue-done notifications

### DIFF
--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -89,13 +89,21 @@ export function formatIssueDone(event: PluginEvent, opts?: IssueLinksOpts): Form
   const p = event.payload as Payload;
   const identifier = String(p.identifier ?? event.entityId);
   const title = String(p.title ?? "");
+  const comment = p.comment ? String(p.comment) : null;
+
+  const lines: string[] = [
+    `${esc("✅")} ${bold("Issue Completed")}: ${issueLink(identifier, opts)}`,
+    `${bold(title)} ${esc("is now done.")}`,
+  ];
+
+  if (comment) {
+    const truncated = truncateAtWord(comment, 300);
+    lines.push(`\n${esc(">")} ${esc(truncated)}`);
+  }
 
   const button = issueButton(identifier, opts);
   return {
-    text: [
-      `${esc("✅")} ${bold("Issue Completed")}: ${issueLink(identifier, opts)}`,
-      `${bold(title)} ${esc("is now done.")}`,
-    ].join("\n"),
+    text: lines.join("\n"),
     options: {
       parseMode: "MarkdownV2",
       ...(button ? { inlineKeyboard: [[button]] } : {}),

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -15,6 +15,7 @@ const manifest: PaperclipPluginManifestV1 = {
     "issues.read",
     "issues.create",
     "issues.update",
+    "issue.comments.read",
     "agents.read",
     "agents.invoke",
     "agent.sessions.create",

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -294,6 +294,18 @@ const plugin = definePlugin({
             if (issue) payload.title = issue.title;
           } catch { /* best effort */ }
         }
+        // Enrich with latest comment (completion summary)
+        if (!payload.comment && event.entityId) {
+          try {
+            const comments = await ctx.issues.listComments(event.entityId, event.companyId);
+            if (comments.length > 0) {
+              const latest = comments.reduce((a, b) =>
+                new Date(a.createdAt) > new Date(b.createdAt) ? a : b,
+              );
+              payload.comment = latest.body;
+            }
+          } catch { /* best effort */ }
+        }
         await notify(event, formatIssueDone);
       });
     }

--- a/tests/formatters.test.ts
+++ b/tests/formatters.test.ts
@@ -84,6 +84,24 @@ describe("formatIssueDone", () => {
     const msg = formatIssueDone(mockEvent({ identifier: undefined }));
     expect(msg.text).toContain("iss\\-123");
   });
+
+  it("includes comment when provided", () => {
+    const msg = formatIssueDone(mockEvent({ comment: "Board prep package completed for Q3" }));
+    expect(msg.text).toContain("Board prep package completed for Q3");
+  });
+
+  it("truncates long comments", () => {
+    const longComment = Array(80).fill("word").join(" ");
+    const msg = formatIssueDone(mockEvent({ comment: longComment }));
+    expect(msg.text).toContain("\\.\\.\\.");
+  });
+
+  it("omits comment section when no comment", () => {
+    const msg = formatIssueDone(mockEvent());
+    // Should only have the title and done line, no blockquote
+    const lines = msg.text.split("\n").filter((l: string) => l.trim());
+    expect(lines.length).toBe(2);
+  });
 });
 
 describe("formatApprovalCreated", () => {


### PR DESCRIPTION
## Summary

- **formatIssueDone** now renders the most recent comment as a truncated blockquote beneath the title, so completion summaries are visible directly in Telegram
- **worker.ts** enriches the `issue.updated` event payload with the latest comment via `ctx.issues.listComments` (same best-effort pattern as the existing title enrichment)
- **manifest.ts** adds `issue.comments.read` capability required by `listComments`

Closes the gap where issue-done notifications showed only the title and "is now done" with no context about what was actually completed.

## Test plan

- [x] Existing formatter tests pass (24/24)
- [x] Three new tests added: comment included, long comment truncated, no-comment case unchanged
- [x] Pre-existing failures in commands.test.ts and media-pipeline.test.ts confirmed on main (not introduced by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)