### PR TITLE
fix: gate agent run start/finish notifications behind config flags

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,6 +14,8 @@ export const DEFAULT_CONFIG = {
   onlyNotifyIfAssignedTo: "",
   notifyOnApprovalCreated: true,
   notifyOnAgentError: true,
+  notifyOnAgentRunStarted: false,
+  notifyOnAgentRunFinished: false,
   enableCommands: true,
   enableInbound: true,
   allowedTelegramUserIds: [] as string[],

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -137,6 +137,20 @@ const manifest: PaperclipPluginManifestV1 = {
         title: "Notify on agent error",
         default: DEFAULT_CONFIG.notifyOnAgentError,
       },
+      notifyOnAgentRunStarted: {
+        type: "boolean",
+        title: "Notify on agent run started",
+        description:
+          "Send a Telegram message every time an agent begins a heartbeat run. Disabled by default — agents run frequently and this is usually noise.",
+        default: DEFAULT_CONFIG.notifyOnAgentRunStarted,
+      },
+      notifyOnAgentRunFinished: {
+        type: "boolean",
+        title: "Notify on agent run finished",
+        description:
+          "Send a Telegram message every time an agent run completes successfully. Disabled by default — agents run frequently and this is usually noise.",
+        default: DEFAULT_CONFIG.notifyOnAgentRunFinished,
+      },
 
       // --- Digest ---
       digestMode: {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -57,6 +57,8 @@ type TelegramConfig = {
   onlyNotifyIfAssignedTo: string;
   notifyOnApprovalCreated: boolean;
   notifyOnAgentError: boolean;
+  notifyOnAgentRunStarted: boolean;
+  notifyOnAgentRunFinished: boolean;
   enableCommands: boolean;
   enableInbound: boolean;
   allowedTelegramUserIds: string[];
@@ -480,12 +482,28 @@ const plugin = definePlugin({
       );
     }
 
-    ctx.events.on("agent.run.started", (event: PluginEvent) =>
-      notify(event, formatAgentRunStarted),
-    );
-    ctx.events.on("agent.run.finished", (event: PluginEvent) =>
-      notify(event, formatAgentRunFinished),
-    );
+    const enrichAgentName = async (event: PluginEvent) => {
+      const payload = event.payload as Record<string, unknown>;
+      if (payload.agentId && !payload.agentName) {
+        try {
+          const agent = await ctx.agents.get(String(payload.agentId), event.companyId);
+          if (agent) payload.agentName = agent.name;
+        } catch { /* best effort */ }
+      }
+    };
+
+    if (config.notifyOnAgentRunStarted) {
+      ctx.events.on("agent.run.started", async (event: PluginEvent) => {
+        await enrichAgentName(event);
+        await notify(event, formatAgentRunStarted);
+      });
+    }
+    if (config.notifyOnAgentRunFinished) {
+      ctx.events.on("agent.run.finished", async (event: PluginEvent) => {
+        await enrichAgentName(event);
+        await notify(event, formatAgentRunFinished);
+      });
+    }
 
     // --- Per-company chat overrides ---
 


### PR DESCRIPTION
## Summary

The plugin currently subscribes to `agent.run.started` and `agent.run.finished` unconditionally and forwards every event to Telegram. With agents running on heartbeat, this becomes high-frequency notification spam — a single chat can receive dozens of `▶️ <uuid> started a new run` / `⏹️ <uuid> completed successfully` messages per hour.

Two issues stack:

1. **No config gate.** Every other notification (`notifyOnIssueCreated`, `notifyOnIssueDone`, `notifyOnApprovalCreated`, `notifyOnAgentError`) is feature-flagged, but these two always fire.
2. **UUIDs instead of names.** The run lifecycle payload from Paperclip's heartbeat service only ships `agentId`, not `agentName`, so the formatter falls back to the agent UUID. Approval notifications already enrich via `ctx.agents.get(...)`, but the run handlers don't.

## Changes

- Add `notifyOnAgentRunStarted` and `notifyOnAgentRunFinished` config flags (both **disabled by default** — these are noisy and rarely useful).
- Gate the `ctx.events.on(...)` subscriptions behind those flags.
- Enrich `payload.agentName` from `ctx.agents.get(payload.agentId, event.companyId)` before formatting, so opting-in users see the agent name rather than a UUID. Mirrors the existing pattern in the approval handler.

`constants.ts`, `manifest.ts`, and `worker.ts` (config type + handlers) updated together.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — formatters/worker-allowlist suites pass; the 3 pre-existing `media-pipeline.test.ts` failures are unrelated to this change (verified by running tests on plain `main` HEAD without the patch — same 3 failures)
- [ ] With both flags off (default): no `agent.run.*` notifications emitted (manual verification by maintainer)
- [ ] With `notifyOnAgentRunStarted: true`: notification text shows the agent name, not the UUID

## Notes

Defaulting the flags to `false` is a behavior change for any operator who relied on the previous always-on subscription. Given the volume of these messages once heartbeat-driven agents are configured, opt-in seems like the saner default — happy to flip to `true` if maintainers prefer backwards compatibility.