### PR TITLE
Attach Telegram topic-created issues to mapped projects

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -367,6 +367,7 @@ async function handleCreate(
     const companyId = await resolveCompanyId(ctx, chatId);
     const company = await ctx.companies.get(companyId);
     const issuePrefix = company?.issuePrefix;
+    const projectId = await resolveProjectIdForTopic(ctx, chatId, companyId, messageThreadId);
 
     // Find the CEO agent to assign to
     const agents = await ctx.agents.list({ companyId });
@@ -376,7 +377,7 @@ async function handleCreate(
     // This ordering is load-bearing: the issue_assigned wake only fires when the assignee
     // *transitions* from null to an agent. If we set the assignee at creation time, there's
     // no transition and the agent never gets woken.
-    let issue = await ctx.issues.create({ companyId, title });
+    let issue = await ctx.issues.create({ companyId, title, ...(projectId ? { projectId } : {}) });
     if (ceo) {
       issue = await ctx.issues.update(
         issue.id,
@@ -484,6 +485,42 @@ export async function getTopicForProject(
   if (!topicMap) return undefined;
   const topicId = topicMap[projectName];
   return topicId ? Number(topicId) : undefined;
+}
+
+async function getProjectNameForTopic(
+  ctx: PluginContext,
+  chatId: string,
+  messageThreadId?: number,
+): Promise<string | undefined> {
+  if (!messageThreadId) return undefined;
+  const topicMap = (await ctx.state.get({
+    scopeKind: "instance",
+    stateKey: `topic-map-${chatId}`,
+  })) as Record<string, string> | null;
+  if (!topicMap) return undefined;
+
+  const topicId = String(messageThreadId);
+  const match = Object.entries(topicMap).find(([, mappedTopicId]) => mappedTopicId === topicId);
+  return match?.[0];
+}
+
+async function resolveProjectIdForTopic(
+  ctx: PluginContext,
+  chatId: string,
+  companyId: string,
+  messageThreadId?: number,
+): Promise<string | undefined> {
+  const projectName = await getProjectNameForTopic(ctx, chatId, messageThreadId);
+  if (!projectName) return undefined;
+
+  try {
+    const projects = await ctx.projects.list({ companyId, limit: 100 });
+    const exactMatch = projects.find((project) => project.name === projectName);
+    if (exactMatch) return exactMatch.id;
+    return projects.find((project) => project.name?.toLowerCase() === projectName.toLowerCase())?.id;
+  } catch {
+    return undefined;
+  }
 }
 
 export async function resolveNotificationThreadId(

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -34,6 +34,10 @@ function mockCtx(): PluginContext {
       get: vi.fn().mockResolvedValue({ id: "123", name: "Test Co", issuePrefix: "PROJ" }),
     },
     projects: {
+      list: vi.fn().mockResolvedValue([
+        { id: issueProjectId, name: "Setup and Tests" },
+        { id: "backend-project-id", name: "Backend" },
+      ]),
       get: vi.fn().mockImplementation(async (projectId: string) =>
         projectId === issueProjectId ? { id: issueProjectId, name: "Setup and Tests" } : null
       ),
@@ -206,6 +210,33 @@ describe("handleCommand", () => {
     expect(sentMessages[0].text).toContain("Task created");
     expect(sentMessages[0].text).toContain("MC\\-99");
     expect(sentMessages[0].text).toContain("Zhu Li");
+  });
+
+  it("/create attaches the issue to the project mapped to the current forum topic", async () => {
+    stateStore["topic-map-123"] = { "Setup and Tests": "58" };
+    const ctx = mockCtx();
+    (ctx.agents as unknown) = {
+      list: vi.fn().mockResolvedValue([
+        { id: "ceo-1", name: "Zhu Li", status: "idle", role: "ceo" },
+      ]),
+    };
+    const createdIssue = { id: "i-new", identifier: "MC-101", title: "Topic scoped task", status: "backlog" };
+    (ctx.issues as unknown) = {
+      ...ctx.issues,
+      create: vi.fn().mockResolvedValue(createdIssue),
+      update: vi.fn().mockResolvedValue({ ...createdIssue, status: "todo", assigneeAgentId: "ceo-1" }),
+    };
+
+    await handleCommand(ctx, "token", "123", "create", "Topic scoped task", 58);
+
+    expect(ctx.issues.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        companyId: "123",
+        title: "Topic scoped task",
+        projectId: issueProjectId,
+      }),
+    );
+    expect(sentMessages[0].options).toMatchObject({ messageThreadId: 58 });
   });
 
   it("/create works without a CEO agent", async () => {


### PR DESCRIPTION
## Summary

When `/create` is used inside a Telegram forum topic that has been linked to a Paperclip project, the new issue should be created in that project.

Today the bot replies in the same Telegram topic, but the Paperclip issue is still created at company level.

## What changed

This resolves the current Telegram topic back to the project configured through `/connect_topic`, then passes the matching `projectId` when creating the issue.

If the current topic is not mapped to a project, `/create` keeps the existing company-level behavior.

## Notes

This is a follow-up to #32 and depends on the same project-read capability used for forum-topic notification routing.

## Validation

- `npm run typecheck`
- `npx vitest run tests/commands.test.ts`
- `npm run build`
