### PR TITLE
Persist Telegram polling offset across worker restarts

### DIFF
--- a/src/polling-offset.ts
+++ b/src/polling-offset.ts
@@ -1,0 +1,36 @@
+import type { PluginContext } from "@paperclipai/plugin-sdk";
+
+export const TELEGRAM_LAST_UPDATE_ID_STATE_KEY = "telegram-last-update-id";
+
+export async function getPersistedTelegramUpdateOffset(ctx: PluginContext): Promise<number> {
+  const saved = await ctx.state.get({
+    scopeKind: "instance",
+    stateKey: TELEGRAM_LAST_UPDATE_ID_STATE_KEY,
+  });
+
+  const updateId =
+    typeof saved === "number"
+      ? saved
+      : typeof saved === "string"
+        ? Number.parseInt(saved, 10)
+        : null;
+
+  return updateId !== null && Number.isSafeInteger(updateId) && updateId >= 0
+    ? updateId
+    : 0;
+}
+
+export async function persistTelegramUpdateOffset(
+  ctx: PluginContext,
+  updateId: number,
+): Promise<void> {
+  if (!Number.isSafeInteger(updateId) || updateId < 0) return;
+
+  await ctx.state.set(
+    {
+      scopeKind: "instance",
+      stateKey: TELEGRAM_LAST_UPDATE_ID_STATE_KEY,
+    },
+    updateId,
+  );
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -35,6 +35,7 @@ import {
   setupAcpOutputListener,
 } from "./acp-bridge.js";
 import { handleMediaMessage } from "./media-pipeline.js";
+import { getPersistedTelegramUpdateOffset, persistTelegramUpdateOffset } from "./polling-offset.js";
 import { handleCommandsCommand, tryCustomCommand } from "./command-registry.js";
 import { handleRegisterWatch, checkWatches } from "./watch-registry.js";
 import { METRIC_NAMES } from "./constants.js";
@@ -169,7 +170,7 @@ const plugin = definePlugin({
 
     // --- Long polling for inbound messages ---
     let pollingActive = true;
-    let lastUpdateId = 0;
+    let lastUpdateId = await getPersistedTelegramUpdateOffset(ctx);
 
     async function pollUpdates(): Promise<void> {
       while (pollingActive) {
@@ -185,8 +186,27 @@ const plugin = definePlugin({
 
           if (data.ok && data.result) {
             for (const update of data.result) {
-              lastUpdateId = Math.max(lastUpdateId, update.update_id);
-              await handleUpdate(ctx, token, config, update, baseUrl, publicUrl);
+              try {
+                await handleUpdate(ctx, token, config, update, baseUrl, publicUrl);
+              } catch (err) {
+                ctx.logger.error("Telegram update handling failed", {
+                  updateId: update.update_id,
+                  error: String(err),
+                });
+              }
+
+              const nextUpdateId = Math.max(lastUpdateId, update.update_id);
+              if (nextUpdateId > lastUpdateId) {
+                lastUpdateId = nextUpdateId;
+                try {
+                  await persistTelegramUpdateOffset(ctx, lastUpdateId);
+                } catch (err) {
+                  ctx.logger.error("Failed to persist Telegram polling offset", {
+                    updateId: lastUpdateId,
+                    error: String(err),
+                  });
+                }
+              }
             }
           }
         } catch (err) {

--- a/tests/polling-offset.test.ts
+++ b/tests/polling-offset.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from "vitest";
+import type { PluginContext } from "@paperclipai/plugin-sdk";
+import {
+  getPersistedTelegramUpdateOffset,
+  persistTelegramUpdateOffset,
+  TELEGRAM_LAST_UPDATE_ID_STATE_KEY,
+} from "../src/polling-offset.js";
+
+function mockCtx(saved: unknown = null): PluginContext {
+  return {
+    state: {
+      get: vi.fn(async () => saved),
+      set: vi.fn(async () => undefined),
+    },
+  } as unknown as PluginContext;
+}
+
+describe("Telegram polling offset persistence", () => {
+  it("returns zero when no offset is stored", async () => {
+    const ctx = mockCtx(null);
+    await expect(getPersistedTelegramUpdateOffset(ctx)).resolves.toBe(0);
+  });
+
+  it("loads a numeric offset", async () => {
+    const ctx = mockCtx(335106053);
+    await expect(getPersistedTelegramUpdateOffset(ctx)).resolves.toBe(335106053);
+  });
+
+  it("loads a string offset", async () => {
+    const ctx = mockCtx("335106053");
+    await expect(getPersistedTelegramUpdateOffset(ctx)).resolves.toBe(335106053);
+  });
+
+  it("ignores invalid stored offsets", async () => {
+    await expect(getPersistedTelegramUpdateOffset(mockCtx("not-a-number"))).resolves.toBe(0);
+    await expect(getPersistedTelegramUpdateOffset(mockCtx(-1))).resolves.toBe(0);
+  });
+
+  it("persists a valid update id in instance state", async () => {
+    const ctx = mockCtx();
+    await persistTelegramUpdateOffset(ctx, 335106054);
+    expect(ctx.state.set).toHaveBeenCalledWith(
+      { scopeKind: "instance", stateKey: TELEGRAM_LAST_UPDATE_ID_STATE_KEY },
+      335106054,
+    );
+  });
+
+  it("does not persist invalid update ids", async () => {
+    const ctx = mockCtx();
+    await persistTelegramUpdateOffset(ctx, -1);
+    await persistTelegramUpdateOffset(ctx, Number.NaN);
+    expect(ctx.state.set).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

This stores the last processed Telegram `update_id` in plugin state and resumes polling from the next offset after a worker restart.

Without this, the long-polling worker starts from `0` each time it boots, which can allow Telegram to replay recent commands or inbound messages.

## What changed

- Load the saved Telegram update offset on worker startup.
- Persist the offset after each processed update.
- Continue processing later updates in the same polling batch if one update handler fails.
- Add focused tests for loading, validating, and persisting offsets.

## Verification

- `npm run typecheck`
- `npx vitest run tests/polling-offset.test.ts`
- `npm run build`

Also validated manually against a live Paperclip runtime:
- `/status` created the offset
- restart did not replay `/status`
- `/help` advanced the offset once
- an unknown command also advanced the offset once
