### PR TITLE
fix: gate agent run start/finish notifications behind config flags

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,6 +14,8 @@ export const DEFAULT_CONFIG = {
   onlyNotifyIfAssignedTo: "",
   notifyOnApprovalCreated: true,
   notifyOnAgentError: true,
+  notifyOnAgentRunStarted: false,
+  notifyOnAgentRunFinished: false,
   enableCommands: true,
   enableInbound: true,
   allowedTelegramUserIds: [] as string[],

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -137,6 +137,20 @@ const manifest: PaperclipPluginManifestV1 = {
         title: "Notify on agent error",
         default: DEFAULT_CONFIG.notifyOnAgentError,
       },
+      notifyOnAgentRunStarted: {
+        type: "boolean",
+        title: "Notify on agent run started",
+        description:
+          "Send a message every time an agent heartbeat run starts. Off by default — these fire on every heartbeat tick and can be very noisy, especially with the issue continuation watchdog or scheduled cycles.",
+        default: DEFAULT_CONFIG.notifyOnAgentRunStarted,
+      },
+      notifyOnAgentRunFinished: {
+        type: "boolean",
+        title: "Notify on agent run finished",
+        description:
+          "Send a message every time an agent heartbeat run completes successfully. Off by default — see notifyOnAgentRunStarted. Failures are still covered by notifyOnAgentError.",
+        default: DEFAULT_CONFIG.notifyOnAgentRunFinished,
+      },
 
       // --- Digest ---
       digestMode: {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -57,6 +57,8 @@ type TelegramConfig = {
   onlyNotifyIfAssignedTo: string;
   notifyOnApprovalCreated: boolean;
   notifyOnAgentError: boolean;
+  notifyOnAgentRunStarted: boolean;
+  notifyOnAgentRunFinished: boolean;
   enableCommands: boolean;
   enableInbound: boolean;
   allowedTelegramUserIds: string[];
@@ -480,12 +482,31 @@ const plugin = definePlugin({
       );
     }
 
-    ctx.events.on("agent.run.started", (event: PluginEvent) =>
-      notify(event, formatAgentRunStarted),
-    );
-    ctx.events.on("agent.run.finished", (event: PluginEvent) =>
-      notify(event, formatAgentRunFinished),
-    );
+    if (config.notifyOnAgentRunStarted) {
+      ctx.events.on("agent.run.started", async (event: PluginEvent) => {
+        const payload = (event.payload ?? {}) as Record<string, unknown>;
+        if (payload.agentId && !payload.agentName) {
+          try {
+            const agent = await ctx.agents.get(String(payload.agentId), event.companyId);
+            if (agent) payload.agentName = agent.name;
+          } catch { /* best effort */ }
+        }
+        await notify(event, formatAgentRunStarted);
+      });
+    }
+
+    if (config.notifyOnAgentRunFinished) {
+      ctx.events.on("agent.run.finished", async (event: PluginEvent) => {
+        const payload = (event.payload ?? {}) as Record<string, unknown>;
+        if (payload.agentId && !payload.agentName) {
+          try {
+            const agent = await ctx.agents.get(String(payload.agentId), event.companyId);
+            if (agent) payload.agentName = agent.name;
+          } catch { /* best effort */ }
+        }
+        await notify(event, formatAgentRunFinished);
+      });
+    }
 
     // --- Per-company chat overrides ---
 


### PR DESCRIPTION
## Summary
- The `agent.run.started` and `agent.run.finished` subscriptions in `worker.ts` were unconditional — every heartbeat tick produced a Telegram message
- Every other notification (issue created/done/assigned, approval, agent error) is feature-flagged; these two were not
- This becomes very noisy with the issue continuation recovery watchdog upstream Paperclip recently added (#4258), which can re-queue an agent every ~30s on stranded `in_progress` issues
- Additionally, the run lifecycle event payload only ships `agentId` (no `agentName`), so messages displayed UUIDs instead of agent names

## Changes
- `constants.ts`: add `notifyOnAgentRunStarted` and `notifyOnAgentRunFinished` to `DEFAULT_CONFIG` (default `false`)
- `manifest.ts`: surface the two new flags in plugin settings with descriptions explaining why they're off by default
- `worker.ts`: gate both subscriptions behind their flags, and enrich the payload with `agent.name` via `ctx.agents.get(...)` before formatting (same pattern as the approval handler)

Failures remain covered by the existing `notifyOnAgentError` flag.

## Test plan
- [ ] Default install: no agent run start/finish notifications
- [ ] Toggle `notifyOnAgentRunStarted` on: notifications appear with the agent's name (not UUID)
- [ ] Toggle `notifyOnAgentRunFinished` on: same
- [ ] `notifyOnAgentError` still fires on failure regardless