### PR TITLE
fix: validate secret-ref fields as UUIDs at config-save time

### DIFF
--- a/src/secret-ref-validation.ts
+++ b/src/secret-ref-validation.ts
@@ -1,0 +1,58 @@
+export type SecretRefConfig = {
+  telegramBotTokenRef?: unknown;
+  paperclipBoardApiTokenRef?: unknown;
+  transcriptionApiKeyRef?: unknown;
+};
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const FIELDS = [
+  { key: "telegramBotTokenRef", required: true },
+  { key: "paperclipBoardApiTokenRef", required: false },
+  { key: "transcriptionApiKeyRef", required: false },
+] as const;
+
+export function isValidSecretRef(value: unknown): value is string {
+  return typeof value === "string" && UUID_RE.test(value.trim());
+}
+
+function describeBadValue(value: unknown): string {
+  if (value === undefined || value === null) return "<empty>";
+  if (typeof value !== "string") return `<${typeof value}>`;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return "<empty string>";
+  // Truncate to avoid leaking long pasted secrets into error logs.
+  const sample = trimmed.length > 16 ? `${trimmed.slice(0, 12)}…` : trimmed;
+  return `"${sample}"`;
+}
+
+function fieldError(key: string, value: unknown): string {
+  return [
+    `${key} must be the UUID of a Paperclip secret`,
+    `(format 8-4-4-4-12, e.g. "12f7ed4a-1234-4d0c-9abc-bd58d44d15e1").`,
+    `Got ${describeBadValue(value)}.`,
+    `Create the secret first via POST /api/companies/{id}/secrets and paste the returned "id" value here —`,
+    `not the raw token, the whole JSON response, or any other identifier.`,
+  ].join(" ");
+}
+
+export function validateSecretRefFields(config: SecretRefConfig): string[] {
+  const errors: string[] = [];
+  for (const { key, required } of FIELDS) {
+    const value = config[key];
+    const isMissing =
+      value === undefined ||
+      value === null ||
+      (typeof value === "string" && value.trim().length === 0);
+
+    if (isMissing) {
+      if (required) errors.push(`${key} is required.`);
+      continue;
+    }
+
+    if (!isValidSecretRef(value)) {
+      errors.push(fieldError(key, value));
+    }
+  }
+  return errors;
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -47,6 +47,7 @@ import { AGENT_ERROR_DEDUPLICATION_WINDOW_MS, METRIC_NAMES } from "./constants.j
 import { EscalationManager } from "./escalation.js";
 import type { EscalationEvent } from "./escalation.js";
 import { isTelegramUpdateAllowed, validateTelegramAllowlists } from "./allowlist.js";
+import { validateSecretRefFields } from "./secret-ref-validation.js";
 import { shouldNotifyApproval } from "./approval-routing.js";
 import { buildPaperclipAuthHeaders, fetchPaperclipApi } from "./paperclip-api.js";
 
@@ -1048,8 +1049,9 @@ const plugin = definePlugin({
   },
 
   async onValidateConfig(config) {
-    if (!config.telegramBotTokenRef || typeof config.telegramBotTokenRef !== "string") {
-      return { ok: false, errors: ["telegramBotTokenRef is required"] };
+    const secretRefErrors = validateSecretRefFields(config);
+    if (secretRefErrors.length > 0) {
+      return { ok: false, errors: secretRefErrors };
     }
     const allowlistErrors = validateTelegramAllowlists(config);
     if (allowlistErrors.length > 0) {

--- a/tests/secret-ref-validation.test.ts
+++ b/tests/secret-ref-validation.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { isValidSecretRef, validateSecretRefFields } from "../src/secret-ref-validation.js";
+
+const VALID_UUID = "12f7ed4a-1234-4d0c-9abc-bd58d44d15e1";
+const VALID_UUID_2 = "abcdef01-2345-6789-abcd-ef0123456789";
+
+describe("isValidSecretRef", () => {
+  it("accepts standard UUIDs in any case", () => {
+    expect(isValidSecretRef(VALID_UUID)).toBe(true);
+    expect(isValidSecretRef(VALID_UUID.toUpperCase())).toBe(true);
+  });
+
+  it("accepts UUIDs with surrounding whitespace", () => {
+    expect(isValidSecretRef(`  ${VALID_UUID}  `)).toBe(true);
+  });
+
+  it("rejects empty and non-string inputs", () => {
+    expect(isValidSecretRef("")).toBe(false);
+    expect(isValidSecretRef("   ")).toBe(false);
+    expect(isValidSecretRef(undefined)).toBe(false);
+    expect(isValidSecretRef(null)).toBe(false);
+    expect(isValidSecretRef(123)).toBe(false);
+    expect(isValidSecretRef({})).toBe(false);
+  });
+
+  it("rejects non-UUID strings (raw tokens, JSON blobs, malformed UUIDs)", () => {
+    expect(isValidSecretRef("not-a-uuid")).toBe(false);
+    expect(isValidSecretRef("123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11")).toBe(false);
+    expect(isValidSecretRef(`{"id":"${VALID_UUID}"}`)).toBe(false);
+    expect(isValidSecretRef("12f7ed4a-1234-4d0c-9abc-bd58d44d15e")).toBe(false);
+    expect(isValidSecretRef("12f7ed4a12344d0c9abcbd58d44d15e1")).toBe(false);
+  });
+});
+
+describe("validateSecretRefFields", () => {
+  it("returns no errors when only the required field is set to a valid UUID", () => {
+    expect(validateSecretRefFields({ telegramBotTokenRef: VALID_UUID })).toEqual([]);
+  });
+
+  it("returns no errors when all three fields are valid UUIDs", () => {
+    expect(
+      validateSecretRefFields({
+        telegramBotTokenRef: VALID_UUID,
+        paperclipBoardApiTokenRef: VALID_UUID_2,
+        transcriptionApiKeyRef: VALID_UUID,
+      }),
+    ).toEqual([]);
+  });
+
+  it("treats empty strings as missing for optional fields (no error)", () => {
+    expect(
+      validateSecretRefFields({
+        telegramBotTokenRef: VALID_UUID,
+        paperclipBoardApiTokenRef: "",
+        transcriptionApiKeyRef: "   ",
+      }),
+    ).toEqual([]);
+  });
+
+  it("flags missing required telegramBotTokenRef with the legacy message", () => {
+    const errors = validateSecretRefFields({});
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toBe("telegramBotTokenRef is required.");
+  });
+
+  it("flags non-UUID telegramBotTokenRef with field-specific guidance", () => {
+    const errors = validateSecretRefFields({ telegramBotTokenRef: "123456:raw-bot-token" });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("telegramBotTokenRef must be the UUID of a Paperclip secret");
+    expect(errors[0]).toContain("POST /api/companies/{id}/secrets");
+  });
+
+  it("flags non-UUID values in optional fields too", () => {
+    const errors = validateSecretRefFields({
+      telegramBotTokenRef: VALID_UUID,
+      paperclipBoardApiTokenRef: "sk-not-a-uuid",
+      transcriptionApiKeyRef: "another-bad-value",
+    });
+    expect(errors).toHaveLength(2);
+    expect(errors[0]).toContain("paperclipBoardApiTokenRef must be the UUID");
+    expect(errors[1]).toContain("transcriptionApiKeyRef must be the UUID");
+  });
+
+  it("truncates long pasted values in error messages to avoid leaking secrets to logs", () => {
+    const longSecret = "x".repeat(200);
+    const errors = validateSecretRefFields({ telegramBotTokenRef: longSecret });
+    expect(errors[0]).toContain("\"xxxxxxxxxxxx…\"");
+    expect(errors[0]).not.toContain(longSecret);
+  });
+
+  it("describes non-string values by their type rather than echoing them", () => {
+    const errors = validateSecretRefFields({
+      telegramBotTokenRef: { id: VALID_UUID } as unknown as string,
+    });
+    expect(errors[0]).toContain("<object>");
+  });
+});


### PR DESCRIPTION
Closes #56.

## Problem

`onValidateConfig` only checked that `telegramBotTokenRef` was a non-empty string. Any non-UUID value — raw bot token, the whole secrets-API JSON response, an agent ID, whitespace — passed validation, persisted via `PATCH /api/companies/{id}/plugins/...`, and only failed at worker activation with:

> Activation failed: worker initialize failed for {workerId} - invalid secret reference

That message identifies the worker, not the field, so users had no actionable signal. Most-common support thread on the plugin (#23, recurring on Discord) and frequently misattributed to upstream paperclipai/paperclip#2795 — but a code read of `paperclip/server/src/services/plugin-secrets-handler.ts:235-241` confirms it's the host's UUID-regex check rejecting the malformed value, which we own preventing.

## Change

New `src/secret-ref-validation.ts`:
- `isValidSecretRef(value)` — type guard, accepts whitespace-padded UUIDs, rejects everything else.
- `validateSecretRefFields(config)` — checks all three secret-ref fields the worker resolves through `ctx.secrets.resolve`:
  - `telegramBotTokenRef` (required)
  - `paperclipBoardApiTokenRef` (optional)
  - `transcriptionApiKeyRef` (optional)
- Field-specific error message includes the expected format, the bad value (truncated to 12 chars to avoid leaking pasted secrets to logs), and a one-line pointer to the correct creation flow.

`worker.ts:onValidateConfig` calls `validateSecretRefFields` first; the prior `telegramBotTokenRef is required` message is preserved for the missing-required case.

## Test plan

- [x] `tests/secret-ref-validation.test.ts` — 12 new tests covering UUID acceptance, whitespace handling, missing required vs missing optional, non-string inputs, long-value truncation, multiple-error reporting.
- [x] Full suite: 220/220 pass (`npx vitest run`).
- [x] Type check clean (`npx tsc --noEmit`).

## Out of scope

- Adding `instanceConfigSchema` to the manifest with `format: "secret-ref"` — would let the host scope-check at the schema level rather than via the UUID-walking fallback. Worth doing eventually but lower priority than catching the bad input at save time.
- Mirroring the same fix to slack/discord plugins — separate PRs once we confirm the pattern lands well here.

---
<sub><em>**[@superbiche](https://github.com/superbiche)** · co-maintainer · drafted with Claude Opus 4.7, reviewed before posting; the voice and decisions are mine.</em></sub>