### PR TITLE
Add Telegram topic mapping management commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,10 @@ This is that plugin.
 - `/approve <id>` - Approve a pending approval
 - `/help` - Display all available commands
 - `/connect <company>` - Link this chat to a Paperclip company
-- `/connect_topic <project-name> <topic-id>` - Map a forum topic to a Paperclip project
+- `/connect_topic <project-name> [topic-id]` - Map a forum topic to an existing Paperclip project
+- `/topics list` - Show forum topic mappings for this chat
+- `/topics remove <project-name>` - Remove one forum topic mapping
+- `/topics clear` - Remove all forum topic mappings for this chat
 - `/acp spawn <agent>` - Start a new agent session in the current thread
 - `/acp status` - Check ACP session status
 - `/acp cancel` - Cancel a running ACP session
@@ -120,7 +123,8 @@ This is that plugin.
 - Includes: tasks completed/created, active agents, in-progress/review/blocked issues
 
 ### Forum topic routing
-- Map Telegram forum topics to Paperclip projects via `/connect_topic`
+- Map Telegram forum topics to existing Paperclip projects via `/connect_topic`
+- Manage mappings with `/topics list`, `/topics remove <project-name>`, and `/topics clear`
 - Notifications for a project are routed to its mapped topic
 - Requires a group with forum topics enabled
 
@@ -190,7 +194,7 @@ curl -X POST http://127.0.0.1:3100/api/plugins/install \
 |---------|---------|-------------|
 | Push notifications | Yes | Yes |
 | Receive messages | No | Yes |
-| Bot commands | No | /status, /issues, /agents, /approve, /acp, /commands |
+| Bot commands | No | /status, /issues, /agents, /approve, /topics, /acp, /commands |
 | Inline buttons | No | Approve/reject on approvals + escalations + handoffs |
 | Reply routing | No | Replies become issue comments |
 | Topic routing | No | Forum topic = project |

