### PR TITLE
Port intent of #40 #43 #45 #47 onto main (post-#44 settings UI)

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -21,6 +21,8 @@ export const DEFAULT_CONFIG = {
   notifyOnApprovalCreated: true,
   onlyNotifyBoardApprovals: false,
   notifyOnAgentError: true,
+  notifyOnAgentRunStarted: false,
+  notifyOnAgentRunFinished: false,
   enableCommands: true,
   enableInbound: true,
   allowedTelegramUserIds: [] as string[],

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -46,6 +46,8 @@ export const DEFAULT_CONFIG = {
   watchDeduplicationWindowMs: 86400000, // 24h
 } as const;
 
+export const AGENT_ERROR_DEDUPLICATION_WINDOW_MS = 30 * 60 * 1000;
+
 export const MAX_CONVERSATION_TURNS = 50;
 export const DEFAULT_CONVERSATION_TURNS = 10;
 

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -49,6 +49,19 @@ function agentButton(agentId: string, label: string, publicUrl?: string): { text
   return null;
 }
 
+function runButton(agentId: string, runId: string | null, publicUrl?: string): { text: string; url: string } | null {
+  if (publicUrl && isExternalUrl(publicUrl) && runId) {
+    return { text: "View Run ↗", url: `${publicUrl}/agents/${agentId}/runs/${runId}` };
+  }
+  return null;
+}
+
+function classifyAgentError(errorMessage: string): string {
+  if (/timed?\s*out|timeout/i.test(errorMessage)) return "Agent Timeout";
+  if (/limit|rate.?limit|quota/i.test(errorMessage)) return "Agent Rate Limit";
+  return "Agent Error";
+}
+
 export function formatIssueCreated(event: PluginEvent, opts?: IssueLinksOpts): FormattedMessage {
   const p = event.payload as Payload;
   const identifier = String(p.identifier ?? event.entityId);
@@ -206,17 +219,36 @@ export function formatAgentError(event: PluginEvent, opts?: IssueLinksOpts): For
   const agentId = String(p.agentId ?? event.entityId);
   const agentName = String(p.agentName ?? p.name ?? agentId);
   const errorMessage = String(p.error ?? p.message ?? "Unknown error");
+  const runId = p.runId ? String(p.runId) : null;
+  const companyName = p.companyName ? String(p.companyName) : null;
+  const issueIdentifier = p.issueIdentifier ? String(p.issueIdentifier) : null;
+  const issueTitle = p.issueTitle ? String(p.issueTitle) : null;
 
-  const btn = agentButton(agentId, "View Agent ↗", opts?.baseUrl);
+  const lines: string[] = [
+    `${esc("❌")} ${bold(classifyAgentError(errorMessage))}`,
+    `Agent: ${bold(agentName)}`,
+  ];
+  if (companyName) lines.push(`Company: ${esc(companyName)}`);
+  if (issueIdentifier) {
+    lines.push(
+      issueTitle
+        ? `Issue: ${issueLink(issueIdentifier, opts)} ${esc("—")} ${esc(issueTitle)}`
+        : `Issue: ${issueLink(issueIdentifier, opts)}`,
+    );
+  }
+  lines.push(`\n${code(truncateAtWord(errorMessage, 500))}`);
+
+  const buttons = [
+    runButton(agentId, runId, opts?.baseUrl),
+    issueIdentifier ? issueButton(issueIdentifier, opts) : null,
+    agentButton(agentId, "View Agent ↗", opts?.baseUrl),
+  ].filter((button): button is { text: string; url: string } => Boolean(button));
+
   return {
-    text: [
-      `${esc("❌")} ${bold("Agent Error")}`,
-      `${bold(agentName)} ${esc("encountered an error")}`,
-      `\n${code(truncateAtWord(errorMessage, 500))}`,
-    ].join("\n"),
+    text: lines.join("\n"),
     options: {
       parseMode: "MarkdownV2",
-      ...(btn ? { inlineKeyboard: [[btn]] } : {}),
+      ...(buttons.length > 0 ? { inlineKeyboard: [buttons] } : {}),
     },
   };
 }

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -63,6 +63,8 @@ type TelegramRoutingConfig = {
   errorsChatId: string;
   errorsTopicId: string;
   notifyOnAgentError: boolean;
+  notifyOnAgentRunStarted: boolean;
+  notifyOnAgentRunFinished: boolean;
   digestChatId: string;
   digestTopicId: string;
   digestMode: "off" | "daily" | "bidaily" | "tridaily";
@@ -127,6 +129,8 @@ const DEFAULT_ROUTING_CONFIG: TelegramRoutingConfig = {
   errorsChatId: "",
   errorsTopicId: "",
   notifyOnAgentError: true,
+  notifyOnAgentRunStarted: false,
+  notifyOnAgentRunFinished: false,
   digestChatId: "",
   digestTopicId: "",
   digestMode: "off",
@@ -260,6 +264,14 @@ function extractRoutingConfig(config: Record<string, unknown>): TelegramRoutingC
     notifyOnAgentError: asBoolean(
       config.notifyOnAgentError,
       DEFAULT_ROUTING_CONFIG.notifyOnAgentError,
+    ),
+    notifyOnAgentRunStarted: asBoolean(
+      config.notifyOnAgentRunStarted,
+      DEFAULT_ROUTING_CONFIG.notifyOnAgentRunStarted,
+    ),
+    notifyOnAgentRunFinished: asBoolean(
+      config.notifyOnAgentRunFinished,
+      DEFAULT_ROUTING_CONFIG.notifyOnAgentRunFinished,
     ),
     digestChatId: asString(config.digestChatId),
     digestTopicId: asString(config.digestTopicId),
@@ -1742,20 +1754,50 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
             onTopicIdChange={(value) => updateRoutingField("errorsTopicId", value)}
             chatHelp="Leave empty to use the default route for agent error notifications."
             footer={
-              <label style={{ color: "#374151", display: "grid", gap: 3, fontSize: 13 }}>
-                <span style={{ alignItems: "center", display: "flex", gap: 8 }}>
-                  <input
-                    checked={routingConfig.notifyOnAgentError}
-                    disabled={routingLoading || routingSaving}
-                    onChange={(event) => updateRoutingField("notifyOnAgentError", event.currentTarget.checked)}
-                    type="checkbox"
-                  />
-                  Enabled
-                </span>
-                <span style={{ color: "#6b7280", fontSize: 12, marginLeft: 22 }}>
-                  Send Telegram notifications when an agent run reports an error.
-                </span>
-              </label>
+              <>
+                <label style={{ color: "#374151", display: "grid", gap: 3, fontSize: 13 }}>
+                  <span style={{ alignItems: "center", display: "flex", gap: 8 }}>
+                    <input
+                      checked={routingConfig.notifyOnAgentError}
+                      disabled={routingLoading || routingSaving}
+                      onChange={(event) => updateRoutingField("notifyOnAgentError", event.currentTarget.checked)}
+                      type="checkbox"
+                    />
+                    Errors enabled
+                  </span>
+                  <span style={{ color: "#6b7280", fontSize: 12, marginLeft: 22 }}>
+                    Send Telegram notifications when an agent run reports an error.
+                  </span>
+                </label>
+                <label style={{ color: "#374151", display: "grid", gap: 3, fontSize: 13 }}>
+                  <span style={{ alignItems: "center", display: "flex", gap: 8 }}>
+                    <input
+                      checked={routingConfig.notifyOnAgentRunStarted}
+                      disabled={routingLoading || routingSaving}
+                      onChange={(event) => updateRoutingField("notifyOnAgentRunStarted", event.currentTarget.checked)}
+                      type="checkbox"
+                    />
+                    Run started
+                  </span>
+                  <span style={{ color: "#6b7280", fontSize: 12, marginLeft: 22 }}>
+                    Notify on every agent run start. Off by default - high-frequency on busy instances. Routes through the default chat.
+                  </span>
+                </label>
+                <label style={{ color: "#374151", display: "grid", gap: 3, fontSize: 13 }}>
+                  <span style={{ alignItems: "center", display: "flex", gap: 8 }}>
+                    <input
+                      checked={routingConfig.notifyOnAgentRunFinished}
+                      disabled={routingLoading || routingSaving}
+                      onChange={(event) => updateRoutingField("notifyOnAgentRunFinished", event.currentTarget.checked)}
+                      type="checkbox"
+                    />
+                    Run finished
+                  </span>
+                  <span style={{ color: "#6b7280", fontSize: 12, marginLeft: 22 }}>
+                    Notify on every agent run completion. Off by default - high-frequency on busy instances. Routes through the default chat.
+                  </span>
+                </label>
+              </>
             }
           />
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -69,6 +69,8 @@ type TelegramConfig = {
   notifyOnApprovalCreated: boolean;
   onlyNotifyBoardApprovals: boolean;
   notifyOnAgentError: boolean;
+  notifyOnAgentRunStarted: boolean;
+  notifyOnAgentRunFinished: boolean;
   enableCommands: boolean;
   enableInbound: boolean;
   allowedTelegramUserIds: string[];
@@ -645,12 +647,28 @@ const plugin = definePlugin({
       );
     }
 
-    ctx.events.on("agent.run.started", (event: PluginEvent) =>
-      notify(event, formatAgentRunStarted),
-    );
-    ctx.events.on("agent.run.finished", (event: PluginEvent) =>
-      notify(event, formatAgentRunFinished),
-    );
+    const enrichAgentName = async (event: PluginEvent) => {
+      const payload = event.payload as Record<string, unknown>;
+      if (payload.agentId && !payload.agentName) {
+        try {
+          const agent = await ctx.agents.get(String(payload.agentId), event.companyId);
+          if (agent) payload.agentName = agent.name;
+        } catch { /* best effort */ }
+      }
+    };
+
+    if (config.notifyOnAgentRunStarted) {
+      ctx.events.on("agent.run.started", async (event: PluginEvent) => {
+        await enrichAgentName(event);
+        await notify(event, formatAgentRunStarted);
+      });
+    }
+    if (config.notifyOnAgentRunFinished) {
+      ctx.events.on("agent.run.finished", async (event: PluginEvent) => {
+        await enrichAgentName(event);
+        await notify(event, formatAgentRunFinished);
+      });
+    }
 
     // --- Per-company chat overrides ---
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -653,6 +653,27 @@ const plugin = definePlugin({
       ctx.events.on("agent.run.failed", async (event: PluginEvent) => {
         const payload = event.payload as Record<string, unknown>;
         const agentId = String(payload.agentId ?? event.entityId);
+        if (payload.agentId && !payload.agentName) {
+          try {
+            const agent = await ctx.agents.get(String(payload.agentId), event.companyId);
+            if (agent) payload.agentName = agent.name;
+          } catch { /* best effort */ }
+        }
+        if (!payload.companyName) {
+          try {
+            const company = await ctx.companies.get(event.companyId);
+            if (company?.name) payload.companyName = company.name;
+          } catch { /* best effort */ }
+        }
+        if (payload.issueId && (!payload.issueIdentifier || !payload.issueTitle)) {
+          try {
+            const issue = await ctx.issues.get(String(payload.issueId), event.companyId);
+            if (issue) {
+              payload.issueIdentifier ??= issue.identifier;
+              payload.issueTitle ??= issue.title;
+            }
+          } catch { /* best effort */ }
+        }
         const errorMessage = normalizeAgentErrorMessage(payload.error ?? payload.message);
         const dedupeKey = ["agent.run.failed", event.companyId, agentId, errorMessage].join(":");
         if (!agentErrorDedupe(dedupeKey)) return;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -43,7 +43,7 @@ import {
 } from "./polling-offset.js";
 import { handleCommandsCommand, tryCustomCommand } from "./command-registry.js";
 import { handleRegisterWatch, checkWatches } from "./watch-registry.js";
-import { METRIC_NAMES } from "./constants.js";
+import { AGENT_ERROR_DEDUPLICATION_WINDOW_MS, METRIC_NAMES } from "./constants.js";
 import { EscalationManager } from "./escalation.js";
 import type { EscalationEvent } from "./escalation.js";
 import { isTelegramUpdateAllowed, validateTelegramAllowlists } from "./allowlist.js";
@@ -270,6 +270,13 @@ function makeUpdateDedupe(windowMs = 5_000, maxEntries = 500) {
     }
     return true;
   };
+}
+
+function normalizeAgentErrorMessage(input: unknown): string {
+  return String(input ?? "Unknown error")
+    .trim()
+    .replace(/\s+/g, " ")
+    .slice(0, 500);
 }
 
 async function resolveChat(
@@ -642,9 +649,15 @@ const plugin = definePlugin({
     }
 
     if (config.notifyOnAgentError) {
-      ctx.events.on("agent.run.failed", (event: PluginEvent) =>
-        notify(event, formatAgentError, config.errorsChatId, config.errorsTopicId),
-      );
+      const agentErrorDedupe = makeUpdateDedupe(AGENT_ERROR_DEDUPLICATION_WINDOW_MS, 1000);
+      ctx.events.on("agent.run.failed", async (event: PluginEvent) => {
+        const payload = event.payload as Record<string, unknown>;
+        const agentId = String(payload.agentId ?? event.entityId);
+        const errorMessage = normalizeAgentErrorMessage(payload.error ?? payload.message);
+        const dedupeKey = ["agent.run.failed", event.companyId, agentId, errorMessage].join(":");
+        if (!agentErrorDedupe(dedupeKey)) return;
+        await notify(event, formatAgentError, config.errorsChatId, config.errorsTopicId);
+      });
     }
 
     const enrichAgentName = async (event: PluginEvent) => {


### PR DESCRIPTION
Bundles three commits porting the intent of @nferro #40 and @promptinprod #43 #45 #47 onto current main. All four originals were CONFLICTING after the settings UI redesign (#44) reshaped manifest.ts and the routing UI - rebasing each one would have meant three round-trips through the new UI surface, so I'm porting on their behalf with credit.

- `feat: gate agent run start/finish notifications` - ports #40 + #43. Default false. Adds the `enrichAgentName` helper from #43 so opted-in messages show the agent name instead of the UUID. Surfaces both toggles in the Errors row of the settings page.
- `fix: dedupe repeated agent error telegram notifications` - ports #45 verbatim. 30-min window keyed by company+agent+normalized error.
- `fix: enrich telegram agent error notifications` - ports #47. Classification headings (Agent Timeout / Agent Rate Limit / Agent Error), company name, issue identifier+title, View Run button.

Closes #40, #43, #45, #47.