### PR TITLE
Fix approval callbacks with public API URL

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -2,6 +2,7 @@ import type { PluginContext, PluginEvent, Agent, Issue, Project } from "@papercl
 import { sendMessage, escapeMarkdownV2, sendChatAction } from "./telegram-api.js";
 import { METRIC_NAMES } from "./constants.js";
 import { handleAcpCommand } from "./acp-bridge.js";
+import { resolvePaperclipApiBaseUrl } from "./paperclip-api.js";
 
 type BotCommand = {
   command: string;
@@ -58,7 +59,7 @@ export async function handleCommand(
       await handleAgents(ctx, token, chatId, messageThreadId, publicUrl, companyId);
       break;
     case "approve":
-      await handleApprove(ctx, token, chatId, args, messageThreadId, baseUrl);
+      await handleApprove(ctx, token, chatId, args, messageThreadId, baseUrl, publicUrl);
       break;
     case "help":
       await handleHelp(ctx, token, chatId, messageThreadId);
@@ -237,6 +238,7 @@ async function handleApprove(
   approvalId: string,
   messageThreadId?: number,
   baseUrl: string = "http://localhost:3100",
+  publicUrl?: string,
 ): Promise<void> {
   if (!approvalId.trim()) {
     await sendMessage(ctx, token, chatId, "Usage: /approve <approval-id>", {
@@ -247,7 +249,7 @@ async function handleApprove(
 
   try {
     await ctx.http.fetch(
-      `${baseUrl}/api/approvals/${approvalId.trim()}/approve`,
+      `${resolvePaperclipApiBaseUrl(baseUrl, publicUrl)}/api/approvals/${approvalId.trim()}/approve`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -237,6 +237,62 @@ export function formatApprovalCreated(event: PluginEvent, opts?: IssueLinksOpts)
   };
 }
 
+function asPayload(value: unknown): Payload {
+  return value && typeof value === "object" ? value as Payload : {};
+}
+
+function firstString(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim()) return value;
+  }
+  return null;
+}
+
+export function formatIssueRequestConfirmation(event: PluginEvent, opts?: IssueLinksOpts): FormattedMessage {
+  const p = event.payload as Payload;
+  const interaction = asPayload(p.interaction ?? p.threadInteraction ?? p);
+  const payload = asPayload(interaction.payload ?? p.payload);
+  const issue = asPayload(p.issue);
+
+  const interactionId = firstString(interaction.id, p.interactionId, event.entityId) ?? "unknown";
+  const identifier = firstString(p.issueIdentifier, issue.identifier, payload.issueIdentifier, p.identifier, event.entityId) ?? "issue";
+  const issueTitle = firstString(p.issueTitle, issue.title, payload.issueTitle, p.title);
+  const title = firstString(interaction.title, payload.title) ?? "Confirmation Requested";
+  const prompt = firstString(payload.prompt, interaction.prompt, p.prompt, interaction.description, p.description);
+  const details = firstString(payload.detailsMarkdown, payload.details, interaction.detailsMarkdown);
+  const acceptLabel = firstString(payload.acceptLabel, interaction.acceptLabel) ?? "Accept";
+  const rejectLabel = firstString(payload.rejectLabel, interaction.rejectLabel) ?? "Reject";
+  const rejectRequiresReason = payload.rejectRequiresReason === true || interaction.rejectRequiresReason === true;
+
+  const lines: string[] = [
+    `${esc("🔔")} ${bold("Confirmation Requested")}: ${issueLink(identifier, opts)}`,
+    bold(title),
+  ];
+
+  if (issueTitle) lines.push(esc(issueTitle));
+  if (prompt) lines.push(`\n${esc(truncateAtWord(prompt, 300))}`);
+  if (details) lines.push(`\n${esc(truncateAtWord(details, 350))}`);
+
+  const keyboard: Array<Array<{ text: string; callback_data?: string; url?: string }>> = [
+    [{ text: acceptLabel, callback_data: `confirm_accept_${interactionId}` }],
+  ];
+  const button = issueButton(identifier, opts);
+  if (rejectRequiresReason) {
+    if (button) keyboard.push([{ text: rejectLabel, url: button.url }]);
+  } else {
+    keyboard[0]!.push({ text: rejectLabel, callback_data: `confirm_reject_${interactionId}` });
+  }
+  if (button) keyboard.push([button]);
+
+  return {
+    text: lines.join("\n"),
+    options: {
+      parseMode: "MarkdownV2",
+      inlineKeyboard: keyboard,
+    },
+  };
+}
+
 export function formatAgentError(event: PluginEvent, opts?: IssueLinksOpts): FormattedMessage {
   const p = event.payload as Payload;
   const agentId = String(p.agentId ?? event.entityId);

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -297,13 +297,16 @@ export function formatAgentError(event: PluginEvent, opts?: IssueLinksOpts): For
   const p = event.payload as Payload;
   const agentId = String(p.agentId ?? event.entityId);
   const agentName = String(p.agentName ?? p.name ?? agentId);
+  const agentLine = agentName === agentId
+    ? bold(agentId)
+    : `${bold(agentName)} ${esc("(")}${code(agentId)}${esc(")")}`;
   const errorMessage = String(p.error ?? p.message ?? "Unknown error");
 
   const btn = agentButton(agentId, "View Agent ↗", opts?.baseUrl);
   return {
     text: [
       `${esc("❌")} ${bold("Agent Error")}`,
-      `${bold(agentName)} ${esc("encountered an error")}`,
+      `${agentLine} ${esc("encountered an error")}`,
       `\n${code(truncateAtWord(errorMessage, 500))}`,
     ].join("\n"),
     options: {

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -23,6 +23,8 @@ function code(s: string): string {
 
 export type IssueLinksOpts = { baseUrl?: string; issuePrefix?: string };
 
+const RESULT_LINE_RE = /\b(result|recommendation|decision|next action|next|owner|approval|completed|in review|blocked)\b/i;
+
 function isExternalUrl(url?: string): boolean {
   return !!url && url.startsWith("https://");
 }
@@ -47,6 +49,34 @@ function agentButton(agentId: string, label: string, publicUrl?: string): { text
     return { text: label, url: `${publicUrl}/agents/${agentId}` };
   }
   return null;
+}
+
+function cleanSummaryLine(line: string): string {
+  return line
+    .trim()
+    .replace(/^[-*]\s+/, "")
+    .replace(/^#{1,6}\s+/, "")
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/`([^`]+)`/g, "$1")
+    .trim();
+}
+
+export function buildDelegatedWorkSummary(comment: string, maxLen = 650): string {
+  const lines = comment
+    .split(/\r?\n/)
+    .map(cleanSummaryLine)
+    .filter((line) => line && !/^compound\?/i.test(line));
+  if (lines.length === 0) return "";
+
+  const picked: string[] = [];
+  for (const line of lines) {
+    if (RESULT_LINE_RE.test(line)) picked.push(line);
+    if (picked.length >= 4) break;
+  }
+  if (picked.length === 0) picked.push(lines[0]!);
+
+  const rendered = picked.map((line) => `• ${line}`).join("\n");
+  return truncateAtWord(rendered, maxLen);
 }
 
 export function formatIssueCreated(event: PluginEvent, opts?: IssueLinksOpts): FormattedMessage {
@@ -123,15 +153,21 @@ export function formatIssueDone(event: PluginEvent, opts?: IssueLinksOpts): Form
   const identifier = String(p.identifier ?? event.entityId);
   const title = String(p.title ?? "");
   const comment = p.comment ? String(p.comment) : null;
+  const status = String(p.status ?? "done");
+  const completionSummary = p.completionSummary ? String(p.completionSummary) : null;
+  const isReview = status === "in_review";
 
   const lines: string[] = [
-    `${esc("✅")} ${bold("Issue Completed")}: ${issueLink(identifier, opts)}`,
-    `${bold(title)} ${esc("is now done.")}`,
+    `${esc(isReview ? "👀" : "✅")} ${bold(isReview ? "Ready for Review" : "Issue Completed")}: ${issueLink(identifier, opts)}`,
+    `${bold(title)} ${esc(isReview ? "is in review." : "is now done.")}`,
   ];
 
-  if (comment) {
-    const truncated = truncateAtWord(comment, 300);
-    lines.push(`\n${esc(">")} ${esc(truncated)}`);
+  if (completionSummary) {
+    lines.push(`\n${bold("Summary")}`);
+    lines.push(esc(completionSummary));
+  } else if (comment) {
+    const summary = buildDelegatedWorkSummary(comment, 300);
+    lines.push(`\n${esc(">")} ${esc(summary || truncateAtWord(comment, 300))}`);
   }
 
   const button = issueButton(identifier, opts);

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -281,12 +281,8 @@ const manifest: PaperclipPluginManifestV1 = {
       description: "Check for timed-out escalations and apply default actions.",
       schedule: "* * * * *",
     },
-    {
-      jobKey: "check-watches",
-      displayName: "Check Proactive Watches",
-      description: "Evaluate registered watches and send suggestions when conditions are met.",
-      schedule: "*/15 * * * *",
-    },
+    // Local policy (2026-04-29): proactive watches disabled after Telegram flood.
+    // Do not declare check-watches until it has bounded config and replay-safe tests.
   ],
   tools: [
     {
@@ -307,12 +303,7 @@ const manifest: PaperclipPluginManifestV1 = {
       description: "Start a back-and-forth conversation with another agent",
       parametersSchema: { type: "object" },
     },
-    {
-      name: "register_watch",
-      displayName: "Register Watch",
-      description: "Register a proactive watch that monitors entities and sends suggestions",
-      parametersSchema: { type: "object" },
-    },
+    // Local policy (2026-04-29): register_watch disabled with watch scheduler.
   ],
 };
 

--- a/src/paperclip-api.ts
+++ b/src/paperclip-api.ts
@@ -1,0 +1,3 @@
+export function resolvePaperclipApiBaseUrl(baseUrl: string, publicUrl?: string): string {
+  return (publicUrl?.trim() || baseUrl || "http://localhost:3100").replace(/\/$/, "");
+}

--- a/src/recovery.ts
+++ b/src/recovery.ts
@@ -1,0 +1,165 @@
+import type { PluginContext, PluginEvent, Issue, Agent } from "@paperclipai/plugin-sdk";
+
+type HeartbeatRunSnapshot = {
+  issueId?: string;
+  taskId?: string;
+  paperclipWake?: {
+    issue?: {
+      id?: string;
+      identifier?: string;
+      title?: string;
+    };
+  };
+};
+
+type HeartbeatRun = {
+  agentId?: string;
+  errorCode?: string;
+  error?: string;
+  scheduledRetryAt?: string | null;
+  scheduledRetryReason?: string | null;
+  contextSnapshot?: HeartbeatRunSnapshot;
+};
+
+function isRecoveryIssueTitle(title: string): boolean {
+  return /^recover (failed|stalled)/i.test(title) || /recovery/i.test(title);
+}
+
+/**
+ * Create or update an Igor-owned recovery issue for a non-transient failed agent run.
+ *
+ * The Telegram notification alone is ephemeral; this makes agent-error recovery durable
+ * in Paperclip so Igor is woken through the normal assignment route.
+ */
+export async function createIgorRecoveryIssueForRunFailure(
+  ctx: PluginContext,
+  event: PluginEvent,
+  baseUrl: string,
+): Promise<Issue | null> {
+  const p = (event.payload ?? {}) as Record<string, unknown>;
+  const runId = p.runId
+    ? String(p.runId)
+    : event.entityType === "heartbeat_run" && event.entityId
+      ? String(event.entityId)
+      : null;
+
+  let run: HeartbeatRun | null = null;
+  if (runId) {
+    try {
+      const response = await ctx.http.fetch(`${baseUrl}/api/heartbeat-runs/${runId}`);
+      if (response.ok) run = (await response.json()) as HeartbeatRun;
+    } catch {
+      // best effort: payload may already contain enough context
+    }
+  }
+
+  const snapshot = run?.contextSnapshot ?? {};
+  const issueId =
+    p.issueId ??
+    snapshot.issueId ??
+    snapshot.taskId ??
+    snapshot.paperclipWake?.issue?.id ??
+    null;
+  const issueIdentifier = p.issueIdentifier ?? snapshot.paperclipWake?.issue?.identifier ?? null;
+  const issueTitle = p.issueTitle ?? snapshot.paperclipWake?.issue?.title ?? null;
+  const agentId = p.agentId ?? run?.agentId ?? null;
+  const errorCode = String(p.errorCode ?? run?.errorCode ?? "");
+  const errorText = String(p.error ?? run?.error ?? p.message ?? "Agent run failed");
+
+  // Let Paperclip's scheduled retry path own transient upstream failures.
+  if (run?.scheduledRetryAt || run?.scheduledRetryReason || errorCode === "claude_transient_upstream") {
+    ctx.logger.info("Skipping Igor recovery issue for transient/scheduled retry", { runId, errorCode });
+    return null;
+  }
+
+  const agents = await ctx.agents.list({ companyId: event.companyId });
+  const igor = agents.find((agent: Agent) => agent.name === "Igor" || agent.role === "ceo");
+  if (!igor?.id) {
+    ctx.logger.warn("Cannot create recovery issue: Igor/CEO agent not found", { companyId: event.companyId });
+    return null;
+  }
+  if (agentId && String(agentId) === String(igor.id)) {
+    ctx.logger.info("Skipping Igor recovery issue for Igor's own failed run", { runId });
+    return null;
+  }
+
+  let linkedIssue: Issue | null = null;
+  if (issueId) {
+    try {
+      linkedIssue = await ctx.issues.get(String(issueId), event.companyId);
+    } catch {
+      // best effort: payload/snapshot still gives enough to create a useful issue
+    }
+  }
+
+  const linkedTitle = linkedIssue?.title ?? (issueTitle ? String(issueTitle) : "unknown issue");
+  const linkedIdentifier = linkedIssue?.identifier ?? (issueIdentifier ? String(issueIdentifier) : issueId ? String(issueId).slice(0, 8) : "unknown");
+  if (isRecoveryIssueTitle(linkedTitle)) {
+    ctx.logger.info("Skipping recovery issue for recovery issue to avoid loops", { runId, issueId, linkedTitle });
+    return null;
+  }
+
+  const openIgorIssues = await ctx.issues.list({
+    companyId: event.companyId,
+    assigneeAgentId: igor.id,
+    status: "todo",
+    limit: 50,
+  });
+  const existing = openIgorIssues.find(
+    (issue) =>
+      (issue.title ?? "").includes(`Recover failed run on ${linkedIdentifier}`) ||
+      (runId ? (issue.description ?? "").includes(runId) : false),
+  );
+  if (existing) {
+    await ctx.issues.createComment(
+      existing.id,
+      `Another failed run matched this recovery route.\n\n- Run: ${runId ?? "unknown"}\n- Error: ${errorCode || errorText}\n- Linked issue: ${linkedIdentifier}\n\nLeaving this recovery issue as the active one.`,
+      event.companyId,
+    );
+    ctx.logger.info("Updated existing Igor recovery issue", { recoveryIssueId: existing.id, runId });
+    return existing;
+  }
+
+  const failedAgent = agents.find((agent) => agentId && String(agent.id) === String(agentId));
+  const failedAgentName = failedAgent?.name ?? (agentId ? String(agentId).slice(0, 8) : "agent");
+  const title = `Recover failed run on ${linkedIdentifier}`;
+  const description = [
+    "Paperclip auto-created this recovery issue from an `agent.run.failed` event.",
+    "",
+    `Failed agent: ${failedAgentName}`,
+    `Failed run: ${runId ?? "unknown"}`,
+    `Linked issue: ${issueId ? `${linkedIdentifier} — ${linkedTitle}` : "none"}`,
+    `Error: ${errorCode || errorText}`,
+    "",
+    "First actions:",
+    "- Inspect the failed run log.",
+    "- If an execution is stuck, cancel it cleanly.",
+    "- Re-wake or reroute the linked issue with narrower instructions.",
+    "- If this is transient and already retried successfully, close this recovery issue.",
+    "",
+    "Loop guard: do not create recovery issues for recovery issues.",
+  ].join("\n");
+
+  // Create unassigned first, then assign+todo so Paperclip emits the normal assignment wake.
+  let recovery = await ctx.issues.create({
+    companyId: event.companyId,
+    projectId: linkedIssue?.projectId,
+    title,
+    description,
+    priority: "high",
+    // Newer Paperclip hosts accept these attribution fields even though older SDK
+    // typings have not caught up yet.
+    originKind: "plugin",
+    originId: "paperclip-plugin-telegram:agent-run-failed-recovery",
+    originRunId: runId ?? undefined,
+    requestDepth: Math.min(Number(linkedIssue?.requestDepth ?? 0) + 1, 10),
+  } as Parameters<PluginContext["issues"]["create"]>[0] & Record<string, unknown>);
+
+  recovery = await ctx.issues.update(recovery.id, { status: "todo", assigneeAgentId: igor.id }, event.companyId);
+  ctx.logger.info("Created Igor recovery issue for failed agent run", {
+    recoveryIssueId: recovery.id,
+    runId,
+    linkedIssueId: issueId,
+  });
+  return recovery;
+}

--- a/src/telegram-api.ts
+++ b/src/telegram-api.ts
@@ -2,6 +2,9 @@ import type { PluginContext } from "@paperclipai/plugin-sdk";
 import { METRIC_NAMES } from "./constants.js";
 
 const TELEGRAM_API = "https://api.telegram.org";
+const SEND_LIMIT_STATE_KEY = "telegram-send-limiter";
+const SEND_LIMIT_WINDOW_MS = 60_000;
+const SEND_LIMIT_MAX_PER_WINDOW = 5;
 
 type InlineButton = {
   text: string;
@@ -26,6 +29,27 @@ export async function sendMessage(
   text: string,
   options: SendMessageOptions = {},
 ): Promise<number | null> {
+  const now = Date.now();
+  const limiter = (await ctx.state.get({
+    scopeKind: "instance",
+    stateKey: SEND_LIMIT_STATE_KEY,
+  })) as { windowStartedAt: number; count: number } | null;
+  const current = limiter && now - limiter.windowStartedAt < SEND_LIMIT_WINDOW_MS
+    ? limiter
+    : { windowStartedAt: now, count: 0 };
+  if (current.count >= SEND_LIMIT_MAX_PER_WINDOW) {
+    ctx.logger.error("Telegram send hard-limited", {
+      chatId,
+      windowStartedAt: current.windowStartedAt,
+      count: current.count,
+      limit: SEND_LIMIT_MAX_PER_WINDOW,
+    });
+    await ctx.metrics.write(METRIC_NAMES.failed, 1);
+    return null;
+  }
+  current.count += 1;
+  await ctx.state.set({ scopeKind: "instance", stateKey: SEND_LIMIT_STATE_KEY }, current);
+
   const body: Record<string, unknown> = {
     chat_id: chatId,
     text,

--- a/src/update-filter.ts
+++ b/src/update-filter.ts
@@ -1,0 +1,54 @@
+// Local policy (2026-04-29): pure helpers used by worker.ts polling loop and
+// command dispatch. Extracted so they are unit-testable without a live
+// Telegram API or PluginContext.
+
+export const STALE_UPDATE_GRACE_SECONDS = 30;
+
+export type TelegramUpdateLite = {
+  update_id: number;
+  message?: { date?: number; entities?: Array<{ type: string; offset: number }> };
+  callback_query?: { message?: { date?: number } };
+};
+
+export type UpdateFilterDecision =
+  | { action: "skip"; reason: "duplicate" | "stale" }
+  | { action: "process" };
+
+/**
+ * Decide whether to process or skip a Telegram polling update.
+ *
+ * - Duplicates (update_id <= lastUpdateId) are dropped to prevent replay floods.
+ * - Updates older than `pollingStartedAtSeconds - graceSeconds` are dropped
+ *   so a plugin restart does not reprocess pre-restart commands.
+ */
+export function classifyUpdate(
+  update: TelegramUpdateLite,
+  lastUpdateId: number,
+  pollingStartedAtSeconds: number,
+  graceSeconds: number = STALE_UPDATE_GRACE_SECONDS,
+): UpdateFilterDecision {
+  if (update.update_id <= lastUpdateId) {
+    return { action: "skip", reason: "duplicate" };
+  }
+  const updateDate = update.message?.date ?? update.callback_query?.message?.date;
+  if (typeof updateDate === "number" && updateDate < pollingStartedAtSeconds - graceSeconds) {
+    return { action: "skip", reason: "stale" };
+  }
+  return { action: "process" };
+}
+
+/**
+ * Decide whether a Telegram message text should be dispatched as a slash
+ * command. Commands are only dispatched when the bot has `enableCommands=true`
+ * AND the first entity is a `bot_command` at offset 0.
+ */
+export function shouldDispatchCommand(
+  text: string | undefined,
+  entities: Array<{ type: string; offset: number }> | undefined,
+  enableCommands: boolean,
+): boolean {
+  if (!enableCommands) return false;
+  if (!text || !text.startsWith("/")) return false;
+  const botCommand = entities?.find((e) => e.type === "bot_command" && e.offset === 0);
+  return Boolean(botCommand);
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -43,6 +43,7 @@ import { METRIC_NAMES } from "./constants.js";
 import { EscalationManager } from "./escalation.js";
 import type { EscalationEvent } from "./escalation.js";
 import { isTelegramUpdateAllowed, validateTelegramAllowlists } from "./allowlist.js";
+import { resolvePaperclipApiBaseUrl } from "./paperclip-api.js";
 
 type TelegramConfig = {
   telegramBotTokenRef: string;
@@ -865,7 +866,7 @@ async function handleUpdate(
   }
 
   if (update.callback_query) {
-    await handleCallbackQuery(ctx, token, update.callback_query, baseUrl);
+    await handleCallbackQuery(ctx, token, update.callback_query, baseUrl, publicUrl);
     return;
   }
 
@@ -971,6 +972,7 @@ async function handleCallbackQuery(
   token: string,
   query: NonNullable<TelegramUpdate["callback_query"]>,
   baseUrl: string,
+  publicUrl?: string,
 ): Promise<void> {
   const data = query.data;
   if (!data) return;
@@ -978,6 +980,7 @@ async function handleCallbackQuery(
   const actor = query.from.username ?? query.from.first_name ?? String(query.from.id);
   const chatId = query.message?.chat.id ? String(query.message.chat.id) : null;
   const messageId = query.message?.message_id;
+  const apiBaseUrl = resolvePaperclipApiBaseUrl(baseUrl, publicUrl);
 
   if (data.startsWith("approve_")) {
     const approvalId = data.replace("approve_", "");
@@ -985,7 +988,7 @@ async function handleCallbackQuery(
 
     try {
       await ctx.http.fetch(
-        `${baseUrl}/api/approvals/${approvalId}/approve`,
+        `${apiBaseUrl}/api/approvals/${approvalId}/approve`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -1036,7 +1039,7 @@ async function handleCallbackQuery(
 
     try {
       await ctx.http.fetch(
-        `${baseUrl}/api/approvals/${approvalId}/reject`,
+        `${apiBaseUrl}/api/approvals/${approvalId}/reject`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -540,14 +540,14 @@ const plugin = definePlugin({
         const payload = event.payload as Record<string, unknown>;
         const interaction = asRecord(payload.interaction ?? payload.threadInteraction ?? payload);
         const interactionPayload = asRecord(interaction.payload ?? payload.payload);
-        const kind = firstNonEmptyString(interaction.kind, payload.kind);
+        const kind = firstNonEmptyString(interaction.kind, payload.kind, payload.interactionKind);
         if (kind !== "request_confirmation") return;
 
-        const status = firstNonEmptyString(interaction.status, payload.status, interactionPayload.status);
+        const status = firstNonEmptyString(interaction.status, payload.status, payload.interactionStatus, interactionPayload.status);
         if (status && status !== "pending") return;
 
-        const interactionId = firstNonEmptyString(interaction.id, payload.interactionId, event.entityId);
-        const issueId = firstNonEmptyString(payload.issueId, interaction.issueId, interactionPayload.issueId);
+        const interactionId = firstNonEmptyString(interaction.id, payload.interactionId);
+        const issueId = firstNonEmptyString(payload.issueId, interaction.issueId, interactionPayload.issueId, event.entityType === "issue" ? event.entityId : undefined);
         if (!interactionId || !issueId) {
           ctx.logger.error("Cannot notify request_confirmation without interaction and issue ids", {
             eventId: event.eventId,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -44,6 +44,7 @@ import { EscalationManager } from "./escalation.js";
 import type { EscalationEvent } from "./escalation.js";
 import { isTelegramUpdateAllowed, validateTelegramAllowlists } from "./allowlist.js";
 import { resolvePaperclipApiBaseUrl } from "./paperclip-api.js";
+import { createIgorRecoveryIssueForRunFailure } from "./recovery.js";
 
 type TelegramConfig = {
   telegramBotTokenRef: string;
@@ -476,9 +477,16 @@ const plugin = definePlugin({
     }
 
     if (config.notifyOnAgentError) {
-      ctx.events.on("agent.run.failed", (event: PluginEvent) =>
-        notify(event, formatAgentError, config.errorsChatId),
-      );
+      ctx.events.on("agent.run.failed", async (event: PluginEvent) => {
+        await notify(event, formatAgentError, config.errorsChatId);
+        try {
+          await createIgorRecoveryIssueForRunFailure(ctx, event, baseUrl);
+        } catch (err) {
+          ctx.logger.error("Failed to route agent failure to Igor recovery issue", {
+            error: String(err),
+          });
+        }
+      });
     }
 
     ctx.events.on("agent.run.started", (event: PluginEvent) =>

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -21,6 +21,7 @@ import {
   formatIssueDone,
   formatIssueAssigned,
   formatApprovalCreated,
+  formatIssueRequestConfirmation,
   formatAgentError,
   formatAgentRunStarted,
   formatAgentRunFinished,
@@ -143,6 +144,17 @@ function makeUpdateDedupe(windowMs = 5_000, maxEntries = 500) {
     }
     return true;
   };
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" ? value as Record<string, unknown> : {};
+}
+
+function firstNonEmptyString(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim()) return value;
+  }
+  return null;
 }
 
 async function resolveChat(
@@ -521,6 +533,50 @@ const plugin = definePlugin({
             : approvalType;
         }
         await notify(event, formatApprovalCreated, config.approvalsChatId);
+      });
+
+      const confirmationDedupe = makeUpdateDedupe(60_000, 500);
+      ctx.events.on("issue.thread_interaction_created" as never, async (event: PluginEvent) => {
+        const payload = event.payload as Record<string, unknown>;
+        const interaction = asRecord(payload.interaction ?? payload.threadInteraction ?? payload);
+        const interactionPayload = asRecord(interaction.payload ?? payload.payload);
+        const kind = firstNonEmptyString(interaction.kind, payload.kind);
+        if (kind !== "request_confirmation") return;
+
+        const status = firstNonEmptyString(interaction.status, payload.status, interactionPayload.status);
+        if (status && status !== "pending") return;
+
+        const interactionId = firstNonEmptyString(interaction.id, payload.interactionId, event.entityId);
+        const issueId = firstNonEmptyString(payload.issueId, interaction.issueId, interactionPayload.issueId);
+        if (!interactionId || !issueId) {
+          ctx.logger.error("Cannot notify request_confirmation without interaction and issue ids", {
+            eventId: event.eventId,
+            eventType: event.eventType,
+          });
+          return;
+        }
+
+        const idempotencyKey = firstNonEmptyString(interaction.idempotencyKey, payload.idempotencyKey);
+        const dedupeKey = idempotencyKey ?? `${issueId}|${interactionId}`;
+        if (!confirmationDedupe(dedupeKey)) return;
+
+        await ctx.state.set(
+          { scopeKind: "instance", stateKey: `confirmation_${interactionId}` },
+          { issueId, interactionId, companyId: event.companyId },
+        );
+
+        if ((!payload.identifier || !payload.title) && issueId) {
+          try {
+            const issue = await ctx.issues.get(issueId, event.companyId);
+            if (issue) {
+              payload.identifier ??= issue.identifier;
+              payload.issueIdentifier ??= issue.identifier;
+              payload.issueTitle ??= issue.title;
+            }
+          } catch { /* best effort */ }
+        }
+
+        await notify(event, formatIssueRequestConfirmation, config.approvalsChatId);
       });
     }
 
@@ -1004,6 +1060,52 @@ async function handleCallbackQuery(
   const chatId = query.message?.chat.id ? String(query.message.chat.id) : null;
   const messageId = query.message?.message_id;
   const apiBaseUrl = resolvePaperclipApiBaseUrl(baseUrl, publicUrl);
+
+  if (data.startsWith("confirm_accept_") || data.startsWith("confirm_reject_")) {
+    const accepting = data.startsWith("confirm_accept_");
+    const interactionId = data.replace(accepting ? "confirm_accept_" : "confirm_reject_", "");
+    const mapping = (await ctx.state.get({
+      scopeKind: "instance",
+      stateKey: `confirmation_${interactionId}`,
+    })) as { issueId?: string; interactionId?: string } | null;
+    const issueId = mapping?.issueId;
+    if (!issueId) {
+      await answerCallbackQuery(ctx, token, query.id, "Open Paperclip to decide this confirmation");
+      return;
+    }
+
+    const action = accepting ? "accept" : "reject";
+    ctx.logger.info("Confirmation button clicked", { interactionId, issueId, action, actor });
+
+    try {
+      await ctx.http.fetch(
+        `${apiBaseUrl}/api/issues/${issueId}/interactions/${interactionId}/${action}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ decidedByUserId: `telegram:${actor}` }),
+        },
+      );
+
+      await answerCallbackQuery(ctx, token, query.id, accepting ? "Accepted" : "Rejected");
+
+      if (chatId && messageId) {
+        await editMessage(
+          ctx,
+          token,
+          chatId,
+          messageId,
+          accepting
+            ? `${escapeMarkdownV2("✅")} *Accepted* by ${escapeMarkdownV2(actor)}`
+            : `${escapeMarkdownV2("❌")} *Rejected* by ${escapeMarkdownV2(actor)}`,
+          { parseMode: "MarkdownV2" },
+        );
+      }
+    } catch (err) {
+      await answerCallbackQuery(ctx, token, query.id, `Failed: ${String(err)}`);
+    }
+    return;
+  }
 
   if (data.startsWith("approve_")) {
     const approvalId = data.replace("approve_", "");

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -361,19 +361,28 @@ const plugin = definePlugin({
     }
 
     if (config.notifyOnIssueDone) {
-      const doneDedupe = makeUpdateDedupe();
+      const resultDedupe = makeUpdateDedupe();
       ctx.events.on("issue.updated", async (event: PluginEvent) => {
         const payload = event.payload as Record<string, unknown>;
-        if (payload.status !== "done") return;
-        if (!doneDedupe(`done|${event.entityId}`)) return;
-        // Enrich with title if missing (issue.updated events often omit it)
-        if (!payload.title && event.entityId) {
+        const status = String(payload.status ?? "");
+        if (status !== "done" && status !== "in_review") return;
+        if (!resultDedupe(`${status}|${event.entityId}`)) return;
+        // Enrich with issue fields if missing (issue.updated events often omit them).
+        if ((!payload.title || !payload.identifier) && event.entityId) {
           try {
             const issue = await ctx.issues.get(event.entityId, event.companyId);
-            if (issue) payload.title = issue.title;
+            if (issue) {
+              payload.title = issue.title;
+              payload.identifier ??= issue.identifier;
+              payload.priority ??= issue.priority;
+              payload.assigneeAgentId ??= issue.assigneeAgentId;
+              payload.assigneeUserId ??= issue.assigneeUserId;
+            }
           } catch { /* best effort */ }
         }
-        // Enrich with latest comment (completion summary)
+        // Enrich with latest comment. This is the delegated-work completion bridge:
+        // the raw terminal status event gets paired with the agent's closing/review
+        // comment so Michael sees the result/recommendation, not just lifecycle noise.
         if (!payload.comment && event.entityId) {
           try {
             const comments = await ctx.issues.listComments(event.entityId, event.companyId);
@@ -489,12 +498,17 @@ const plugin = definePlugin({
       });
     }
 
-    ctx.events.on("agent.run.started", (event: PluginEvent) =>
-      notify(event, formatAgentRunStarted),
-    );
-    ctx.events.on("agent.run.finished", (event: PluginEvent) =>
-      notify(event, formatAgentRunFinished),
-    );
+    // Local policy (CHO-772): do not emit routine run lifecycle pings to Telegram.
+    // Paperclip issue updates/comments/reassignments can legitimately spawn repeated
+    // short adapter runs for the same issue; notifying each `agent.run.started` made
+    // handoffs look like notification loops. Keep issue/approval/error notifications,
+    // which carry the actual user-facing state change.
+    // ctx.events.on("agent.run.started", (event: PluginEvent) =>
+    //   notify(event, formatAgentRunStarted),
+    // );
+    // ctx.events.on("agent.run.finished", (event: PluginEvent) =>
+    //   notify(event, formatAgentRunFinished),
+    // );
 
     // --- Per-company chat overrides ---
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -582,6 +582,13 @@ const plugin = definePlugin({
 
     if (config.notifyOnAgentError) {
       ctx.events.on("agent.run.failed", async (event: PluginEvent) => {
+        const payload = event.payload as Record<string, unknown>;
+        if (payload.agentId && !payload.agentName) {
+          try {
+            const agent = await ctx.agents.get(String(payload.agentId), event.companyId);
+            if (agent) payload.agentName = agent.name;
+          } catch { /* best effort */ }
+        }
         await notify(event, formatAgentError, config.errorsChatId);
         try {
           await createIgorRecoveryIssueForRunFailure(ctx, event, baseUrl);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -37,6 +37,7 @@ import {
 } from "./acp-bridge.js";
 import { handleMediaMessage } from "./media-pipeline.js";
 import { getPersistedTelegramUpdateOffset, persistTelegramUpdateOffset } from "./polling-offset.js";
+import { classifyUpdate, STALE_UPDATE_GRACE_SECONDS } from "./update-filter.js";
 import { handleCommandsCommand, tryCustomCommand } from "./command-registry.js";
 import { handleRegisterWatch, checkWatches } from "./watch-registry.js";
 import { METRIC_NAMES } from "./constants.js";
@@ -85,6 +86,7 @@ type TelegramUpdate = {
   update_id: number;
   message?: {
     message_id: number;
+    date?: number;
     from?: { id: number; username?: string; first_name?: string };
     chat: { id: number; type: string; title?: string };
     text?: string;
@@ -108,6 +110,7 @@ type TelegramUpdate = {
     from: { id: number; username?: string; first_name?: string };
     message?: {
       message_id: number;
+      date?: number;
       chat: { id: number };
       text?: string;
     };
@@ -203,6 +206,7 @@ const plugin = definePlugin({
 
     // --- Long polling for inbound messages ---
     let pollingActive = true;
+    const pollingStartedAtSeconds = Math.floor(Date.now() / 1000);
     let lastUpdateId = await getPersistedTelegramUpdateOffset(ctx);
 
     async function pollUpdates(): Promise<void> {
@@ -219,6 +223,34 @@ const plugin = definePlugin({
 
           if (data.ok && data.result) {
             for (const update of data.result) {
+              const decision = classifyUpdate(update, lastUpdateId, pollingStartedAtSeconds);
+              if (decision.action === "skip" && decision.reason === "duplicate") {
+                continue;
+              }
+
+              // Persist offset before handling. If handling sends a Telegram reply and then
+              // crashes before the offset write, the same update is replayed on restart and
+              // can flood the chat. At-most-once command handling is safer than replay.
+              lastUpdateId = update.update_id;
+              try {
+                await persistTelegramUpdateOffset(ctx, lastUpdateId);
+              } catch (err) {
+                ctx.logger.error("Failed to persist Telegram polling offset before handling", {
+                  updateId: lastUpdateId,
+                  error: String(err),
+                });
+                continue;
+              }
+
+              if (decision.action === "skip" && decision.reason === "stale") {
+                ctx.logger.info("Skipping stale Telegram update", {
+                  updateId: update.update_id,
+                  pollingStartedAtSeconds,
+                  graceSeconds: STALE_UPDATE_GRACE_SECONDS,
+                });
+                continue;
+              }
+
               try {
                 await handleUpdate(ctx, token, config, update, baseUrl, publicUrl);
               } catch (err) {
@@ -226,19 +258,6 @@ const plugin = definePlugin({
                   updateId: update.update_id,
                   error: String(err),
                 });
-              }
-
-              const nextUpdateId = Math.max(lastUpdateId, update.update_id);
-              if (nextUpdateId > lastUpdateId) {
-                lastUpdateId = nextUpdateId;
-                try {
-                  await persistTelegramUpdateOffset(ctx, lastUpdateId);
-                } catch (err) {
-                  ctx.logger.error("Failed to persist Telegram polling offset", {
-                    updateId: lastUpdateId,
-                    error: String(err),
-                  });
-                }
               }
             }
           }
@@ -264,6 +283,18 @@ const plugin = definePlugin({
 
     // --- Event subscriptions ---
 
+    // Local policy (2026-04-29): drop replayed/stale host events on plugin startup.
+    // The Paperclip host may deliver queued historical events when a plugin is re-enabled
+    // after downtime. Without this guard, a repair/restart can replay hundreds of old
+    // issue.created/issue.updated events as fresh Telegram notifications.
+    const pluginStartedAtMs = Date.now();
+    const replayGraceMs = 30_000;
+    function isFreshEvent(event: PluginEvent): boolean {
+      const occurredAtMs = Date.parse(String(event.occurredAt ?? ""));
+      if (!Number.isFinite(occurredAtMs)) return true;
+      return occurredAtMs >= pluginStartedAtMs - replayGraceMs;
+    }
+
     const issuePrefixCache = new Map<string, string>();
 
     async function resolveIssueLinksOpts(companyId: string): Promise<IssueLinksOpts> {
@@ -281,6 +312,14 @@ const plugin = definePlugin({
       formatter: (e: PluginEvent, opts?: IssueLinksOpts) => { text: string; options: import("./telegram-api.js").SendMessageOptions },
       overrideChatId?: string,
     ) => {
+      if (!isFreshEvent(event)) {
+        ctx.logger.info("Skipping stale Telegram notification event", {
+          eventType: event.eventType,
+          eventId: event.eventId,
+          occurredAt: event.occurredAt,
+        });
+        return;
+      }
       const chatId = await resolveChat(
         ctx,
         event.companyId,
@@ -794,39 +833,10 @@ const plugin = definePlugin({
       return handleDiscussToolCall(ctx, token, params as Record<string, unknown>, runCtx.companyId, runCtx.agentId);
     });
 
-    // --- Phase 5: Register register_watch tool ---
-    ctx.tools.register("register_watch", {
-      displayName: "Register Watch",
-      description: "Register a proactive watch that monitors entities and sends suggestions",
-      parametersSchema: {
-        type: "object",
-        properties: {
-          name: { type: "string", description: "Name of the watch" },
-          description: { type: "string", description: "What this watch monitors" },
-          entityType: { type: "string", enum: ["issue", "agent", "company", "custom"], description: "Type of entity to watch" },
-          conditions: {
-            type: "array",
-            items: {
-              type: "object",
-              properties: {
-                field: { type: "string" },
-                operator: { type: "string", enum: ["gt", "lt", "eq", "ne", "contains", "exists"] },
-                value: {},
-              },
-              required: ["field", "operator", "value"],
-            },
-            description: "Conditions that trigger the watch",
-          },
-          template: { type: "string", description: "Message template with {{field}} placeholders" },
-          builtinTemplate: { type: "string", enum: ["invoice-overdue", "lead-stale"], description: "Use a built-in template instead" },
-          chatId: { type: "string", description: "Telegram chat ID for suggestions" },
-          threadId: { type: "number", description: "Telegram thread ID for suggestions" },
-        },
-        required: ["chatId"],
-      },
-    }, async (params: unknown, runCtx) => {
-      return handleRegisterWatch(ctx, params as Record<string, unknown>, runCtx.companyId);
-    });
+    // Local policy (2026-04-29): proactive watches are disabled on this instance.
+    // The watch scheduler can emit suggestions independently of issue state and caused
+    // a notification storm during plugin recovery. Re-enable only after a bounded,
+    // reviewed design exists.
 
     // --- Phase 1: Escalation timeout checker job ---
     ctx.jobs.register("check-escalation-timeouts", async () => {
@@ -837,17 +847,8 @@ const plugin = definePlugin({
       }
     });
 
-    // --- Phase 5: Watch checker job ---
-    ctx.jobs.register("check-watches", async () => {
-      try {
-        await checkWatches(ctx, token, {
-          maxSuggestionsPerHourPerCompany: config.maxSuggestionsPerHourPerCompany ?? 10,
-          watchDeduplicationWindowMs: config.watchDeduplicationWindowMs ?? 86400000,
-        });
-      } catch (err) {
-        ctx.logger.error("Watch check failed", { error: String(err) });
-      }
-    });
+    // --- Phase 5: Watch checker job disabled locally (2026-04-29). ---
+    // Proactive watches are disabled until they have explicit bounded config and tests.
 
     ctx.logger.info("Telegram bot plugin started (Chat OS v2 - all 5 phases)");
   },

--- a/tests/formatters.test.ts
+++ b/tests/formatters.test.ts
@@ -287,10 +287,12 @@ describe("formatIssueRequestConfirmation", () => {
 describe("formatAgentError", () => {
   it("includes agent name and error", () => {
     const msg = formatAgentError(mockEvent({
+      agentId: "agent-123",
       agentName: "Builder",
       error: "Connection refused",
     }));
     expect(msg.text).toContain("Builder");
+    expect(msg.text).toContain("agent\\-123");
     expect(msg.text).toContain("Connection refused");
   });
 

--- a/tests/formatters.test.ts
+++ b/tests/formatters.test.ts
@@ -91,6 +91,33 @@ describe("formatIssueDone", () => {
     expect(msg.text).toContain("Board prep package completed for Q3");
   });
 
+  it("turns delegated completion comments into concise result summaries", () => {
+    const msg = formatIssueDone(mockEvent({
+      comment: [
+        "Completed the controlled model eval and posted the comparison table/recommendation.",
+        "",
+        "Result: recommend Codex GPT-5.5 as Richie default; keep Sonnet as fallback for synthesis/editorial review.",
+        "Next action/owner: CHO-771 already reflects this recommendation, so no further mutation was needed there.",
+        "",
+        "Compound? memory/doc — already captured.",
+      ].join("\n"),
+    }));
+    expect(msg.text).toContain("Completed the controlled model eval");
+    expect(msg.text).toContain("Result: recommend Codex GPT\\-5\\.5 as Richie default");
+    expect(msg.text).toContain("Next action/owner: CHO\\-771 already reflects");
+    expect(msg.text).not.toContain("Compound");
+  });
+
+  it("formats in_review transitions as review-ready summaries", () => {
+    const msg = formatIssueDone(mockEvent({
+      status: "in_review",
+      comment: "Recommendation: approve the patch after operator restart.",
+    }));
+    expect(msg.text).toContain("Ready for Review");
+    expect(msg.text).toContain("is in review");
+    expect(msg.text).toContain("Recommendation: approve the patch");
+  });
+
   it("truncates long comments", () => {
     const longComment = Array(80).fill("word").join(" ");
     const msg = formatIssueDone(mockEvent({ comment: longComment }));

--- a/tests/formatters.test.ts
+++ b/tests/formatters.test.ts
@@ -4,6 +4,7 @@ import {
   formatIssueDone,
   formatIssueAssigned,
   formatApprovalCreated,
+  formatIssueRequestConfirmation,
   formatAgentError,
   formatAgentRunStarted,
   formatAgentRunFinished,
@@ -223,6 +224,63 @@ describe("formatApprovalCreated", () => {
     const longDesc = Array(80).fill("word").join(" ");
     const msg = formatApprovalCreated(mockEvent({ description: longDesc }));
     expect(msg.text).toContain("\\.\\.\\.");
+  });
+});
+
+describe("formatIssueRequestConfirmation", () => {
+  it("includes issue link and accept/reject buttons", () => {
+    const msg = formatIssueRequestConfirmation(mockEvent({
+      eventType: "issue.thread_interaction_created",
+      entityId: "int-123",
+      interaction: {
+        id: "int-123",
+        kind: "request_confirmation",
+        title: "Restart approval",
+        payload: {
+          prompt: "Approve restarting Paperclip?",
+          acceptLabel: "Approve restart",
+          rejectLabel: "Do not restart",
+        },
+      },
+      issueIdentifier: "CHO-781",
+      issueTitle: "Add structured review guards",
+    }));
+
+    expect(msg.text).toContain("Confirmation Requested");
+    expect(msg.text).toContain("CHO\\-781");
+    expect(msg.text).toContain("Restart approval");
+    expect(msg.text).toContain("Approve restarting Paperclip");
+    expect(msg.options.inlineKeyboard).toBeDefined();
+    expect(msg.options.inlineKeyboard![0][0]).toEqual({
+      text: "Approve restart",
+      callback_data: "confirm_accept_int-123",
+    });
+    expect(msg.options.inlineKeyboard![0][1]).toEqual({
+      text: "Do not restart",
+      callback_data: "confirm_reject_int-123",
+    });
+  });
+
+  it("uses an issue link for reject when a rejection reason is required", () => {
+    const msg = formatIssueRequestConfirmation(mockEvent({
+      entityId: "int-456",
+      interaction: {
+        id: "int-456",
+        kind: "request_confirmation",
+        title: "Plan approval",
+        payload: {
+          rejectLabel: "Request changes",
+          rejectRequiresReason: true,
+        },
+      },
+      issueIdentifier: "CHO-788",
+    }), { baseUrl: "https://paperclip.example", issuePrefix: "CHO" });
+
+    expect(msg.options.inlineKeyboard![0][0].callback_data).toBe("confirm_accept_int-456");
+    expect(msg.options.inlineKeyboard![1][0]).toEqual({
+      text: "Request changes",
+      url: "https://paperclip.example/CHO/issues/CHO-788",
+    });
   });
 });
 

--- a/tests/paperclip-api.test.ts
+++ b/tests/paperclip-api.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { resolvePaperclipApiBaseUrl } from "../src/paperclip-api.js";
+
+describe("resolvePaperclipApiBaseUrl", () => {
+  it("prefers paperclipPublicUrl when provided", () => {
+    expect(resolvePaperclipApiBaseUrl("http://localhost:3100", "https://paperclip.example.com"))
+      .toBe("https://paperclip.example.com");
+  });
+
+  it("falls back to paperclipBaseUrl when no public URL is configured", () => {
+    expect(resolvePaperclipApiBaseUrl("http://localhost:3100", ""))
+      .toBe("http://localhost:3100");
+  });
+
+  it("normalizes trailing slashes", () => {
+    expect(resolvePaperclipApiBaseUrl("http://localhost:3100/", "https://paperclip.example.com/"))
+      .toBe("https://paperclip.example.com");
+  });
+});

--- a/tests/recovery.test.ts
+++ b/tests/recovery.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PluginContext, PluginEvent } from "@paperclipai/plugin-sdk";
+import { createIgorRecoveryIssueForRunFailure } from "../src/recovery.js";
+
+function makeCtx(overrides: Partial<PluginContext> = {}) {
+  const ctx = {
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    http: { fetch: vi.fn() },
+    agents: { list: vi.fn() },
+    issues: { list: vi.fn(), get: vi.fn(), create: vi.fn(), update: vi.fn(), createComment: vi.fn() },
+    ...overrides,
+  } as unknown as PluginContext;
+  return ctx;
+}
+
+const event = {
+  companyId: "co-1",
+  entityType: "heartbeat_run",
+  entityId: "run-1",
+  payload: {},
+} as unknown as PluginEvent;
+
+describe("createIgorRecoveryIssueForRunFailure", () => {
+  it("creates and assigns an Igor recovery issue from a failed run snapshot", async () => {
+    const ctx = makeCtx();
+    vi.mocked(ctx.http.fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        agentId: "agent-cody",
+        errorCode: "runtime_error",
+        contextSnapshot: {
+          paperclipWake: { issue: { id: "issue-1", identifier: "CHO-123", title: "Build thing" } },
+        },
+      }),
+    } as Response);
+    vi.mocked(ctx.agents.list).mockResolvedValue([
+      { id: "igor-1", name: "Igor", role: "ceo" },
+      { id: "agent-cody", name: "Cody", role: "general" },
+    ] as never);
+    vi.mocked(ctx.issues.get).mockResolvedValue({
+      id: "issue-1",
+      identifier: "CHO-123",
+      title: "Build thing",
+      projectId: "project-1",
+      requestDepth: 2,
+    } as never);
+    vi.mocked(ctx.issues.list).mockResolvedValue([] as never);
+    vi.mocked(ctx.issues.create).mockResolvedValue({ id: "recovery-1" } as never);
+    vi.mocked(ctx.issues.update).mockResolvedValue({
+      id: "recovery-1",
+      title: "Recover failed run on CHO-123",
+      assigneeAgentId: "igor-1",
+      status: "todo",
+    } as never);
+
+    const result = await createIgorRecoveryIssueForRunFailure(ctx, event, "http://paperclip.local");
+
+    expect(ctx.http.fetch).toHaveBeenCalledWith("http://paperclip.local/api/heartbeat-runs/run-1");
+    expect(ctx.issues.create).toHaveBeenCalledWith(expect.objectContaining({
+      companyId: "co-1",
+      projectId: "project-1",
+      title: "Recover failed run on CHO-123",
+      priority: "high",
+      originKind: "plugin",
+      originId: "paperclip-plugin-telegram:agent-run-failed-recovery",
+      originRunId: "run-1",
+      requestDepth: 3,
+    }));
+    expect(ctx.issues.update).toHaveBeenCalledWith("recovery-1", { status: "todo", assigneeAgentId: "igor-1" }, "co-1");
+    expect(result?.id).toBe("recovery-1");
+  });
+
+  it("does not create a recovery issue for transient scheduled retries", async () => {
+    const ctx = makeCtx();
+    vi.mocked(ctx.http.fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ scheduledRetryAt: "2026-04-28T10:00:00.000Z", agentId: "agent-cody" }),
+    } as Response);
+
+    const result = await createIgorRecoveryIssueForRunFailure(ctx, event, "http://paperclip.local");
+
+    expect(result).toBeNull();
+    expect(ctx.issues.create).not.toHaveBeenCalled();
+  });
+
+  it("updates an existing open recovery issue instead of duplicating it", async () => {
+    const ctx = makeCtx();
+    vi.mocked(ctx.http.fetch).mockResolvedValue({ ok: false } as Response);
+    vi.mocked(ctx.agents.list).mockResolvedValue([
+      { id: "igor-1", name: "Igor", role: "ceo" },
+      { id: "agent-cody", name: "Cody", role: "general" },
+    ] as never);
+    vi.mocked(ctx.issues.get).mockResolvedValue({
+      id: "issue-1",
+      identifier: "CHO-123",
+      title: "Build thing",
+    } as never);
+    vi.mocked(ctx.issues.list).mockResolvedValue([
+      { id: "existing-1", title: "Recover failed run on CHO-123", description: "old" },
+    ] as never);
+
+    const result = await createIgorRecoveryIssueForRunFailure(
+      ctx,
+      { ...event, payload: { runId: "run-2", issueId: "issue-1", agentId: "agent-cody", errorCode: "boom" } } as unknown as PluginEvent,
+      "http://paperclip.local",
+    );
+
+    expect(ctx.issues.createComment).toHaveBeenCalledWith(
+      "existing-1",
+      expect.stringContaining("Another failed run matched this recovery route."),
+      "co-1",
+    );
+    expect(ctx.issues.create).not.toHaveBeenCalled();
+    expect(result?.id).toBe("existing-1");
+  });
+});

--- a/tests/send-limiter.test.ts
+++ b/tests/send-limiter.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from "vitest";
+import type { PluginContext } from "@paperclipai/plugin-sdk";
+import { sendMessage } from "../src/telegram-api.js";
+
+function makeMockCtx() {
+  const store = new Map<string, unknown>();
+  const fetchMock = vi.fn(async () =>
+    new Response(JSON.stringify({ ok: true, result: { message_id: 42 } }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }),
+  );
+  const ctx = {
+    state: {
+      get: vi.fn(async (scope: { stateKey: string }) => store.get(scope.stateKey) ?? null),
+      set: vi.fn(async (scope: { stateKey: string }, value: unknown) => {
+        store.set(scope.stateKey, value);
+      }),
+    },
+    metrics: { write: vi.fn(async () => undefined) },
+    http: { fetch: fetchMock },
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+  } as unknown as PluginContext;
+  return { ctx, fetchMock };
+}
+
+describe("sendMessage hard send limiter", () => {
+  it("hard-caps at 5 sends per minute and drops the 6th", async () => {
+    // Acceptance: More than 5 sends/min hits limiter.
+    const { ctx, fetchMock } = makeMockCtx();
+    for (let i = 0; i < 5; i++) {
+      const result = await sendMessage(ctx, "TOKEN", "chat-1", `msg ${i}`);
+      expect(result).toBe(42);
+    }
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+
+    const dropped = await sendMessage(ctx, "TOKEN", "chat-1", "msg 6");
+    expect(dropped).toBeNull();
+    // No new outbound fetch — limiter dropped without sleep/retry.
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+    expect(ctx.logger.error).toHaveBeenCalledWith(
+      "Telegram send hard-limited",
+      expect.objectContaining({ chatId: "chat-1", limit: 5 }),
+    );
+  });
+
+  it("limiter is shared across all chat ids on the same plugin instance", async () => {
+    // The runaway flood was driven by sendMessage to many chats from one
+    // worker; the limiter must be instance-scoped, not per-chat.
+    const { ctx, fetchMock } = makeMockCtx();
+    for (let i = 0; i < 5; i++) {
+      await sendMessage(ctx, "TOKEN", `chat-${i}`, "x");
+    }
+    const dropped = await sendMessage(ctx, "TOKEN", "chat-other", "x");
+    expect(dropped).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+  });
+
+  it("resets the window after 60s and allows new sends", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-04-29T00:00:00Z"));
+      const { ctx, fetchMock } = makeMockCtx();
+      for (let i = 0; i < 5; i++) {
+        await sendMessage(ctx, "TOKEN", "chat-1", "x");
+      }
+      expect(await sendMessage(ctx, "TOKEN", "chat-1", "x")).toBeNull();
+
+      vi.setSystemTime(new Date("2026-04-29T00:01:01Z"));
+      const result = await sendMessage(ctx, "TOKEN", "chat-1", "x");
+      expect(result).toBe(42);
+      expect(fetchMock).toHaveBeenCalledTimes(6);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/tests/update-filter.test.ts
+++ b/tests/update-filter.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyUpdate,
+  shouldDispatchCommand,
+  STALE_UPDATE_GRACE_SECONDS,
+} from "../src/update-filter.js";
+
+const POLLING_STARTED = 1_000_000;
+
+describe("classifyUpdate (replay & staleness)", () => {
+  it("processes a fresh, never-seen update", () => {
+    const decision = classifyUpdate(
+      { update_id: 100, message: { date: POLLING_STARTED } },
+      0,
+      POLLING_STARTED,
+    );
+    expect(decision).toEqual({ action: "process" });
+  });
+
+  it("skips an update with the same update_id as the persisted offset (replay)", () => {
+    // Acceptance: Same update_id twice sends once at most. The second poll
+    // returns the already-persisted update_id, which must be ignored.
+    const decision = classifyUpdate(
+      { update_id: 100, message: { date: POLLING_STARTED } },
+      100,
+      POLLING_STARTED,
+    );
+    expect(decision).toEqual({ action: "skip", reason: "duplicate" });
+  });
+
+  it("skips an update older than the persisted offset", () => {
+    const decision = classifyUpdate(
+      { update_id: 99, message: { date: POLLING_STARTED } },
+      100,
+      POLLING_STARTED,
+    );
+    expect(decision).toEqual({ action: "skip", reason: "duplicate" });
+  });
+
+  it("skips a stale message that pre-dates plugin boot beyond the grace window", () => {
+    // Acceptance: Old update after plugin boot sends zero.
+    const decision = classifyUpdate(
+      {
+        update_id: 200,
+        message: { date: POLLING_STARTED - STALE_UPDATE_GRACE_SECONDS - 1 },
+      },
+      0,
+      POLLING_STARTED,
+    );
+    expect(decision).toEqual({ action: "skip", reason: "stale" });
+  });
+
+  it("processes a slightly-old update inside the grace window", () => {
+    const decision = classifyUpdate(
+      { update_id: 200, message: { date: POLLING_STARTED - 5 } },
+      0,
+      POLLING_STARTED,
+    );
+    expect(decision).toEqual({ action: "process" });
+  });
+
+  it("uses callback_query date when message date is absent", () => {
+    const decision = classifyUpdate(
+      {
+        update_id: 200,
+        callback_query: {
+          message: { date: POLLING_STARTED - STALE_UPDATE_GRACE_SECONDS - 100 },
+        },
+      },
+      0,
+      POLLING_STARTED,
+    );
+    expect(decision).toEqual({ action: "skip", reason: "stale" });
+  });
+
+  it("processes when no date field is present (cannot prove staleness)", () => {
+    const decision = classifyUpdate({ update_id: 200 }, 0, POLLING_STARTED);
+    expect(decision).toEqual({ action: "process" });
+  });
+});
+
+describe("shouldDispatchCommand (commands disabled by default)", () => {
+  it("does not dispatch /agents when enableCommands=false", () => {
+    // Acceptance: Commands disabled sends zero for /agents.
+    expect(
+      shouldDispatchCommand(
+        "/agents",
+        [{ type: "bot_command", offset: 0 }],
+        /* enableCommands */ false,
+      ),
+    ).toBe(false);
+  });
+
+  it("dispatches /agents when enableCommands=true", () => {
+    expect(
+      shouldDispatchCommand(
+        "/agents",
+        [{ type: "bot_command", offset: 0 }],
+        true,
+      ),
+    ).toBe(true);
+  });
+
+  it("does not dispatch when bot_command entity is missing", () => {
+    expect(shouldDispatchCommand("/agents", [], true)).toBe(false);
+    expect(shouldDispatchCommand("/agents", undefined, true)).toBe(false);
+  });
+
+  it("does not dispatch on plain text", () => {
+    expect(shouldDispatchCommand("hello", undefined, true)).toBe(false);
+  });
+
+  it("does not dispatch when bot_command is not at offset 0", () => {
+    expect(
+      shouldDispatchCommand(
+        "look /agents",
+        [{ type: "bot_command", offset: 5 }],
+        true,
+      ),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #29.

Telegram approval/rejection callbacks currently call the Paperclip REST API using `paperclipBaseUrl`. In default/local installs that is commonly `http://localhost:3100`, which can be blocked by the plugin host SSRF guard when invoked through `ctx.http.fetch`.

This PR adds a small URL resolver and uses `paperclipPublicUrl || paperclipBaseUrl` for approval API calls, so inline Approve/Reject buttons can use the externally reachable Paperclip URL when configured.

## Changes

- Add `resolvePaperclipApiBaseUrl(baseUrl, publicUrl)` helper
- Use it for inline approval/rejection callbacks
- Use it for the `/approve <id>` command path as well
- Add tests for URL selection and trailing slash normalization

## Validation

- `npm run typecheck` ✅
- `npx vitest run tests/paperclip-api.test.ts tests/commands.test.ts tests/worker-allowlist.test.ts` ✅ — 50 tests passed
- `npm run build` ✅

Note: full `npm test` currently has 3 failures in `tests/media-pipeline.test.ts` around transcription-preview expectations; those appear unrelated to this change.