--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -80,7 +80,7 @@ type StepResult = {
 
 const BUILTIN_COMMANDS = new Set([
   "status", "issues", "agents", "approve", "help",
-  "connect", "connect_topic", "acp", "commands",
+  "connect", "connect_topic", "topics", "acp", "commands",
 ]);
 
 // --- Command registry ---

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,4 +1,4 @@
-import type { PluginContext, PluginEvent, Agent, Issue } from "@paperclipai/plugin-sdk";
+import type { PluginContext, PluginEvent, Agent, Issue, Project } from "@paperclipai/plugin-sdk";
 import { sendMessage, escapeMarkdownV2, sendChatAction } from "./telegram-api.js";
 import { METRIC_NAMES } from "./constants.js";
 import { handleAcpCommand } from "./acp-bridge.js";
@@ -7,6 +7,15 @@ type BotCommand = {
   command: string;
   description: string;
 };
+
+type TopicMappingRecord = {
+  projectId?: string;
+  projectName: string;
+  topicId: string;
+};
+
+type TopicMappingValue = string | TopicMappingRecord;
+type TopicMap = Record<string, TopicMappingValue>;
 
 export const BOT_COMMANDS: BotCommand[] = [
   { command: "create", description: "Create a new task (assigned to CEO agent)" },
@@ -17,6 +26,7 @@ export const BOT_COMMANDS: BotCommand[] = [
   { command: "help", description: "Show available commands" },
   { command: "connect", description: "Link this chat to a Paperclip company" },
   { command: "connect_topic", description: "Map a project to a forum topic" },
+  { command: "topics", description: "List or remove forum topic mappings" },
   { command: "acp", description: "Manage agent sessions (spawn, status, cancel, close)" },
   { command: "commands", description: "Manage custom workflow commands (list, import, run, delete)" },
 ];
@@ -57,6 +67,9 @@ export async function handleCommand(
       break;
     case "connect_topic":
       await handleConnectTopic(ctx, token, chatId, args, messageThreadId);
+      break;
+    case "topics":
+      await handleTopicsCommand(ctx, token, chatId, args, messageThreadId);
       break;
     case "acp":
       await handleAcpCommand(ctx, token, chatId, args, messageThreadId);
@@ -420,9 +433,18 @@ export async function handleConnectTopic(
   args: string,
   messageThreadId?: number,
 ): Promise<void> {
-  const parts = args.trim().split(/\s+/);
-  if (parts.length < 1 || (parts.length < 2 && !messageThreadId)) {
-    await sendMessage(ctx, token, chatId, "Usage: /connect\\-topic <project\\-name> \\[topic\\-id\\]", {
+  const trimmedArgs = args.trim();
+  if (!trimmedArgs) {
+    await sendMessage(ctx, token, chatId, "Usage: /connect\\_topic <project\\-name> \\[topic\\-id\\]", {
+      parseMode: "MarkdownV2",
+      messageThreadId,
+    });
+    return;
+  }
+
+  const parts = trimmedArgs.split(/\s+/);
+  if (parts.length < 2 && !messageThreadId) {
+    await sendMessage(ctx, token, chatId, "Usage: /connect\\_topic <project\\-name> \\[topic\\-id\\]", {
       parseMode: "MarkdownV2",
       messageThreadId,
     });
@@ -430,45 +452,244 @@ export async function handleConnectTopic(
   }
 
   let topicId: string;
-  let projectName: string;
+  let projectNameInput: string;
   const explicitTopicId = parts.length >= 2 && /^\d+$/.test(parts[parts.length - 1]);
   if (explicitTopicId) {
     topicId = parts.pop()!;
-    projectName = parts.join(" ");
+    projectNameInput = parts.join(" ");
   } else {
     if (!messageThreadId) {
-      await sendMessage(ctx, token, chatId, "Usage: /connect\\-topic <project\\-name> \\[topic\\-id\\]", {
+      await sendMessage(ctx, token, chatId, "Usage: /connect\\_topic <project\\-name> \\[topic\\-id\\]", {
         parseMode: "MarkdownV2",
         messageThreadId,
       });
       return;
     }
     topicId = String(messageThreadId);
-    projectName = parts.join(" ");
+    projectNameInput = parts.join(" ");
   }
 
-  const existing = (await ctx.state.get({
-    scopeKind: "instance",
-    stateKey: `topic-map-${chatId}`,
-  })) as Record<string, string> | null;
+  const companyId = await resolveCompanyId(ctx, chatId);
+  const project = await resolveProjectByName(ctx, companyId, projectNameInput);
+  if (!project) {
+    await sendProjectNotFoundMessage(ctx, token, chatId, companyId, projectNameInput, messageThreadId);
+    return;
+  }
 
-  const topicMap = existing ?? {};
-  topicMap[projectName] = topicId;
+  const topicMap = await getTopicMap(ctx, chatId);
+  const existingKey = findTopicMapKey(topicMap, project.name) ?? findTopicMapKey(topicMap, projectNameInput);
+  if (existingKey && existingKey !== project.name) {
+    delete topicMap[existingKey];
+  }
+  topicMap[project.name] = { projectId: project.id, projectName: project.name, topicId };
 
-  await ctx.state.set(
-    { scopeKind: "instance", stateKey: `topic-map-${chatId}` },
-    topicMap,
-  );
+  await setTopicMap(ctx, chatId, topicMap);
 
   await sendMessage(
     ctx,
     token,
     chatId,
-    `${escapeMarkdownV2("🔗")} ${escapeMarkdownV2(`Mapped project "${projectName}" to topic ${topicId}`)}`,
+    `${escapeMarkdownV2("🔗")} ${escapeMarkdownV2(`Mapped project "${project.name}" to topic ${topicId}`)}`,
     { parseMode: "MarkdownV2", messageThreadId },
   );
 
-  ctx.logger.info("Topic mapped", { chatId, projectName, topicId });
+  ctx.logger.info("Topic mapped", { chatId, projectId: project.id, projectName: project.name, topicId });
+}
+
+async function handleTopicsCommand(
+  ctx: PluginContext,
+  token: string,
+  chatId: string,
+  args: string,
+  messageThreadId?: number,
+): Promise<void> {
+  const [subcommand = "list", ...rest] = args.trim().split(/\s+/).filter(Boolean);
+
+  switch (subcommand.toLowerCase()) {
+    case "list":
+      await handleTopicsList(ctx, token, chatId, messageThreadId);
+      break;
+    case "remove":
+      await handleTopicsRemove(ctx, token, chatId, rest.join(" "), messageThreadId);
+      break;
+    case "clear":
+      await handleTopicsClear(ctx, token, chatId, messageThreadId);
+      break;
+    default:
+      await sendTopicsUsage(ctx, token, chatId, messageThreadId);
+  }
+}
+
+async function handleTopicsList(
+  ctx: PluginContext,
+  token: string,
+  chatId: string,
+  messageThreadId?: number,
+): Promise<void> {
+  const topicMap = await getTopicMap(ctx, chatId);
+  const entries = Object.entries(topicMap);
+
+  if (entries.length === 0) {
+    await sendMessage(ctx, token, chatId, "No topic mappings found for this chat.", { messageThreadId });
+    return;
+  }
+
+  const lines = [
+    escapeMarkdownV2("🧭") + " *Topic mappings*",
+    "",
+    ...entries.map(([key, value]) => {
+      const mapping = normalizeTopicMapping(key, value);
+      return `• ${escapeMarkdownV2(mapping.projectName)} ${escapeMarkdownV2("→")} ${escapeMarkdownV2(mapping.topicId)}`;
+    }),
+  ];
+
+  await sendMessage(ctx, token, chatId, lines.join("\n"), {
+    parseMode: "MarkdownV2",
+    messageThreadId,
+  });
+}
+
+async function handleTopicsRemove(
+  ctx: PluginContext,
+  token: string,
+  chatId: string,
+  projectName: string,
+  messageThreadId?: number,
+): Promise<void> {
+  const input = projectName.trim();
+  if (!input) {
+    await sendMessage(ctx, token, chatId, "Usage: /topics remove <project\\-name>", {
+      parseMode: "MarkdownV2",
+      messageThreadId,
+    });
+    return;
+  }
+
+  const topicMap = await getTopicMap(ctx, chatId);
+  const key = findTopicMapKey(topicMap, input);
+  if (!key) {
+    await sendMessage(ctx, token, chatId, `No topic mapping found for "${input}".`, { messageThreadId });
+    return;
+  }
+
+  const mapping = normalizeTopicMapping(key, topicMap[key]);
+  delete topicMap[key];
+  await setTopicMap(ctx, chatId, topicMap);
+
+  await sendMessage(
+    ctx,
+    token,
+    chatId,
+    `${escapeMarkdownV2("🗑️")} ${escapeMarkdownV2(`Removed topic mapping for "${mapping.projectName}".`)}`,
+    { parseMode: "MarkdownV2", messageThreadId },
+  );
+}
+
+async function handleTopicsClear(
+  ctx: PluginContext,
+  token: string,
+  chatId: string,
+  messageThreadId?: number,
+): Promise<void> {
+  await setTopicMap(ctx, chatId, {});
+  await sendMessage(ctx, token, chatId, "Cleared all topic mappings for this chat.", { messageThreadId });
+}
+
+async function sendTopicsUsage(
+  ctx: PluginContext,
+  token: string,
+  chatId: string,
+  messageThreadId?: number,
+): Promise<void> {
+  await sendMessage(
+    ctx,
+    token,
+    chatId,
+    [
+      escapeMarkdownV2("🧭") + " *Topic Commands*",
+      "",
+      `/topics list \\- ${escapeMarkdownV2("Show mappings for this chat")}`,
+      `/topics remove <project\\-name> \\- ${escapeMarkdownV2("Remove one mapping")}`,
+      `/topics clear \\- ${escapeMarkdownV2("Remove all mappings for this chat")}`,
+    ].join("\n"),
+    { parseMode: "MarkdownV2", messageThreadId },
+  );
+}
+
+async function resolveProjectByName(
+  ctx: PluginContext,
+  companyId: string,
+  projectName: string,
+): Promise<Project | undefined> {
+  const input = projectName.trim();
+  if (!input) return undefined;
+
+  const projects = await ctx.projects.list({ companyId, limit: 100 });
+  return projects.find((project) => project.id === input)
+    ?? projects.find((project) => project.name === input)
+    ?? projects.find((project) => project.name?.toLowerCase() === input.toLowerCase());
+}
+
+async function sendProjectNotFoundMessage(
+  ctx: PluginContext,
+  token: string,
+  chatId: string,
+  companyId: string,
+  projectName: string,
+  messageThreadId?: number,
+): Promise<void> {
+  try {
+    const projects = await ctx.projects.list({ companyId, limit: 100 });
+    const names = projects.map((project) => project.name || project.id).filter(Boolean).join(", ");
+    await sendMessage(
+      ctx,
+      token,
+      chatId,
+      `Project "${projectName.trim()}" not found. Available: ${names || "none"}`,
+      { messageThreadId },
+    );
+  } catch {
+    await sendMessage(ctx, token, chatId, `Project "${projectName.trim()}" not found.`, { messageThreadId });
+  }
+}
+
+async function getTopicMap(ctx: PluginContext, chatId: string): Promise<TopicMap> {
+  const existing = await ctx.state.get({
+    scopeKind: "instance",
+    stateKey: `topic-map-${chatId}`,
+  });
+  if (!existing || typeof existing !== "object" || Array.isArray(existing)) return {};
+  return existing as TopicMap;
+}
+
+async function setTopicMap(ctx: PluginContext, chatId: string, topicMap: TopicMap): Promise<void> {
+  await ctx.state.set(
+    { scopeKind: "instance", stateKey: `topic-map-${chatId}` },
+    topicMap,
+  );
+}
+
+function findTopicMapKey(topicMap: TopicMap, projectName: string): string | undefined {
+  const input = projectName.trim().toLowerCase();
+  if (!input) return undefined;
+
+  return Object.entries(topicMap).find(([key, value]) => {
+    const mapping = normalizeTopicMapping(key, value);
+    return key.toLowerCase() === input
+      || mapping.projectName.toLowerCase() === input
+      || mapping.projectId?.toLowerCase() === input;
+  })?.[0];
+}
+
+function normalizeTopicMapping(projectName: string, value: TopicMappingValue): TopicMappingRecord {
+  if (typeof value === "string") {
+    return { projectName, topicId: value };
+  }
+  return {
+    projectId: value.projectId,
+    projectName: value.projectName || projectName,
+    topicId: String(value.topicId),
+  };
 }
 
 export async function getTopicForProject(
@@ -477,13 +698,11 @@ export async function getTopicForProject(
   projectName?: string,
 ): Promise<number | undefined> {
   if (!projectName) return undefined;
-  const topicMap = (await ctx.state.get({
-    scopeKind: "instance",
-    stateKey: `topic-map-${chatId}`,
-  })) as Record<string, string> | null;
-  if (!topicMap) return undefined;
-  const topicId = topicMap[projectName];
-  return topicId ? Number(topicId) : undefined;
+  const topicMap = await getTopicMap(ctx, chatId);
+  const key = findTopicMapKey(topicMap, projectName);
+  if (!key) return undefined;
+  const mapping = normalizeTopicMapping(key, topicMap[key]);
+  return Number(mapping.topicId);
 }
 
 export async function resolveNotificationThreadId(

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -37,6 +37,10 @@ function mockCtx(): PluginContext {
       get: vi.fn().mockImplementation(async (projectId: string) =>
         projectId === issueProjectId ? { id: issueProjectId, name: "Setup and Tests" } : null
       ),
+      list: vi.fn().mockResolvedValue([
+        { id: issueProjectId, name: "Setup and Tests" },
+        { id: "backend-project-id", name: "Backend" },
+      ]),
     },
     agents: {
       list: vi.fn().mockResolvedValue([
@@ -241,13 +245,17 @@ describe("handleConnectTopic", () => {
   it("stores topic mapping for a project", async () => {
     const ctx = mockCtx();
     await handleConnectTopic(ctx, "token", "123", "Backend 42");
-    expect(stateStore["topic-map-123"]).toEqual({ Backend: "42" });
+    expect(stateStore["topic-map-123"]).toEqual({
+      Backend: { projectId: "backend-project-id", projectName: "Backend", topicId: "42" },
+    });
   });
 
   it("uses the current forum topic when no explicit topic id is provided", async () => {
     const ctx = mockCtx();
     await handleConnectTopic(ctx, "token", "123", "Setup and Tests", 58);
-    expect(stateStore["topic-map-123"]).toEqual({ "Setup and Tests": "58" });
+    expect(stateStore["topic-map-123"]).toEqual({
+      "Setup and Tests": { projectId: issueProjectId, projectName: "Setup and Tests", topicId: "58" },
+    });
   });
 
   it("shows usage when args are insufficient", async () => {
@@ -260,12 +268,81 @@ describe("handleConnectTopic", () => {
     stateStore["topic-map-123"] = { Frontend: "10" };
     const ctx = mockCtx();
     await handleConnectTopic(ctx, "token", "123", "Backend 42");
-    expect(stateStore["topic-map-123"]).toEqual({ Frontend: "10", Backend: "42" });
+    expect(stateStore["topic-map-123"]).toEqual({
+      Frontend: "10",
+      Backend: { projectId: "backend-project-id", projectName: "Backend", topicId: "42" },
+    });
+  });
+
+  it("rejects unknown projects without storing a topic mapping", async () => {
+    const ctx = mockCtx();
+    await handleConnectTopic(ctx, "token", "123", "Unknown Project 42");
+    expect(stateStore["topic-map-123"]).toBeUndefined();
+    expect(sentMessages[0].text).toContain("Project \"Unknown Project\" not found");
+  });
+
+  it("replaces a legacy mapping with the canonical project name", async () => {
+    stateStore["topic-map-123"] = { backend: "41" };
+    const ctx = mockCtx();
+    await handleConnectTopic(ctx, "token", "123", "backend 42");
+    expect(stateStore["topic-map-123"]).toEqual({
+      Backend: { projectId: "backend-project-id", projectName: "Backend", topicId: "42" },
+    });
+  });
+});
+
+describe("topics command", () => {
+  it("lists topic mappings", async () => {
+    stateStore["topic-map-123"] = {
+      Backend: { projectId: "backend-project-id", projectName: "Backend", topicId: "42" },
+      Legacy: "7",
+    };
+    const ctx = mockCtx();
+    await handleCommand(ctx, "token", "123", "topics", "list");
+    expect(sentMessages[0].text).toContain("Topic mappings");
+    expect(sentMessages[0].text).toContain("Backend");
+    expect(sentMessages[0].text).toContain("42");
+    expect(sentMessages[0].text).toContain("Legacy");
+    expect(sentMessages[0].text).toContain("7");
+  });
+
+  it("removes one topic mapping", async () => {
+    stateStore["topic-map-123"] = {
+      Backend: { projectId: "backend-project-id", projectName: "Backend", topicId: "42" },
+      Frontend: "10",
+    };
+    const ctx = mockCtx();
+    await handleCommand(ctx, "token", "123", "topics", "remove Backend");
+    expect(stateStore["topic-map-123"]).toEqual({ Frontend: "10" });
+    expect(sentMessages[0].text).toContain("Removed topic mapping");
+  });
+
+  it("clears all topic mappings", async () => {
+    stateStore["topic-map-123"] = { Backend: "42" };
+    const ctx = mockCtx();
+    await handleCommand(ctx, "token", "123", "topics", "clear");
+    expect(stateStore["topic-map-123"]).toEqual({});
+    expect(sentMessages[0].text).toContain("Cleared all topic mappings");
+  });
+
+  it("shows usage for unknown topics subcommands", async () => {
+    const ctx = mockCtx();
+    await handleCommand(ctx, "token", "123", "topics", "wat");
+    expect(sentMessages[0].text).toContain("Topic Commands");
   });
 });
 
 describe("getTopicForProject", () => {
   it("returns topic id for mapped project", async () => {
+    stateStore["topic-map-123"] = {
+      Backend: { projectId: "backend-project-id", projectName: "Backend", topicId: "42" },
+    };
+    const ctx = mockCtx();
+    const result = await getTopicForProject(ctx, "123", "Backend");
+    expect(result).toBe(42);
+  });
+
+  it("returns topic id for legacy string mappings", async () => {
     stateStore["topic-map-123"] = { Backend: "42" };
     const ctx = mockCtx();
     const result = await getTopicForProject(ctx, "123", "Backend");
@@ -364,5 +441,6 @@ describe("BOT_COMMANDS", () => {
     expect(names).toContain("help");
     expect(names).toContain("connect");
     expect(names).toContain("connect_topic");
+    expect(names).toContain("topics");
   });
 });


### PR DESCRIPTION
## Summary

This adds a small management layer for Telegram forum-topic mappings.

The main changes are:
- `/connect_topic <project-name> [topic-id]` now validates that the project exists before saving a mapping
- when `/connect_topic` is run from inside a forum topic, the topic id is inferred automatically and `[topic-id]` is not required
- new mappings store the project id, project name, and topic id
- existing legacy string mappings continue to work
- `/topics list`, `/topics remove <project-name>`, and `/topics clear` make mappings manageable from Telegram
- `topics` is reserved as a built-in command so custom commands cannot shadow it

## Why

A typo in `/connect_topic` could previously create a stale or unusable mapping, and fixing mappings required manual state cleanup. These commands make topic routing easier to operate from Telegram itself.

## Validation

- `npm run typecheck`
- `npx vitest run tests/commands.test.ts tests/command-registry.test.ts`
- `npm run build`
- manual Telegram forum-topic smoke test:
  - unknown project names are rejected
  - a valid project can be mapped from inside the current topic without passing an explicit topic id
  - `/topics list` shows the mapping
  - `/topics remove <project-name>` removes it
  - the project can be mapped again after removal
