### PR TITLE
feat: gate agent run start/finish notifications behind config flags

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,6 +14,8 @@ export const DEFAULT_CONFIG = {
   onlyNotifyIfAssignedTo: "",
   notifyOnApprovalCreated: true,
   notifyOnAgentError: true,
+  notifyOnAgentRunStarted: false,
+  notifyOnAgentRunFinished: false,
   enableCommands: true,
   enableInbound: true,
   allowedTelegramUserIds: [] as string[],

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -137,6 +137,20 @@ const manifest: PaperclipPluginManifestV1 = {
         title: "Notify on agent error",
         default: DEFAULT_CONFIG.notifyOnAgentError,
       },
+      notifyOnAgentRunStarted: {
+        type: "boolean",
+        title: "Notify on agent run started",
+        description:
+          "Send a Telegram message every time an agent starts a run. Disabled by default to avoid chat flooding on busy instances.",
+        default: DEFAULT_CONFIG.notifyOnAgentRunStarted,
+      },
+      notifyOnAgentRunFinished: {
+        type: "boolean",
+        title: "Notify on agent run finished",
+        description:
+          "Send a Telegram message every time an agent finishes a run successfully. Disabled by default to avoid chat flooding on busy instances.",
+        default: DEFAULT_CONFIG.notifyOnAgentRunFinished,
+      },
 
       // --- Digest ---
       digestMode: {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -57,6 +57,8 @@ type TelegramConfig = {
   onlyNotifyIfAssignedTo: string;
   notifyOnApprovalCreated: boolean;
   notifyOnAgentError: boolean;
+  notifyOnAgentRunStarted: boolean;
+  notifyOnAgentRunFinished: boolean;
   enableCommands: boolean;
   enableInbound: boolean;
   allowedTelegramUserIds: string[];
@@ -480,12 +482,16 @@ const plugin = definePlugin({
       );
     }
 
-    ctx.events.on("agent.run.started", (event: PluginEvent) =>
-      notify(event, formatAgentRunStarted),
-    );
-    ctx.events.on("agent.run.finished", (event: PluginEvent) =>
-      notify(event, formatAgentRunFinished),
-    );
+    if (config.notifyOnAgentRunStarted) {
+      ctx.events.on("agent.run.started", (event: PluginEvent) =>
+        notify(event, formatAgentRunStarted),
+      );
+    }
+    if (config.notifyOnAgentRunFinished) {
+      ctx.events.on("agent.run.finished", (event: PluginEvent) =>
+        notify(event, formatAgentRunFinished),
+      );
+    }
 
     // --- Per-company chat overrides ---
 


### PR DESCRIPTION
Closes #39.

Adds `notifyOnAgentRunStarted` and `notifyOnAgentRunFinished` config flags so operators can opt in to per-run lifecycle notifications instead of having them fire unconditionally.

## Why

`agent.run.started` and `agent.run.finished` are the only event subscriptions in `worker.ts` not gated by a `notifyOn…` flag. On instances with several busy agents, the chat fills with `▶️ … started a new run` / `⏹️ … completed successfully` messages with no opt-out short of uninstalling the plugin.

## Changes

- `src/constants.ts` — add `notifyOnAgentRunStarted` and `notifyOnAgentRunFinished` to `DEFAULT_CONFIG`
- `src/manifest.ts` — declare both flags in `instanceConfigSchema.properties`, alongside the other `notifyOn…` entries
- `src/worker.ts` — extend `TelegramConfig`; wrap the two `ctx.events.on(...)` calls in `if (config.notifyOn…)` guards, matching every other notification type

## Defaults

Both default to **`false`**. This is a behavior change: existing instances that relied on these messages will need to flip the flags on after upgrading. The defaults match the assumption that per-run notifications are noise on instances with active agents — operators who want them can opt in.

Open to flipping to `true` for back-compat if you'd prefer to preserve the current default and document the change instead.

## Verification

- `npm run typecheck` — clean
- `npm test` — only the 3 pre-existing `media-pipeline.test.ts` audio-detection failures, unrelated to this change (also fail on `upstream/main`)