### PR TITLE
Add Telegram inbound allowlists

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ curl -X POST http://127.0.0.1:3100/api/plugins/install \
 | `paperclipPublicUrl` | No | Public URL for issue links in messages |
 | `enableCommands` | No | Enable bot commands (default: true) |
 | `enableInbound` | No | Route Telegram replies to issues (default: true) |
+| `allowedTelegramUserIds` | No | Optional allowlist of Telegram user IDs allowed to use inbound features and inline buttons. Empty means any user is allowed |
+| `allowedTelegramChatIds` | No | Optional allowlist of Telegram chat IDs where inbound features are accepted. Empty means any chat is allowed |
 | `topicRouting` | No | Map forum topics to projects (default: false) |
 | `digestMode` | No | Digest frequency: off, daily, bidaily, tridaily (default: off) |
 | `dailyDigestTime` | No | UTC time for digest, HH:MM (default: 09:00) |

--- a/README.md
+++ b/README.md
@@ -160,8 +160,8 @@ curl -X POST http://127.0.0.1:3100/api/plugins/install \
 | `paperclipPublicUrl` | No | Public URL for issue links in messages |
 | `enableCommands` | No | Enable bot commands (default: true) |
 | `enableInbound` | No | Route Telegram replies to issues (default: true) |
-| `allowedTelegramUserIds` | No | Optional allowlist of Telegram user IDs allowed to use inbound features and inline buttons. Empty means any user is allowed |
-| `allowedTelegramChatIds` | No | Optional allowlist of Telegram chat IDs where inbound features are accepted. Empty means any chat is allowed |
+| `allowedTelegramUserIds` | No | Optional allowlist of Telegram user IDs allowed to use commands, inbound replies, media intake, and inline buttons. Empty means any user is allowed |
+| `allowedTelegramChatIds` | No | Optional allowlist of Telegram chat IDs where commands, inbound replies, media intake, and inline buttons are accepted. Empty means any chat is allowed |
 | `topicRouting` | No | Map forum topics to projects (default: false) |
 | `digestMode` | No | Digest frequency: off, daily, bidaily, tridaily (default: off) |
 | `dailyDigestTime` | No | UTC time for digest, HH:MM (default: 09:00) |
@@ -176,6 +176,24 @@ curl -X POST http://127.0.0.1:3100/api/plugins/install \
 | `transcriptionApiKeyRef` | No | Secret reference to OpenAI API key for Whisper |
 | `maxSuggestionsPerHourPerCompany` | No | Rate limit for proactive suggestions (default: 10) |
 | `watchDeduplicationWindowMs` | No | Suppress duplicate watch suggestions within this window (default: 86400000 / 24h) |
+
+### Inbound security allowlists
+
+Telegram does not provide a BotFather setting to disable direct messages while still allowing group use. To safely enable `enableCommands` or `enableInbound`, configure one or both allowlists:
+
+- `allowedTelegramUserIds`: who may interact with the bot
+- `allowedTelegramChatIds`: where interactions are accepted
+
+If both allowlists are configured, both must match. For example, a user must be on the user allowlist and the message must come from an allowed DM or group chat.
+
+The allowlists apply to:
+
+- bot commands
+- inbound replies routed back to Paperclip
+- media intake
+- inline button callbacks
+
+Leave an allowlist empty only if that dimension should be unrestricted. After changing allowlists, save the plugin settings and restart the plugin if the new values are not picked up immediately.
 
 ## Agent tools
 

--- a/src/allowlist.ts
+++ b/src/allowlist.ts
@@ -26,6 +26,16 @@ function normalizeAllowlist(values: unknown): Set<string> {
   );
 }
 
