### PR TITLE
fix: add diagnostic logging to polling loop

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -421,6 +421,11 @@ const plugin = definePlugin({
               description: data.description,
               error_code: data.error_code,
             });
+            // ok:false (revoked token/401, 409 conflict, 429) returns immediately
+            // rather than honoring timeout=10, and fetch does not throw on non-2xx,
+            // so without this the loop spins hot — flooding logs and hammering
+            // Telegram. Back off 5s, mirroring the catch block below.
+            await new Promise((r) => setTimeout(r, 5000));
           }
         } catch (err) {
           ctx.logger.error("Telegram polling error", { error: String(err) });

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -415,12 +415,12 @@ const plugin = definePlugin({
               logger: ctx.logger,
             });
           } else {
-            ctx.logger.warn("Telegram getUpdates returned not-ok", {
+            ctx.logger.warn("Telegram getUpdates: unexpected response", {
               ok: data.ok,
+              hasResult: !!data.result,
               description: data.description,
               error_code: data.error_code,
             });
-            await new Promise((r) => setTimeout(r, 5000));
           }
         } catch (err) {
           ctx.logger.error("Telegram polling error", { error: String(err) });

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -391,8 +391,10 @@ const plugin = definePlugin({
     let lastUpdateId = await getPersistedTelegramUpdateOffset(ctx);
 
     async function pollUpdates(): Promise<void> {
+      ctx.logger.info("Telegram polling loop starting");
       while (pollingActive) {
         try {
+          ctx.logger.debug("Telegram poll tick", { lastUpdateId });
           const res = await ctx.http.fetch(
             `${TELEGRAM_API}/bot${token}/getUpdates?offset=${lastUpdateId + 1}&timeout=10&allowed_updates=["message","callback_query"]`,
             { method: "GET" },
@@ -400,6 +402,8 @@ const plugin = definePlugin({
           const data = (await res.json()) as {
             ok: boolean;
             result?: TelegramUpdate[];
+            description?: string;
+            error_code?: number;
           };
 
           if (data.ok && data.result) {
@@ -410,18 +414,29 @@ const plugin = definePlugin({
               persistOffset: (updateId) => persistTelegramUpdateOffset(ctx, updateId),
               logger: ctx.logger,
             });
+          } else {
+            ctx.logger.warn("Telegram getUpdates returned not-ok", {
+              ok: data.ok,
+              description: data.description,
+              error_code: data.error_code,
+            });
+            await new Promise((r) => setTimeout(r, 5000));
           }
         } catch (err) {
           ctx.logger.error("Telegram polling error", { error: String(err) });
           await new Promise((r) => setTimeout(r, 5000));
         }
       }
+      ctx.logger.warn("Telegram polling loop exited", { pollingActive });
     }
 
     if (config.enableCommands || config.enableInbound) {
+      ctx.logger.info("Dispatching pollUpdates() fire-and-forget");
       pollUpdates().catch((err) =>
         ctx.logger.error("Polling loop crashed", { error: String(err) }),
       );
+    } else {
+      ctx.logger.warn("Telegram polling NOT started — both enableCommands and enableInbound are false");
     }
 
     ctx.events.on("plugin.stopping", async () => {


### PR DESCRIPTION
## Summary

- Adds log points to the polling loop so silent failures (#20) are immediately diagnosable from server logs
- **Loop start**: `info` when `pollUpdates()` enters
- **Each tick**: `debug`-level with current `lastUpdateId`
- **Unexpected response**: `warn` with `ok`, `hasResult`, `description`, `error_code` from Telegram — the silent `else` branch that previously no-op'd
- **Loop exit**: `warn` when `while (pollingActive)` terminates
- **Dispatch decision**: `info` confirming fire-and-forget dispatch, or `warn` if both `enableCommands` and `enableInbound` are false
- Also widens the response type to include `description?` and `error_code?` for type-safe access
- **Adds a 5s backoff in the `else` branch.** When `getUpdates` returns `ok:false` (revoked token/401, 409 second-poller conflict, 429) Telegram replies immediately rather than honoring `timeout=10`, and `ctx.http.fetch` does not throw on non-2xx — so the loop otherwise spins hot, flooding the new logs and hammering Telegram. The backoff mirrors the existing catch block and quietly fixes that spin.

Closes #20

## Test plan

- [x] `tsc` typecheck passes
- [ ] Manual: install patched plugin, trigger silent-fail scenario, confirm new log lines appear
- [ ] Verify `debug`-level tick logs are suppressed at default log level

🤖 Generated with [Claude Code](https://claude.com/claude-code)