### PR TITLE
Persist Telegram polling offset after update handling succeeds

### DIFF
--- a/src/polling-offset.ts
+++ b/src/polling-offset.ts
@@ -34,3 +34,68 @@ export async function persistTelegramUpdateOffset(
     updateId,
   );
 }
+
+type PollingLogger = Pick<PluginContext["logger"], "error">;
+
+export async function handleTelegramUpdateThenPersistOffset(options: {
+  updateId: number;
+  lastUpdateId: number;
+  handleUpdate: () => Promise<void>;
+  persistOffset: (updateId: number) => Promise<void>;
+  logger: PollingLogger;
+}): Promise<number> {
+  const { updateId, lastUpdateId, handleUpdate, persistOffset, logger } = options;
+
+  try {
+    await handleUpdate();
+  } catch (err) {
+    logger.error("Telegram update handling failed", {
+      updateId,
+      error: String(err),
+    });
+    return lastUpdateId;
+  }
+
+  const nextUpdateId = Math.max(lastUpdateId, updateId);
+  if (nextUpdateId <= lastUpdateId) return lastUpdateId;
+
+  try {
+    await persistOffset(nextUpdateId);
+  } catch (err) {
+    logger.error("Failed to persist Telegram polling offset", {
+      updateId: nextUpdateId,
+      error: String(err),
+    });
+  }
+
+  return nextUpdateId;
+}
+
+export async function processTelegramUpdateBatch<TUpdate extends { update_id: number }>(options: {
+  updates: TUpdate[];
+  lastUpdateId: number;
+  handleUpdate: (update: TUpdate) => Promise<void>;
+  persistOffset: (updateId: number) => Promise<void>;
+  logger: PollingLogger;
+}): Promise<number> {
+  const { updates, handleUpdate, persistOffset, logger } = options;
+  let lastUpdateId = options.lastUpdateId;
+
+  for (const update of updates) {
+    const nextUpdateId = await handleTelegramUpdateThenPersistOffset({
+      updateId: update.update_id,
+      lastUpdateId,
+      handleUpdate: () => handleUpdate(update),
+      persistOffset,
+      logger,
+    });
+
+    if (nextUpdateId === lastUpdateId && update.update_id > lastUpdateId) {
+      break;
+    }
+
+    lastUpdateId = nextUpdateId;
+  }
+
+  return lastUpdateId;
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -36,7 +36,11 @@ import {
   setupAcpOutputListener,
 } from "./acp-bridge.js";
 import { handleMediaMessage } from "./media-pipeline.js";
-import { getPersistedTelegramUpdateOffset, persistTelegramUpdateOffset } from "./polling-offset.js";
+import {
+  getPersistedTelegramUpdateOffset,
+  persistTelegramUpdateOffset,
+  processTelegramUpdateBatch,
+} from "./polling-offset.js";
 import { handleCommandsCommand, tryCustomCommand } from "./command-registry.js";
 import { handleRegisterWatch, checkWatches } from "./watch-registry.js";
 import { METRIC_NAMES } from "./constants.js";
@@ -388,29 +392,13 @@ const plugin = definePlugin({
           };
 
           if (data.ok && data.result) {
-            for (const update of data.result) {
-              try {
-                await handleUpdate(ctx, token, config, update, baseUrl, publicUrl);
-              } catch (err) {
-                ctx.logger.error("Telegram update handling failed", {
-                  updateId: update.update_id,
-                  error: String(err),
-                });
-              }
-
-              const nextUpdateId = Math.max(lastUpdateId, update.update_id);
-              if (nextUpdateId > lastUpdateId) {
-                lastUpdateId = nextUpdateId;
-                try {
-                  await persistTelegramUpdateOffset(ctx, lastUpdateId);
-                } catch (err) {
-                  ctx.logger.error("Failed to persist Telegram polling offset", {
-                    updateId: lastUpdateId,
-                    error: String(err),
-                  });
-                }
-              }
-            }
+            lastUpdateId = await processTelegramUpdateBatch({
+              updates: data.result,
+              lastUpdateId,
+              handleUpdate: (update) => handleUpdate(ctx, token, config, update, baseUrl, publicUrl),
+              persistOffset: (updateId) => persistTelegramUpdateOffset(ctx, updateId),
+              logger: ctx.logger,
+            });
           }
         } catch (err) {
           ctx.logger.error("Telegram polling error", { error: String(err) });

--- a/tests/polling-offset.test.ts
+++ b/tests/polling-offset.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, vi } from "vitest";
 import type { PluginContext } from "@paperclipai/plugin-sdk";
 import {
   getPersistedTelegramUpdateOffset,
+  handleTelegramUpdateThenPersistOffset,
   persistTelegramUpdateOffset,
+  processTelegramUpdateBatch,
   TELEGRAM_LAST_UPDATE_ID_STATE_KEY,
 } from "../src/polling-offset.js";
 
@@ -50,5 +52,97 @@ describe("Telegram polling offset persistence", () => {
     await persistTelegramUpdateOffset(ctx, -1);
     await persistTelegramUpdateOffset(ctx, Number.NaN);
     expect(ctx.state.set).not.toHaveBeenCalled();
+  });
+});
+
+describe("handleTelegramUpdateThenPersistOffset", () => {
+  it("persists the update offset only after handling succeeds", async () => {
+    const calls: string[] = [];
+    const logger = { error: vi.fn() };
+
+    const nextOffset = await handleTelegramUpdateThenPersistOffset({
+      updateId: 42,
+      lastUpdateId: 41,
+      handleUpdate: vi.fn(async () => {
+        calls.push("handle");
+      }),
+      persistOffset: vi.fn(async (updateId) => {
+        calls.push(`persist:${updateId}`);
+      }),
+      logger,
+    });
+
+    expect(nextOffset).toBe(42);
+    expect(calls).toEqual(["handle", "persist:42"]);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it("does not advance or persist the offset when handling fails", async () => {
+    const persistOffset = vi.fn(async () => undefined);
+    const logger = { error: vi.fn() };
+
+    const nextOffset = await handleTelegramUpdateThenPersistOffset({
+      updateId: 42,
+      lastUpdateId: 41,
+      handleUpdate: vi.fn(async () => {
+        throw new Error("boom");
+      }),
+      persistOffset,
+      logger,
+    });
+
+    expect(nextOffset).toBe(41);
+    expect(persistOffset).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith("Telegram update handling failed", {
+      updateId: 42,
+      error: "Error: boom",
+    });
+  });
+});
+
+describe("processTelegramUpdateBatch", () => {
+  it("stops after a failed update so later updates cannot advance past it", async () => {
+    const handledUpdateIds: number[] = [];
+    const persistOffset = vi.fn(async () => undefined);
+    const logger = { error: vi.fn() };
+
+    const nextOffset = await processTelegramUpdateBatch({
+      updates: [{ update_id: 42 }, { update_id: 43 }],
+      lastUpdateId: 41,
+      handleUpdate: vi.fn(async (update) => {
+        handledUpdateIds.push(update.update_id);
+        if (update.update_id === 42) {
+          throw new Error("boom");
+        }
+      }),
+      persistOffset,
+      logger,
+    });
+
+    expect(nextOffset).toBe(41);
+    expect(handledUpdateIds).toEqual([42]);
+    expect(persistOffset).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith("Telegram update handling failed", {
+      updateId: 42,
+      error: "Error: boom",
+    });
+  });
+
+  it("persists each contiguous successfully handled update", async () => {
+    const persistOffset = vi.fn(async () => undefined);
+    const logger = { error: vi.fn() };
+
+    const nextOffset = await processTelegramUpdateBatch({
+      updates: [{ update_id: 42 }, { update_id: 43 }],
+      lastUpdateId: 41,
+      handleUpdate: vi.fn(async () => undefined),
+      persistOffset,
+      logger,
+    });
+
+    expect(nextOffset).toBe(43);
+    expect(persistOffset).toHaveBeenNthCalledWith(1, 42);
+    expect(persistOffset).toHaveBeenNthCalledWith(2, 43);
+    expect(logger.error).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Move Telegram polling offset advancement behind successful `handleUpdate()` completion.
- Stop processing the current `getUpdates` batch on the first handling failure, leaving `lastUpdateId` unchanged so Telegram can retry the failed update instead of skipping past it.
- Add focused tests for success ordering, failure non-advance/non-persist behavior, and the multi-update regression where a later successful update follows an earlier failed one in the same batch.

Fixes #27

## Validation
- `npm test -- --run tests/polling-offset.test.ts` — passed (10 tests)
- `npm run typecheck` — passed
- `git diff --check` — passed
- `npm test` — failed in pre-existing media pipeline tests unrelated to this change: `tests/media-pipeline.test.ts` audio transcription preview assertions (3 failures). The changed polling-offset tests passed in the full run.

## Notes
- No public/private deployment details, chat IDs, tokens, or internal logs are included.