+export function validateTelegramAllowlists(config: TelegramAllowlistConfig): string[] {
+  const errors: string[] = [];
+  for (const key of ["allowedTelegramUserIds", "allowedTelegramChatIds"] as const) {
+    const value = config[key];
+    if (value === undefined || Array.isArray(value)) continue;
+    errors.push(`${key} must be an array of Telegram ID strings. Leave it empty to allow any ${key === "allowedTelegramUserIds" ? "user" : "chat"}.`);
+  }
+  return errors;
+}
+
 export function isTelegramUpdateAllowed(
   config: TelegramAllowlistConfig,
   update: TelegramAllowlistUpdate,

--- a/src/allowlist.ts
+++ b/src/allowlist.ts
@@ -1,0 +1,52 @@
+export type TelegramAllowlistConfig = {
+  allowedTelegramUserIds?: unknown;
+  allowedTelegramChatIds?: unknown;
+};
+
+export type TelegramAllowlistUpdate = {
+  update_id: number;
+  message?: {
+    from?: { id: number };
+    chat: { id: number };
+  };
+  callback_query?: {
+    from: { id: number };
+    message?: {
+      chat: { id: number };
+    };
+  };
+};
+
+function normalizeAllowlist(values: unknown): Set<string> {
+  if (!Array.isArray(values)) return new Set();
+  return new Set(
+    values
+      .map((value) => String(value).trim())
+      .filter((value) => value.length > 0),
+  );
+}
+
+export function isTelegramUpdateAllowed(
+  config: TelegramAllowlistConfig,
+  update: TelegramAllowlistUpdate,
+): boolean {
+  const allowedUserIds = normalizeAllowlist(config.allowedTelegramUserIds);
+  const allowedChatIds = normalizeAllowlist(config.allowedTelegramChatIds);
+
+  if (allowedUserIds.size === 0 && allowedChatIds.size === 0) {
+    return true;
+  }
+
+  const fromId = update.message?.from?.id ?? update.callback_query?.from.id;
+  const chatId = update.message?.chat.id ?? update.callback_query?.message?.chat.id;
+
+  if (allowedUserIds.size > 0 && (!fromId || !allowedUserIds.has(String(fromId)))) {
+    return false;
+  }
+
+  if (allowedChatIds.size > 0 && (!chatId || !allowedChatIds.has(String(chatId)))) {
+    return false;
+  }
+
+  return true;
+}

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -30,21 +30,22 @@ export async function handleCommand(
   messageThreadId?: number,
   baseUrl?: string,
   publicUrl?: string,
+  companyId?: string,
 ): Promise<void> {
   await ctx.metrics.write(METRIC_NAMES.commandsHandled, 1);
 
   switch (command) {
     case "create":
-      await handleCreate(ctx, token, chatId, args, messageThreadId, publicUrl || baseUrl);
+      await handleCreate(ctx, token, chatId, args, messageThreadId, publicUrl || baseUrl, companyId);
       break;
     case "status":
-      await handleStatus(ctx, token, chatId, messageThreadId, publicUrl);
+      await handleStatus(ctx, token, chatId, messageThreadId, publicUrl, companyId);
       break;
     case "issues":
-      await handleIssues(ctx, token, chatId, args, messageThreadId, publicUrl || baseUrl);
+      await handleIssues(ctx, token, chatId, args, messageThreadId, publicUrl || baseUrl, companyId);
       break;
     case "agents":
-      await handleAgents(ctx, token, chatId, messageThreadId, publicUrl);
+      await handleAgents(ctx, token, chatId, messageThreadId, publicUrl, companyId);
       break;
     case "approve":
       await handleApprove(ctx, token, chatId, args, messageThreadId, baseUrl);
@@ -78,11 +79,12 @@ async function handleStatus(
   chatId: string,
   messageThreadId?: number,
   publicUrl?: string,
+  resolvedCompanyId?: string,
 ): Promise<void> {
   await sendChatAction(ctx, token, chatId);
 
   try {
-    const companyId = await resolveCompanyId(ctx, chatId);
+    const companyId = resolvedCompanyId ?? await resolveCompanyId(ctx, chatId);
     const agents = await ctx.agents.list({ companyId });
     const activeAgents = agents.filter((a: Agent) => a.status === "active");
     const issues = await ctx.issues.list({ companyId, limit: 10 });
@@ -119,11 +121,12 @@ async function handleIssues(
   projectFilter: string,
   messageThreadId?: number,
   baseUrl?: string,
+  resolvedCompanyId?: string,
 ): Promise<void> {
   await sendChatAction(ctx, token, chatId);
 
   try {
-    const companyId = await resolveCompanyId(ctx, chatId);
+    const companyId = resolvedCompanyId ?? await resolveCompanyId(ctx, chatId);
     const company = await ctx.companies.get(companyId);
     const issues = await ctx.issues.list({ companyId, limit: 10 });
     const filtered = projectFilter
@@ -173,11 +176,12 @@ async function handleAgents(
   chatId: string,
   messageThreadId?: number,
   publicUrl?: string,
+  resolvedCompanyId?: string,
 ): Promise<void> {
   await sendChatAction(ctx, token, chatId);
 
   try {
-    const companyId = await resolveCompanyId(ctx, chatId);
+    const companyId = resolvedCompanyId ?? await resolveCompanyId(ctx, chatId);
     const agents = await ctx.agents.list({ companyId });
 
     if (agents.length === 0) {
@@ -354,6 +358,7 @@ async function handleCreate(
   titleArg: string,
   messageThreadId?: number,
   linkBaseUrl?: string,
+  resolvedCompanyId?: string,
 ): Promise<void> {
   const title = titleArg.trim();
   if (!title) {
@@ -364,7 +369,7 @@ async function handleCreate(
   await sendChatAction(ctx, token, chatId);
 
   try {
-    const companyId = await resolveCompanyId(ctx, chatId);
+    const companyId = resolvedCompanyId ?? await resolveCompanyId(ctx, chatId);
     const company = await ctx.companies.get(companyId);
     const issuePrefix = company?.issuePrefix;
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,6 +16,8 @@ export const DEFAULT_CONFIG = {
   notifyOnAgentError: true,
   enableCommands: true,
   enableInbound: true,
+  allowedTelegramUserIds: [] as string[],
+  allowedTelegramChatIds: [] as string[],
   digestMode: "off" as "off" | "daily" | "bidaily" | "tridaily",
   dailyDigestTime: "09:00",
   bidailySecondTime: "17:00",

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -180,6 +180,22 @@ const manifest: PaperclipPluginManifestV1 = {
           "Route Telegram messages to Paperclip issue comments. Messages sent in reply to a notification get attached to that issue.",
         default: DEFAULT_CONFIG.enableInbound,
       },
+      allowedTelegramUserIds: {
+        type: "array",
+        items: { type: "string" },
+        title: "Allowed Telegram User IDs",
+        description:
+          "Optional allowlist of Telegram user IDs allowed to interact with the bot. Leave empty to allow any user. Applies to commands, inbound replies, media intake, and inline button callbacks.",
+        default: DEFAULT_CONFIG.allowedTelegramUserIds,
+      },
+      allowedTelegramChatIds: {
+        type: "array",
+        items: { type: "string" },
+        title: "Allowed Telegram Chat IDs",
+        description:
+          "Optional allowlist of Telegram chat IDs where inbound bot interactions are accepted. Leave empty to allow any chat. Useful for restricting the bot to private groups and approved DMs.",
+        default: DEFAULT_CONFIG.allowedTelegramChatIds,
+      },
 
       // --- Escalation ---
       escalationTimeoutMs: {

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -170,30 +170,30 @@ const manifest: PaperclipPluginManifestV1 = {
         type: "boolean",
         title: "Enable bot commands",
         description:
-          "Allow users to interact with Paperclip via Telegram bot commands (/status, /issues, /agents).",
+          "Allow users to interact with Paperclip via Telegram bot commands (/status, /issues, /agents). If this is enabled, consider configuring the Telegram user/chat allowlists below.",
         default: DEFAULT_CONFIG.enableCommands,
       },
       enableInbound: {
         type: "boolean",
         title: "Enable inbound message routing",
         description:
-          "Route Telegram messages to Paperclip issue comments. Messages sent in reply to a notification get attached to that issue.",
+          "Route Telegram messages to Paperclip issue comments. Messages sent in reply to a notification get attached to that issue. If this is enabled, consider configuring the Telegram user/chat allowlists below.",
         default: DEFAULT_CONFIG.enableInbound,
       },
       allowedTelegramUserIds: {
         type: "array",
         items: { type: "string" },
-        title: "Allowed Telegram User IDs",
+        title: "Allowed Telegram user IDs",
         description:
-          "Optional allowlist of Telegram user IDs allowed to interact with the bot. Leave empty to allow any user. Applies to commands, inbound replies, media intake, and inline button callbacks.",
+          "Optional allowlist of Telegram user IDs allowed to interact with the bot. Leave empty to allow any user. Applies to bot commands, inbound replies, media intake, and inline button callbacks. If both user and chat allowlists are set, both must match. Save the config and restart the plugin if changes are not picked up immediately.",
         default: DEFAULT_CONFIG.allowedTelegramUserIds,
       },
       allowedTelegramChatIds: {
         type: "array",
         items: { type: "string" },
-        title: "Allowed Telegram Chat IDs",
+        title: "Allowed Telegram chat IDs",
         description:
-          "Optional allowlist of Telegram chat IDs where inbound bot interactions are accepted. Leave empty to allow any chat. Useful for restricting the bot to private groups and approved DMs.",
+          "Optional allowlist of Telegram chat IDs where inbound bot interactions are accepted. Leave empty to allow any chat. Use private DM IDs and/or private group IDs to restrict where commands, replies, media intake, and callbacks are accepted. If both user and chat allowlists are set, both must match. Save the config and restart the plugin if changes are not picked up immediately.",
         default: DEFAULT_CONFIG.allowedTelegramChatIds,
       },
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -42,7 +42,7 @@ import { handleRegisterWatch, checkWatches } from "./watch-registry.js";
 import { METRIC_NAMES } from "./constants.js";
 import { EscalationManager } from "./escalation.js";
 import type { EscalationEvent } from "./escalation.js";
-import { isTelegramUpdateAllowed } from "./allowlist.js";
+import { isTelegramUpdateAllowed, validateTelegramAllowlists } from "./allowlist.js";
 
 type TelegramConfig = {
   telegramBotTokenRef: string;
@@ -832,6 +832,10 @@ const plugin = definePlugin({
   async onValidateConfig(config) {
     if (!config.telegramBotTokenRef || typeof config.telegramBotTokenRef !== "string") {
       return { ok: false, errors: ["telegramBotTokenRef is required"] };
+    }
+    const allowlistErrors = validateTelegramAllowlists(config);
+    if (allowlistErrors.length > 0) {
+      return { ok: false, errors: allowlistErrors };
     }
     return { ok: true };
   },

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -42,6 +42,7 @@ import { handleRegisterWatch, checkWatches } from "./watch-registry.js";
 import { METRIC_NAMES } from "./constants.js";
 import { EscalationManager } from "./escalation.js";
 import type { EscalationEvent } from "./escalation.js";
+import { isTelegramUpdateAllowed } from "./allowlist.js";
 
 type TelegramConfig = {
   telegramBotTokenRef: string;
@@ -58,6 +59,8 @@ type TelegramConfig = {
   notifyOnAgentError: boolean;
   enableCommands: boolean;
   enableInbound: boolean;
+  allowedTelegramUserIds: string[];
+  allowedTelegramChatIds: string[];
   digestMode: "off" | "daily" | "bidaily" | "tridaily";
   dailyDigestTime: string;
   bidailySecondTime: string;
@@ -846,6 +849,17 @@ async function handleUpdate(
   baseUrl: string,
   publicUrl?: string,
 ): Promise<void> {
+  if (!isTelegramUpdateAllowed(config, update)) {
+    const fromId = update.message?.from?.id ?? update.callback_query?.from.id;
+    const chatId = update.message?.chat.id ?? update.callback_query?.message?.chat.id;
+    ctx.logger.warn("Blocked unauthorized Telegram update", {
+      updateId: update.update_id,
+      fromId,
+      chatId,
+    });
+    return;
+  }
+
   if (update.callback_query) {
     await handleCallbackQuery(ctx, token, update.callback_query, baseUrl);
     return;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -916,7 +916,7 @@ async function handleUpdate(
     if (handledCustom) return;
 
     // Built-in commands
-    await handleCommand(ctx, token, chatId, command, args, threadId, baseUrl, publicUrl);
+    await handleCommand(ctx, token, chatId, command, args, threadId, baseUrl, publicUrl, companyId);
     return;
   }
 

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -91,6 +91,14 @@ describe("handleCommand", () => {
     expect(sentMessages[0].text).toContain("Paperclip Status");
   });
 
+  it("uses a resolved company id for group chat commands", async () => {
+    const ctx = mockCtx();
+    await handleCommand(ctx, "token", "-1003800613668", "status", "", undefined, undefined, undefined, "co-1");
+    expect(ctx.agents.list).toHaveBeenCalledWith({ companyId: "co-1" });
+    expect(ctx.agents.list).not.toHaveBeenCalledWith({ companyId: "-1003800613668" });
+    expect(sentMessages[0].text).toContain("Paperclip Status");
+  });
+
   it("routes /issues command", async () => {
     const ctx = mockCtx();
     await handleCommand(ctx, "token", "123", "issues", "");

--- a/tests/worker-allowlist.test.ts
+++ b/tests/worker-allowlist.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import { isTelegramUpdateAllowed } from "../src/allowlist.js";
+
+const baseConfig = {
+  allowedTelegramUserIds: [],
+  allowedTelegramChatIds: [],
+};
+
+describe("isTelegramUpdateAllowed", () => {
+  it("allows all updates when allowlists are empty", () => {
+    expect(isTelegramUpdateAllowed(baseConfig, {
+      update_id: 1,
+      message: {
+        message_id: 10,
+        from: { id: 123 },
+        chat: { id: 456, type: "private" },
+        text: "/status",
+      },
+    })).toBe(true);
+  });
+
+  it("blocks messages from users outside the user allowlist", () => {
+    expect(isTelegramUpdateAllowed({
+      allowedTelegramUserIds: ["123"],
+      allowedTelegramChatIds: [],
+    }, {
+      update_id: 1,
+      message: {
+        message_id: 10,
+        from: { id: 999 },
+        chat: { id: 456, type: "private" },
+        text: "/status",
+      },
+    })).toBe(false);
+  });
+
+  it("allows messages from users inside the user allowlist", () => {
+    expect(isTelegramUpdateAllowed({
+      allowedTelegramUserIds: ["123"],
+      allowedTelegramChatIds: [],
+    }, {
+      update_id: 1,
+      message: {
+        message_id: 10,
+        from: { id: 123 },
+        chat: { id: 456, type: "private" },
+        text: "/status",
+      },
+    })).toBe(true);
+  });
+
+  it("blocks messages from chats outside the chat allowlist", () => {
+    expect(isTelegramUpdateAllowed({
+      allowedTelegramUserIds: [],
+      allowedTelegramChatIds: ["-1001"],
+    }, {
+      update_id: 1,
+      message: {
+        message_id: 10,
+        from: { id: 123 },
+        chat: { id: -2002, type: "supergroup" },
+        text: "/status",
+      },
+    })).toBe(false);
+  });
+
+  it("requires both user and chat to match when both allowlists are configured", () => {
+    expect(isTelegramUpdateAllowed({
+      allowedTelegramUserIds: ["123"],
+      allowedTelegramChatIds: ["-1001"],
+    }, {
+      update_id: 1,
+      message: {
+        message_id: 10,
+        from: { id: 123 },
+        chat: { id: -2002, type: "supergroup" },
+        text: "/status",
+      },
+    })).toBe(false);
+  });
+
+  it("applies the user allowlist to inline button callbacks", () => {
+    expect(isTelegramUpdateAllowed({
+      allowedTelegramUserIds: ["123"],
+      allowedTelegramChatIds: [],
+    }, {
+      update_id: 1,
+      callback_query: {
+        id: "cb-1",
+        from: { id: 999 },
+        message: {
+          message_id: 10,
+          chat: { id: -1001 },
+          text: "Approval",
+        },
+        data: "approve_apr-1",
+      },
+    })).toBe(false);
+  });
+
+  it("applies the chat allowlist to inline button callbacks", () => {
+    expect(isTelegramUpdateAllowed({
+      allowedTelegramUserIds: [],
+      allowedTelegramChatIds: ["-1001"],
+    }, {
+      update_id: 1,
+      callback_query: {
+        id: "cb-1",
+        from: { id: 123 },
+        message: {
+          message_id: 10,
+          chat: { id: -1001 },
+          text: "Approval",
+        },
+        data: "approve_apr-1",
+      },
+    })).toBe(true);
+  });
+});

--- a/tests/worker-allowlist.test.ts
+++ b/tests/worker-allowlist.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isTelegramUpdateAllowed } from "../src/allowlist.js";
+import { isTelegramUpdateAllowed, validateTelegramAllowlists } from "../src/allowlist.js";
 
 const baseConfig = {
   allowedTelegramUserIds: [],
@@ -115,5 +115,25 @@ describe("isTelegramUpdateAllowed", () => {
         data: "approve_apr-1",
       },
     })).toBe(true);
+  });
+});
+
+describe("validateTelegramAllowlists", () => {
+  it("accepts missing or array allowlists", () => {
+    expect(validateTelegramAllowlists({})).toEqual([]);
+    expect(validateTelegramAllowlists({
+      allowedTelegramUserIds: ["123"],
+      allowedTelegramChatIds: ["-1001"],
+    })).toEqual([]);
+  });
+
+  it("rejects non-array allowlist values", () => {
+    expect(validateTelegramAllowlists({
+      allowedTelegramUserIds: "123",
+      allowedTelegramChatIds: "-1001",
+    })).toEqual([
+      "allowedTelegramUserIds must be an array of Telegram ID strings. Leave it empty to allow any user.",
+      "allowedTelegramChatIds must be an array of Telegram ID strings. Leave it empty to allow any chat.",
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

This adds an optional allowlist in front of Telegram inbound handling, plus settings guidance so operators can configure it safely.

The goal is to let operators enable bot commands, inbound replies, media intake, and inline button callbacks without making the bot open to every Telegram user or chat that can reach it.

If no allowlist is configured, the plugin behaves as it does today.

## What changed

- Added `allowedTelegramUserIds` for approved Telegram users.
- Added `allowedTelegramChatIds` for approved chats, groups, or DMs.
- Unauthorized Telegram updates are ignored before any command, inbound reply, media, or callback handling runs.
- Built-in commands now use the already-resolved Paperclip company id when invoked from a mapped chat, instead of falling back to the Telegram chat id.
- Clarified the settings descriptions for commands, inbound replies, media intake, and callbacks.
- Documented that empty allowlists are unrestricted, and that user + chat allowlists both have to match when both are configured.
- Added config validation so allowlist values must be arrays.
- Added focused test coverage for message/callback allowlist behavior and allowlist config validation.

## Verification

- `npm run typecheck`
- `npx vitest run tests/worker-allowlist.test.ts tests/commands.test.ts`
- `npm run build`
