### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "paperclip-plugin-telegram",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "paperclip-plugin-telegram",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "devDependencies": {
         "@paperclipai/plugin-sdk": "^2026.318.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paperclip-plugin-telegram",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "main": "./dist/index.js",
   "paperclipPlugin": {


### PR DESCRIPTION
Bumps package.json to 0.4.0 so the publish workflow actually publishes. Without a version bump it sees paperclip-plugin-telegram@0.3.0 already on npm and skips.

Captures four merged PRs since 0.3.0 (semver minor for the new features):
- #30 feat: notify on issue assignment changes
- #32 fix: Telegram forum topic routing for project notifications
- #34 fix: persist Telegram polling offset across worker restarts
- #36 feat: thread issue notifications via reply anchors

## Test plan
- [ ] CI green
- [ ] After merge, Publish to npm workflow publishes 0.4.0 to https://www.npmjs.com/package/paperclip-plugin-telegram