### PR TITLE
fix(tests): stub global fetch for native-fetch transcription path

### DIFF
--- a/tests/media-pipeline.test.ts
+++ b/tests/media-pipeline.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { handleMediaMessage } from "../src/media-pipeline.js";
 import type { PluginContext } from "@paperclipai/plugin-sdk";
 
@@ -74,6 +74,23 @@ beforeEach(() => {
   sentMessages = [];
   stateStore = {};
   emittedEvents = [];
+
+  vi.stubGlobal("fetch", vi.fn(async (url: unknown) => {
+    const u = String(url);
+    if (u.includes("openai.com")) {
+      return new Response(JSON.stringify({ text: "Transcribed" }), {
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (u.includes("api.telegram.org")) {
+      return new Response(new ArrayBuffer(8));
+    }
+    throw new Error(`Unmocked native fetch: ${u}`);
+  }));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
 });
 
 describe("Intake detection", () => {
@@ -154,16 +171,6 @@ describe("Intake detection", () => {
 describe("Audio type detection", () => {
   it("detects voice messages as audio", async () => {
     const ctx = mockCtx();
-    // Mock the Whisper API response
-    (ctx.http.fetch as ReturnType<typeof vi.fn>).mockImplementation(async (url: string) => {
-      if (String(url).includes("openai.com")) {
-        return { json: () => Promise.resolve({ text: "Transcribed voice" }) };
-      }
-      if (String(url).includes("getFile")) {
-        return { json: () => Promise.resolve({ ok: true, result: { file_path: "voice/file.oga" } }) };
-      }
-      return { blob: () => Promise.resolve(new Blob(["data"])) };
-    });
 
     await handleMediaMessage(ctx, "token", {
       message_id: 1,
@@ -178,15 +185,6 @@ describe("Audio type detection", () => {
 
   it("detects audio messages as audio", async () => {
     const ctx = mockCtx();
-    (ctx.http.fetch as ReturnType<typeof vi.fn>).mockImplementation(async (url: string) => {
-      if (String(url).includes("openai.com")) {
-        return { json: () => Promise.resolve({ text: "Transcribed audio" }) };
-      }
-      if (String(url).includes("getFile")) {
-        return { json: () => Promise.resolve({ ok: true, result: { file_path: "audio/file.mp3" } }) };
-      }
-      return { blob: () => Promise.resolve(new Blob(["data"])) };
-    });
 
     await handleMediaMessage(ctx, "token", {
       message_id: 1,
@@ -200,15 +198,6 @@ describe("Audio type detection", () => {
 
   it("detects video_note as audio (transcribable)", async () => {
     const ctx = mockCtx();
-    (ctx.http.fetch as ReturnType<typeof vi.fn>).mockImplementation(async (url: string) => {
-      if (String(url).includes("openai.com")) {
-        return { json: () => Promise.resolve({ text: "Video note text" }) };
-      }
-      if (String(url).includes("getFile")) {
-        return { json: () => Promise.resolve({ ok: true, result: { file_path: "videonote/file.mp4" } }) };
-      }
-      return { blob: () => Promise.resolve(new Blob(["data"])) };
-    });
 
     await handleMediaMessage(ctx, "token", {
       message_id: 1,


### PR DESCRIPTION
## Problem

Three tests in `tests/media-pipeline.test.ts > Audio type detection` have been failing on `main`:

- `detects voice messages as audio`
- `detects audio messages as audio`
- `detects video_note as audio (transcribable)`

Each fails on the same assertion:

```
expect(sentMessages.some(m => m.text.includes("Transcription"))).toBe(true)
// Expected: true
// Received: false
```

## Root cause

Commit 7107c49 (`fix: use native fetch for voice transcription to avoid RPC bridge binary corruption`) switched two of `transcribeAudio`'s three HTTP calls from `ctx.http.fetch` to native `fetch`:

- Step 2: binary download from `api.telegram.org/file/...`
- Step 5: multipart POST to `api.openai.com/v1/audio/transcriptions`

Step 1 (the JSON `getFile` call) still uses `ctx.http.fetch`.

The test file mocks only `ctx.http.fetch`. The native `fetch` calls therefore hit the real network in the test runner, fail, the source's `try/catch` silently swallows the error (`textContent = "[Audio - transcription failed]"`), and the `Transcription:` preview message is never sent. The other tests in the suite pass because they do not rely on that preview.

## Fix

Stub the global `fetch` in `beforeEach` to mirror the routing the source expects, and unstub in `afterEach`:

- `openai.com` → JSON Whisper response with `text` field
- `api.telegram.org` → empty binary `ArrayBuffer`
- anything else → throw, so unmocked calls surface in future tests

The per-test `ctx.http.fetch.mockImplementation` overrides in the three failing tests are dead code post-7107c49 (their `openai.com` branches no longer fire, their `getFile` branches duplicate the default mock in `mockCtx`) and have been removed.

No runtime change.

## Verification

```
npm test
# Test Files  12 passed (12)
#      Tests  201 passed (201)

npm run typecheck && npm run build
# clean
```

Diff: +18 / -29 in a single file (`tests/media-pipeline.test.ts`).

— Claude