### PR TITLE
Preserve project context for Telegram topic agent sessions

### DIFF
--- a/src/acp-bridge.ts
+++ b/src/acp-bridge.ts
@@ -1,6 +1,7 @@
 import type { PluginContext, AgentSessionEvent } from "@paperclipai/plugin-sdk";
 import { sendMessage, escapeMarkdownV2, sendChatAction } from "./telegram-api.js";
 import { truncateAtWord } from "./telegram-api.js";
+import { resolveMappedProjectIdForTopic } from "./topic-projects.js";
 import {
   MAX_AGENTS_PER_THREAD,
   DEFAULT_CONVERSATION_TURNS,
@@ -186,6 +187,7 @@ export async function wakeAgentWithIssue(
   companyId: string,
   promptText: string,
   reason: string,
+  projectId?: string,
 ): Promise<string | null> {
   try {
     const title = truncateAtWord(promptText.replace(/\n/g, " "), 200);
@@ -193,6 +195,7 @@ export async function wakeAgentWithIssue(
 
     const issue = await ctx.issues.create({
       companyId,
+      ...(projectId ? { projectId } : {}),
       title: `[Telegram] ${title}`,
       description,
       assigneeAgentId: agentId,
@@ -212,6 +215,7 @@ export async function wakeAgentWithIssue(
     ctx.logger.error("Failed to create issue for native prompt delivery", {
       agentId,
       companyId,
+      projectId,
       reason,
       error: String(err),
     });
@@ -609,6 +613,7 @@ export async function routeMessageToAgent(
   await saveSessions(ctx, chatId, threadId, sessions);
 
   const resolvedCompanyId = companyId ?? await resolveCompanyIdFromChat(ctx, chatId);
+  const projectId = await resolveMappedProjectIdForTopic(ctx, chatId, resolvedCompanyId, threadId);
 
   // Route via correct transport
   if (targetSession.transport === "native") {
@@ -618,6 +623,7 @@ export async function routeMessageToAgent(
       resolvedCompanyId,
       text,
       "telegram_message",
+      projectId,
     );
     if (!issueId) {
       ctx.logger.error("Failed to deliver message to native agent — issue creation failed", {

--- a/src/media-pipeline.ts
+++ b/src/media-pipeline.ts
@@ -2,6 +2,7 @@ import type { PluginContext } from "@paperclipai/plugin-sdk";
 import { sendMessage, escapeMarkdownV2, sendChatAction } from "./telegram-api.js";
 import { METRIC_NAMES } from "./constants.js";
 import { getSessions, wakeAgentWithIssue } from "./acp-bridge.js";
+import { resolveMappedProjectIdForTopic } from "./topic-projects.js";
 
 const TELEGRAM_API = "https://api.telegram.org";
 
@@ -130,6 +131,7 @@ export async function handleMediaMessage(
     if (target) {
       const mediaLabel = isAudio ? "Audio message" : msg.photo ? "Photo" : "Document";
       const prompt = `[${mediaLabel}] ${textContent || "(no caption)"}`;
+      const projectId = await resolveMappedProjectIdForTopic(ctx, chatId, companyId, threadId);
 
       if (target.transport === "native") {
         await wakeAgentWithIssue(
@@ -138,6 +140,7 @@ export async function handleMediaMessage(
           companyId,
           prompt,
           "media_message",
+          projectId,
         );
       } else {
         ctx.events.emit("acp-spawn", companyId, {

--- a/src/topic-projects.ts
+++ b/src/topic-projects.ts
@@ -1,0 +1,53 @@
+import type { PluginContext } from "@paperclipai/plugin-sdk";
+
+type TopicMappingRecord = {
+  projectId?: string;
+  projectName: string;
+  topicId: string;
+};
+
+type TopicMappingValue = string | TopicMappingRecord;
+type TopicMap = Record<string, TopicMappingValue>;
+
+function normalizeTopicMapping(projectName: string, value: TopicMappingValue): TopicMappingRecord {
+  if (typeof value === "string") {
+    return { projectName, topicId: value };
+  }
+  return {
+    projectId: value.projectId,
+    projectName: value.projectName || projectName,
+    topicId: value.topicId,
+  };
+}
+
+export async function resolveMappedProjectIdForTopic(
+  ctx: PluginContext,
+  chatId: string,
+  companyId: string,
+  messageThreadId?: number,
+): Promise<string | undefined> {
+  if (!messageThreadId) return undefined;
+
+  const topicMap = (await ctx.state.get({
+    scopeKind: "instance",
+    stateKey: `topic-map-${chatId}`,
+  })) as TopicMap | null;
+  if (!topicMap) return undefined;
+
+  const topicId = String(messageThreadId);
+  const match = Object.entries(topicMap)
+    .map(([projectName, value]) => normalizeTopicMapping(projectName, value))
+    .find((mapping) => mapping.topicId === topicId);
+
+  if (!match) return undefined;
+  if (match.projectId) return match.projectId;
+
+  try {
+    const projects = await ctx.projects.list({ companyId, limit: 100 });
+    const exactMatch = projects.find((project) => project.name === match.projectName);
+    if (exactMatch) return exactMatch.id;
+    return projects.find((project) => project.name?.toLowerCase() === match.projectName.toLowerCase())?.id;
+  } catch {
+    return undefined;
+  }
+}

--- a/tests/acp-bridge.test.ts
+++ b/tests/acp-bridge.test.ts
@@ -44,6 +44,13 @@ function mockCtx(): PluginContext {
         close: vi.fn(),
       },
     },
+    issues: {
+      create: vi.fn().mockResolvedValue({ id: "issue-1" }),
+      update: vi.fn().mockResolvedValue({ id: "issue-1" }),
+    },
+    projects: {
+      list: vi.fn().mockResolvedValue([]),
+    },
   } as unknown as PluginContext;
 }
 
@@ -224,6 +231,36 @@ describe("routeMessageToAgent - reply-to fallback", () => {
     const ctx = mockCtx();
     const result = await routeMessageToAgent(ctx, "token", "chat-1", 42, "hello", undefined, "company-1");
     expect(result).toBe(false);
+  });
+
+  it("creates native wake-up issues in the project mapped to the Telegram topic", async () => {
+    const ctx = mockCtx();
+    stateStore["topic-map-chat-1"] = {
+      "Setup and Tests": {
+        projectId: "project-1",
+        projectName: "Setup and Tests",
+        topicId: "42",
+      },
+    };
+    stateStore["sessions_chat-1_42"] = [{
+      sessionId: "s1",
+      agentId: "agent-1",
+      agentName: "ceo",
+      agentDisplayName: "CEO",
+      transport: "native",
+      spawnedAt: "2026-01-01T00:00:00Z",
+      status: "active",
+      lastActivityAt: "2026-01-01T00:00:00Z",
+    }];
+
+    const result = await routeMessageToAgent(ctx, "token", "chat-1", 42, "hello from topic", undefined, "company-1");
+
+    expect(result).toBe(true);
+    expect(ctx.issues.create).toHaveBeenCalledWith(expect.objectContaining({
+      companyId: "company-1",
+      projectId: "project-1",
+      assigneeAgentId: "agent-1",
+    }));
   });
 });
 

--- a/tests/media-pipeline.test.ts
+++ b/tests/media-pipeline.test.ts
@@ -58,6 +58,9 @@ function mockCtx(): PluginContext {
         sendMessage: vi.fn(),
       },
     },
+    projects: {
+      list: vi.fn().mockResolvedValue([]),
+    },
     secrets: {
       resolve: vi.fn().mockResolvedValue("sk-test-key"),
     },
@@ -290,6 +293,13 @@ describe("Media routing to agents in threads", () => {
   it("sends to native session when transport is native", async () => {
     const { wakeAgentWithIssue } = await import("../src/acp-bridge.js");
 
+    stateStore["topic-map-456"] = {
+      "Setup and Tests": {
+        projectId: "project-1",
+        projectName: "Setup and Tests",
+        topicId: "42",
+      },
+    };
     stateStore["sessions_456_42"] = [{
       sessionId: "s1",
       agentId: "a1",
@@ -309,7 +319,14 @@ describe("Media routing to agents in threads", () => {
       document: { file_id: "doc-1", file_name: "file.txt" },
     }, { ...defaultConfig, briefAgentChatIds: [] }, "company-1");
 
-    expect(wakeAgentWithIssue).toHaveBeenCalled();
+    expect(wakeAgentWithIssue).toHaveBeenCalledWith(
+      ctx,
+      "a1",
+      "company-1",
+      "[Document] (no caption)",
+      "media_message",
+      "project-1",
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

When a Telegram forum topic is mapped to a Paperclip project, agent-session wake-up issues created from that topic should stay in the same project.

This fixes the native agent-session path so text and media routed from a mapped topic pass the mapped project ID into issue creation.

## What changed

- Resolve the mapped project for a Telegram chat/topic before native agent-session issue creation.
- Preserve that project ID when creating wake-up issues for normal text messages.
- Preserve that project ID when creating wake-up issues for media and voice messages.
- Keep existing behavior unchanged for unmapped topics.

## Validation

- Added coverage for native text routing from a mapped topic.
- Added coverage for native media routing from a mapped topic.
- Ran typecheck.
- Ran the ACP routing test file successfully.
- Note: the media test file on current main is affected by the existing native-fetch test mock issue tracked separately in #50.