### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "paperclip-plugin-telegram",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "paperclip-plugin-telegram",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "devDependencies": {
         "@paperclipai/plugin-sdk": "^2026.318.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paperclip-plugin-telegram",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "type": "module",
   "main": "./dist/index.js",
   "paperclipPlugin": {


### PR DESCRIPTION
## Why

The npm package is 4 commits behind main. Every recent merge ran the publish workflow, which correctly skipped because `package.json` version was unchanged from the prior release.

## Changes since 0.4.0 (last published 2026-04-26)

- #31 Add Telegram inbound allowlists
- #33 fix: attach topic create commands to mapped projects
- #35 feat: manage Telegram topic mappings
- #37 feat: improve Telegram approval topic routing + board auth (+1016/-63, board-access connection + auth)

## Bump

3 feats + 1 fix since 0.4.0, no breaking changes -> 0.5.0 (minor).

## After merge

Publish workflow will fire on push to main, see version bumped to 0.5.0, and `npm publish --provenance --access public` the package.