### PR TITLE
Thread issue notifications via reply anchors

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -252,6 +252,23 @@ const plugin = definePlugin({
         msg.options.messageThreadId = messageThreadId;
       }
 
+      // Issue threading — if we've already sent a message for this entity in this
+      // chat+topic, reply to that anchor so all updates about a single entity stack
+      // as one Telegram thread on mobile (created → comments → done).
+      const anchorKey = event.entityId
+        ? `anchor_${chatId}_${event.entityType}_${event.entityId}`
+        : null;
+      if (anchorKey) {
+        const anchor = (await ctx.state.get({
+          scopeKind: "instance",
+          stateKey: anchorKey,
+        })) as { messageId: number; messageThreadId?: number } | null;
+        // Only thread when targeting the same topic — Telegram rejects cross-topic replies.
+        if (anchor?.messageId && anchor.messageThreadId === messageThreadId) {
+          msg.options.replyToMessageId = anchor.messageId;
+        }
+      }
+
       const messageId = await sendMessage(ctx, token, chatId, msg.text, msg.options);
 
       if (messageId) {
@@ -274,6 +291,21 @@ const plugin = definePlugin({
           entityType: "plugin",
           entityId: event.entityId,
         });
+
+        // First-message-per-entity: store the anchor so future notifications about the
+        // same entity reply to this one. Never overwritten — the first message stays root.
+        if (anchorKey) {
+          const existing = (await ctx.state.get({
+            scopeKind: "instance",
+            stateKey: anchorKey,
+          })) as { messageId: number; messageThreadId?: number } | null;
+          if (!existing) {
+            await ctx.state.set(
+              { scopeKind: "instance", stateKey: anchorKey },
+              { messageId, messageThreadId },
+            );
+          }
+        }
       }
     };
 


### PR DESCRIPTION
## Summary
Stack all notifications for a single issue (created → comments → done) as one Telegram thread by replying to the first message sent for that entity. On mobile, this turns N interleaved notifications about a single issue into one expandable thread you can read in order without scrolling past notifications about other issues.

## How it works
- On the first notification for an issue (or any entity), store an anchor at `anchor_{chatId}_{entityType}_{entityId}` containing `{messageId, messageThreadId}`.
- On every subsequent notification for the same entity in the same chat + forum topic, pass `reply_to_message_id` so Telegram threads it under the anchor.

## Edge cases handled
- **Forum topics:** anchor records the `messageThreadId`. Threading only applies when the new notification targets the same topic — prevents cross-topic reply errors from Telegram.
- **No `entityId`:** plugin events without an entity skip threading entirely (no anchor created or read).
- **Anchor never overwritten:** the first message stays the thread root for the entity's lifetime.

## What it isn't
- No new config knobs — behavior is on by default, degrades gracefully to standalone messages on the edge cases above.
- No new dependencies, no SDK changes, no manifest changes.
- Single file touched (`src/worker.ts`), 32 lines added, 0 removed.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` — same 5 pre-existing failures in `media-pipeline.test.ts` on plain `main`; this PR adds 0 new failures
- [ ] Manual: create a new issue → notification appears standalone (no parent yet)
- [ ] Manual: comment on it → comment notification replies to the issue-created message in Telegram
- [ ] Manual: mark done → done notification replies to the same anchor
- [ ] Manual (forum group + `topicRouting: true`): threading works within a topic and doesn't try to cross-thread between topics

🤖 Generated with [Claude Code](https://claude.com/claude-code)