### PR TITLE
Fix Telegram forum topic routing for project notifications

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,4 +1,4 @@
-import type { PluginContext, Agent, Issue } from "@paperclipai/plugin-sdk";
+import type { PluginContext, PluginEvent, Agent, Issue } from "@paperclipai/plugin-sdk";
 import { sendMessage, escapeMarkdownV2, sendChatAction } from "./telegram-api.js";
 import { METRIC_NAMES } from "./constants.js";
 import { handleAcpCommand } from "./acp-bridge.js";
@@ -421,16 +421,31 @@ export async function handleConnectTopic(
   messageThreadId?: number,
 ): Promise<void> {
   const parts = args.trim().split(/\s+/);
-  if (parts.length < 2) {
-    await sendMessage(ctx, token, chatId, "Usage: /connect\\-topic <project\\-name> <topic\\-id>", {
+  if (parts.length < 1 || (parts.length < 2 && !messageThreadId)) {
+    await sendMessage(ctx, token, chatId, "Usage: /connect\\-topic <project\\-name> \\[topic\\-id\\]", {
       parseMode: "MarkdownV2",
       messageThreadId,
     });
     return;
   }
 
-  const topicId = parts.pop()!;
-  const projectName = parts.join(" ");
+  let topicId: string;
+  let projectName: string;
+  const explicitTopicId = parts.length >= 2 && /^\d+$/.test(parts[parts.length - 1]);
+  if (explicitTopicId) {
+    topicId = parts.pop()!;
+    projectName = parts.join(" ");
+  } else {
+    if (!messageThreadId) {
+      await sendMessage(ctx, token, chatId, "Usage: /connect\\-topic <project\\-name> \\[topic\\-id\\]", {
+        parseMode: "MarkdownV2",
+        messageThreadId,
+      });
+      return;
+    }
+    topicId = String(messageThreadId);
+    projectName = parts.join(" ");
+  }
 
   const existing = (await ctx.state.get({
     scopeKind: "instance",
@@ -469,6 +484,46 @@ export async function getTopicForProject(
   if (!topicMap) return undefined;
   const topicId = topicMap[projectName];
   return topicId ? Number(topicId) : undefined;
+}
+
+export async function resolveNotificationThreadId(
+  ctx: PluginContext,
+  chatId: string,
+  event: PluginEvent,
+  topicRouting: boolean,
+): Promise<number | undefined> {
+  if (!topicRouting) return undefined;
+  const projectName = await resolveEventProjectName(ctx, event);
+  return getTopicForProject(ctx, chatId, projectName);
+}
+
+async function resolveEventProjectName(
+  ctx: PluginContext,
+  event: PluginEvent,
+): Promise<string | undefined> {
+  const payload = event.payload as Record<string, unknown>;
+  const payloadProjectName = payload.projectName ? String(payload.projectName) : undefined;
+  if (payloadProjectName) return payloadProjectName;
+
+  const payloadProjectId = payload.projectId ? String(payload.projectId) : undefined;
+  if (payloadProjectId) {
+    try {
+      const project = await ctx.projects.get(payloadProjectId, event.companyId);
+      if (project?.name) return project.name;
+    } catch {
+      return undefined;
+    }
+  }
+
+  if (event.entityType !== "issue" || !event.entityId) return undefined;
+  try {
+    const issue = await ctx.issues.get(event.entityId, event.companyId);
+    if (!issue?.projectId) return undefined;
+    const project = await ctx.projects.get(issue.projectId, event.companyId);
+    return project?.name;
+  } catch {
+    return undefined;
+  }
 }
 
 async function resolveCompanyId(ctx: PluginContext, chatId: string): Promise<string> {

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -12,6 +12,7 @@ const manifest: PaperclipPluginManifestV1 = {
   categories: ["connector", "automation"],
   capabilities: [
     "companies.read",
+    "projects.read",
     "issues.read",
     "issues.create",
     "issues.update",

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -25,7 +25,7 @@ import {
   formatAgentRunFinished,
   type IssueLinksOpts,
 } from "./formatters.js";
-import { handleCommand, getTopicForProject, BOT_COMMANDS } from "./commands.js";
+import { handleCommand, resolveNotificationThreadId, BOT_COMMANDS } from "./commands.js";
 import {
   routeMessageToAgent,
   handleHandoffToolCall,
@@ -238,15 +238,7 @@ const plugin = definePlugin({
       const msg = formatter(event, linksOpts);
 
       let messageThreadId: number | undefined;
-      if (config.topicRouting) {
-        const payload = event.payload as Record<string, unknown>;
-        const projectName = payload.projectName ? String(payload.projectName) : undefined;
-        messageThreadId = await getTopicForProject(ctx, chatId, projectName);
-      }
-      // For forum groups, fall back to General topic if no specific topic mapping
-      if (!messageThreadId && await isForum(ctx, token, chatId)) {
-        messageThreadId = GENERAL_TOPIC_THREAD_ID;
-      }
+      messageThreadId = await resolveNotificationThreadId(ctx, chatId, event, config.topicRouting);
 
       if (messageThreadId) {
         msg.options.messageThreadId = messageThreadId;

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { handleCommand, BOT_COMMANDS, handleConnectTopic, getTopicForProject } from "../src/commands.js";
+import { handleCommand, BOT_COMMANDS, handleConnectTopic, getTopicForProject, resolveNotificationThreadId } from "../src/commands.js";
 import type { PluginContext } from "@paperclipai/plugin-sdk";
 
 let sentMessages: Array<{ chatId: string; text: string; options?: Record<string, unknown> }> = [];
 let metricsWritten: Array<{ name: string; value: number }> = [];
 let stateStore: Record<string, unknown> = {};
+const issueProjectId = "43c45c22-79cd-430c-ab9c-e4a56a30855f";
 
 function mockCtx(): PluginContext {
   return {
@@ -29,6 +30,14 @@ function mockCtx(): PluginContext {
       warn: vi.fn(),
       error: vi.fn(),
     },
+    companies: {
+      get: vi.fn().mockResolvedValue({ id: "123", name: "Test Co", issuePrefix: "PROJ" }),
+    },
+    projects: {
+      get: vi.fn().mockImplementation(async (projectId: string) =>
+        projectId === issueProjectId ? { id: issueProjectId, name: "Setup and Tests" } : null
+      ),
+    },
     agents: {
       list: vi.fn().mockResolvedValue([
         { id: "a1", name: "Builder", status: "active" },
@@ -40,6 +49,11 @@ function mockCtx(): PluginContext {
         { id: "i1", identifier: "PROJ-1", title: "Fix bug", status: "todo", project: null },
         { id: "i2", identifier: "PROJ-2", title: "Add feature", status: "done", project: { name: "Backend" } },
       ]),
+      get: vi.fn().mockResolvedValue({
+        id: "issue-1",
+        projectId: issueProjectId,
+        title: "Telegram forum topic routing smoke test",
+      }),
     },
   } as unknown as PluginContext;
 }
@@ -230,6 +244,12 @@ describe("handleConnectTopic", () => {
     expect(stateStore["topic-map-123"]).toEqual({ Backend: "42" });
   });
 
+  it("uses the current forum topic when no explicit topic id is provided", async () => {
+    const ctx = mockCtx();
+    await handleConnectTopic(ctx, "token", "123", "Setup and Tests", 58);
+    expect(stateStore["topic-map-123"]).toEqual({ "Setup and Tests": "58" });
+  });
+
   it("shows usage when args are insufficient", async () => {
     const ctx = mockCtx();
     await handleConnectTopic(ctx, "token", "123", "");
@@ -268,6 +288,68 @@ describe("getTopicForProject", () => {
   it("returns undefined when no project name", async () => {
     const ctx = mockCtx();
     const result = await getTopicForProject(ctx, "123");
+    expect(result).toBeUndefined();
+  });
+});
+
+describe("resolveNotificationThreadId", () => {
+  it("returns mapped topic when topic routing is enabled", async () => {
+    stateStore["topic-map-123"] = { "Setup and Tests": "58" };
+    const ctx = mockCtx();
+    const result = await resolveNotificationThreadId(ctx, "123", {
+      eventId: "evt-1",
+      eventType: "issue.created",
+      occurredAt: new Date().toISOString(),
+      entityId: "issue-1",
+      entityType: "issue",
+      companyId: "company-1",
+      payload: { projectName: "Setup and Tests" },
+    }, true);
+    expect(result).toBe(58);
+  });
+
+  it("resolves mapped topic from issue project when event payload has no project name", async () => {
+    stateStore["topic-map-123"] = { "Setup and Tests": "58" };
+    const ctx = mockCtx();
+    const result = await resolveNotificationThreadId(ctx, "123", {
+      eventId: "evt-1",
+      eventType: "issue.created",
+      occurredAt: new Date().toISOString(),
+      entityId: "issue-1",
+      entityType: "issue",
+      companyId: "company-1",
+      payload: {},
+    }, true);
+    expect(result).toBe(58);
+  });
+
+  it("does not force a General topic fallback when no project mapping exists", async () => {
+    stateStore["topic-map-123"] = { Backend: "42" };
+    const ctx = mockCtx();
+    const result = await resolveNotificationThreadId(ctx, "123", {
+      eventId: "evt-1",
+      eventType: "issue.created",
+      occurredAt: new Date().toISOString(),
+      entityId: "issue-1",
+      entityType: "issue",
+      companyId: "company-1",
+      payload: {},
+    }, true);
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when topic routing is disabled", async () => {
+    stateStore["topic-map-123"] = { "Setup and Tests": "58" };
+    const ctx = mockCtx();
+    const result = await resolveNotificationThreadId(ctx, "123", {
+      eventId: "evt-1",
+      eventType: "issue.created",
+      occurredAt: new Date().toISOString(),
+      entityId: "issue-1",
+      entityType: "issue",
+      companyId: "company-1",
+      payload: { projectName: "Setup and Tests" },
+    }, false);
     expect(result).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

This fixes Telegram forum-topic routing for project notifications.

Some issue events do not include a project name in the event payload. When that happened, the plugin could not find the configured topic mapping and could fall back to the forum's General topic instead of the topic linked to the issue's project.

## What changed

- resolves the project name from the event payload when available
- falls back to resolving the issue's `projectId` through the projects API
- adds the required `projects.read` capability
- only sends a Telegram `message_thread_id` when a mapped project topic is found
- allows `/connect_topic <project name>` to be run directly inside the target forum topic, using the current thread ID
- adds tests for mapped topic resolution and missing-project fallback behavior

## Verification

- `npm run typecheck`
- `npx vitest run tests/commands.test.ts`
- `npm run build`