### PR TITLE
fix: throw on unlinked chat instead of using chatId as companyId

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paperclip-plugin-telegram",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "type": "module",
   "main": "./dist/index.js",
   "paperclipPlugin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paperclip-plugin-telegram",
-  "version": "0.6.2",
+  "version": "0.6.1",
   "type": "module",
   "main": "./dist/index.js",
   "paperclipPlugin": {

--- a/src/acp-bridge.ts
+++ b/src/acp-bridge.ts
@@ -94,6 +94,11 @@ export async function handleAcpCommand(
   const parts = args.trim().split(/\s+/);
   const subcommand = parts[0]?.toLowerCase() ?? "";
 
+  if (!companyId && (subcommand === "spawn" || subcommand === "cancel" || subcommand === "close")) {
+    await sendMessage(ctx, token, chatId, "This chat is not linked to a Paperclip company. Use /connect first.", { messageThreadId });
+    return;
+  }
+
   switch (subcommand) {
     case "spawn":
       await handleAcpSpawn(ctx, token, chatId, parts.slice(1).join(" "), messageThreadId, companyId, maxAgentsPerThread);

--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -96,6 +96,11 @@ export async function handleCommandsCommand(
   const parts = args.trim().split(/\s+/);
   const subcommand = parts[0]?.toLowerCase() ?? "";
 
+  if (!companyId && ["list", "import", "delete", "run"].includes(subcommand)) {
+    await sendMessage(ctx, token, chatId, "This chat is not linked to a Paperclip company. Use /connect first.", { messageThreadId });
+    return;
+  }
+
   switch (subcommand) {
     case "list":
       await listCommands(ctx, token, chatId, messageThreadId, companyId);
@@ -133,14 +138,17 @@ export async function tryCustomCommand(
 ): Promise<boolean> {
   if (BUILTIN_COMMANDS.has(command)) return false;
 
-  const resolvedCompanyId = companyId ?? chatId;
-  const commands = await getCommandRegistry(ctx, resolvedCompanyId);
+  // Unlinked chat: never fall back to chatId as a companyId. Returning false
+  // lets the built-in command path answer with its "not linked" guidance.
+  if (!companyId) return false;
+
+  const commands = await getCommandRegistry(ctx, companyId);
   const cmd = commands.find((c) => c.name === command);
 
   if (!cmd) return false;
 
   const args = argsStr.trim().split(/\s+/).filter(Boolean);
-  await executeWorkflow(ctx, token, chatId, cmd, args, messageThreadId, resolvedCompanyId);
+  await executeWorkflow(ctx, token, chatId, cmd, args, messageThreadId, companyId);
   return true;
 }
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -483,7 +483,13 @@ export async function handleConnectTopic(
     projectNameInput = parts.join(" ");
   }
 
-  const companyId = await resolveCompanyId(ctx, chatId);
+  let companyId: string;
+  try {
+    companyId = await resolveCompanyId(ctx, chatId);
+  } catch {
+    await sendMessage(ctx, token, chatId, "This chat is not linked to a Paperclip company. Use /connect first.", { messageThreadId });
+    return;
+  }
   const project = await resolveProjectByName(ctx, companyId, projectNameInput);
   if (!project) {
     await sendProjectNotFoundMessage(ctx, token, chatId, companyId, projectNameInput, messageThreadId);
@@ -800,5 +806,9 @@ async function resolveCompanyId(ctx: PluginContext, chatId: string): Promise<str
     scopeKind: "instance",
     stateKey: `chat_${chatId}`,
   }) as { companyId?: string; companyName?: string } | null;
-  return mapping?.companyId ?? mapping?.companyName ?? chatId;
+  const companyId = mapping?.companyId ?? mapping?.companyName;
+  if (!companyId) {
+    throw new Error("This chat is not linked to a Paperclip company. Use /connect first.");
+  }
+  return companyId;
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -328,7 +328,11 @@ async function resolveCompanyId(ctx: PluginContext, chatId: string): Promise<str
     scopeKind: "instance",
     stateKey: `chat_${chatId}`,
   }) as { companyId?: string; companyName?: string } | null;
-  return mapping?.companyId ?? mapping?.companyName ?? chatId;
+  const companyId = mapping?.companyId ?? mapping?.companyName;
+  if (!companyId) {
+    throw new Error("This chat is not linked to a Paperclip company. Use /connect first.");
+  }
+  return companyId;
 }
 
 const plugin = definePlugin({

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -338,6 +338,19 @@ async function resolveCompanyId(ctx: PluginContext, chatId: string): Promise<str
   return companyId;
 }
 
+// Non-throwing variant for handleUpdate call sites. A throw escaping
+// handleUpdate prevents the polling offset from advancing, so the same
+// update is re-fetched and re-thrown forever — the poller wedges for every
+// chat. Unlinked chats must degrade per-path instead (friendly reply for
+// commands, skip for media/thread routing).
+async function resolveCompanyIdOrNull(ctx: PluginContext, chatId: string): Promise<string | null> {
+  try {
+    return await resolveCompanyId(ctx, chatId);
+  } catch {
+    return null;
+  }
+}
+
 const plugin = definePlugin({
   async setup(ctx) {
     const rawConfig = await ctx.config.get();
@@ -1083,7 +1096,7 @@ const plugin = definePlugin({
   },
 });
 
-async function handleUpdate(
+export async function handleUpdate(
   ctx: PluginContext,
   token: string,
   config: TelegramConfig,
@@ -1119,14 +1132,18 @@ async function handleUpdate(
   // Phase 3: Handle media messages
   const hasMedia = !!(msg.voice || msg.audio || msg.video_note || msg.document || msg.photo);
   if (hasMedia) {
-    const companyId = await resolveCompanyId(ctx, chatId);
-    const handled = await handleMediaMessage(ctx, token, msg as Parameters<typeof handleMediaMessage>[2], {
-      briefAgentId: config.briefAgentId ?? "",
-      briefAgentChatIds: config.briefAgentChatIds ?? [],
-      transcriptionApiKeyRef: config.transcriptionApiKeyRef ?? "",
-      publicUrl,
-    }, companyId);
-    if (handled) return;
+    const companyId = await resolveCompanyIdOrNull(ctx, chatId);
+    if (companyId) {
+      const handled = await handleMediaMessage(ctx, token, msg as Parameters<typeof handleMediaMessage>[2], {
+        briefAgentId: config.briefAgentId ?? "",
+        briefAgentChatIds: config.briefAgentChatIds ?? [],
+        transcriptionApiKeyRef: config.transcriptionApiKeyRef ?? "",
+        publicUrl,
+      }, companyId);
+      if (handled) return;
+    } else {
+      ctx.logger.debug("Ignoring media message from unlinked chat", { chatId });
+    }
   }
 
   if (!msg.text) return;
@@ -1137,10 +1154,14 @@ async function handleUpdate(
   if (threadId) {
     const isCommand = text.startsWith("/");
     if (!isCommand) {
-      const companyId = await resolveCompanyId(ctx, chatId);
-      const replyToId = msg.reply_to_message?.message_id;
-      const routed = await routeMessageToAgent(ctx, token, chatId, threadId, text, replyToId, companyId);
-      if (routed) return;
+      const companyId = await resolveCompanyIdOrNull(ctx, chatId);
+      if (companyId) {
+        const replyToId = msg.reply_to_message?.message_id;
+        const routed = await routeMessageToAgent(ctx, token, chatId, threadId, text, replyToId, companyId);
+        if (routed) return;
+      } else {
+        ctx.logger.debug("Not routing thread message from unlinked chat", { chatId });
+      }
     }
   }
 
@@ -1149,7 +1170,9 @@ async function handleUpdate(
     const fullCommand = text.slice(botCommand.offset, botCommand.offset + botCommand.length);
     const command = fullCommand.replace(/^\//, "").replace(/@.*$/, "");
     const args = text.slice(botCommand.offset + botCommand.length).trim();
-    const companyId = await resolveCompanyId(ctx, chatId);
+    // undefined on unlinked chats: /connect and /help still work, and the
+    // company-scoped handlers answer with their "not linked" guidance.
+    const companyId = (await resolveCompanyIdOrNull(ctx, chatId)) ?? undefined;
 
     // Phase 4: Check custom commands first
     if (command === "commands") {

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -108,6 +108,7 @@ describe("handleCommand", () => {
   });
 
   it("routes /issues command", async () => {
+    stateStore["chat_123"] = { companyId: "co-1" };
     const ctx = mockCtx();
     await handleCommand(ctx, "token", "123", "issues", "");
     expect(sentMessages.length).toBe(1);
@@ -115,6 +116,7 @@ describe("handleCommand", () => {
   });
 
   it("routes /agents command", async () => {
+    stateStore["chat_123"] = { companyId: "co-1" };
     const ctx = mockCtx();
     await handleCommand(ctx, "token", "123", "agents", "");
     expect(sentMessages.length).toBe(1);
@@ -154,6 +156,17 @@ describe("handleCommand", () => {
     expect(metricsWritten.some(m => m.name === "telegram_commands_handled")).toBe(true);
   });
 
+  it("never uses chatId as companyId when chat is not linked (regression: BEL-183 spam-loop)", async () => {
+    const ctx = mockCtx();
+    // No stateStore entry for chat_5851857072 — simulates an unlinked group chat
+    await handleCommand(ctx, "token", "5851857072", "status", "");
+    expect(sentMessages.length).toBe(1);
+    expect(sentMessages[0].text).toContain("Make sure this chat is linked");
+    // The raw chatId must never reach the API as a companyId
+    expect(ctx.agents.list).not.toHaveBeenCalledWith(expect.objectContaining({ companyId: "5851857072" }));
+    expect(ctx.issues.list).not.toHaveBeenCalledWith(expect.objectContaining({ companyId: "5851857072" }));
+  });
+
   it("/connect stores company mapping", async () => {
     const ctx = mockCtx();
     (ctx.companies as unknown) = {
@@ -172,12 +185,14 @@ describe("handleCommand", () => {
   });
 
   it("/issues filters by project name", async () => {
+    stateStore["chat_123"] = { companyId: "co-1" };
     const ctx = mockCtx();
     await handleCommand(ctx, "token", "123", "issues", "Backend");
     expect(sentMessages[0].text).toContain("PROJ\\-2");
   });
 
   it("/agents shows agent names and status", async () => {
+    stateStore["chat_123"] = { companyId: "co-1" };
     const ctx = mockCtx();
     await handleCommand(ctx, "token", "123", "agents", "");
     expect(sentMessages[0].text).toContain("Builder");
@@ -191,6 +206,7 @@ describe("handleCommand", () => {
   });
 
   it("/create creates issue then updates assignee and status to trigger wake", async () => {
+    stateStore["chat_123"] = { companyId: "co-1" };
     const ctx = mockCtx();
     (ctx.agents as unknown) = {
       list: vi.fn().mockResolvedValue([
@@ -225,6 +241,7 @@ describe("handleCommand", () => {
   });
 
   it("/create attaches the issue to the project mapped to the current forum topic", async () => {
+    stateStore["chat_123"] = { companyId: "co-1" };
     stateStore["topic-map-123"] = { "Setup and Tests": "58" };
     const ctx = mockCtx();
     (ctx.agents as unknown) = {
@@ -243,7 +260,7 @@ describe("handleCommand", () => {
 
     expect(ctx.issues.create).toHaveBeenCalledWith(
       expect.objectContaining({
-        companyId: "123",
+        companyId: "co-1",
         title: "Topic scoped task",
         projectId: issueProjectId,
       }),
@@ -252,6 +269,7 @@ describe("handleCommand", () => {
   });
 
   it("/create works without a CEO agent", async () => {
+    stateStore["chat_123"] = { companyId: "co-1" };
     const ctx = mockCtx();
     (ctx.agents as unknown) = {
       list: vi.fn().mockResolvedValue([
@@ -282,6 +300,7 @@ describe("handleCommand", () => {
 
 describe("handleConnectTopic", () => {
   it("stores topic mapping for a project", async () => {
+    stateStore["chat_123"] = { companyId: "co-1" };
     const ctx = mockCtx();
     await handleConnectTopic(ctx, "token", "123", "Backend 42");
     expect(stateStore["topic-map-123"]).toEqual({
@@ -290,6 +309,7 @@ describe("handleConnectTopic", () => {
   });
 
   it("uses the current forum topic when no explicit topic id is provided", async () => {
+    stateStore["chat_123"] = { companyId: "co-1" };
     const ctx = mockCtx();
     await handleConnectTopic(ctx, "token", "123", "Setup and Tests", 58);
     expect(stateStore["topic-map-123"]).toEqual({
@@ -303,7 +323,16 @@ describe("handleConnectTopic", () => {
     expect(sentMessages[0].text).toContain("Usage");
   });
 
+  it("sends a friendly error when chat is not linked to a company", async () => {
+    const ctx = mockCtx();
+    await handleConnectTopic(ctx, "token", "5851857072", "Backend 42");
+    expect(sentMessages.length).toBe(1);
+    expect(sentMessages[0].text).toContain("not linked");
+    expect(stateStore["topic-map-5851857072"]).toBeUndefined();
+  });
+
   it("appends to existing topic map", async () => {
+    stateStore["chat_123"] = { companyId: "co-1" };
     stateStore["topic-map-123"] = { Frontend: "10" };
     const ctx = mockCtx();
     await handleConnectTopic(ctx, "token", "123", "Backend 42");
@@ -314,6 +343,7 @@ describe("handleConnectTopic", () => {
   });
 
   it("rejects unknown projects without storing a topic mapping", async () => {
+    stateStore["chat_123"] = { companyId: "co-1" };
     const ctx = mockCtx();
     await handleConnectTopic(ctx, "token", "123", "Unknown Project 42");
     expect(stateStore["topic-map-123"]).toBeUndefined();
@@ -321,6 +351,7 @@ describe("handleConnectTopic", () => {
   });
 
   it("replaces a legacy mapping with the canonical project name", async () => {
+    stateStore["chat_123"] = { companyId: "co-1" };
     stateStore["topic-map-123"] = { backend: "41" };
     const ctx = mockCtx();
     await handleConnectTopic(ctx, "token", "123", "backend 42");

--- a/tests/worker-unlinked.test.ts
+++ b/tests/worker-unlinked.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { PluginContext } from "@paperclipai/plugin-sdk";
+
+let sentMessages: Array<{ chatId: string; text: string }> = [];
+
+vi.mock("@paperclipai/plugin-sdk", async () => {
+  const actual = await vi.importActual("@paperclipai/plugin-sdk") as Record<string, unknown>;
+  return {
+    ...actual,
+    runWorker: vi.fn(),
+  };
+});
+
+vi.mock("../src/telegram-api.js", async () => {
+  const actual = await vi.importActual("../src/telegram-api.js") as Record<string, unknown>;
+  return {
+    ...actual,
+    sendMessage: vi.fn(async (_ctx: unknown, _token: string, chatId: string, text: string) => {
+      sentMessages.push({ chatId, text });
+      return 1;
+    }),
+    sendChatAction: vi.fn(),
+  };
+});
+
+import { handleUpdate } from "../src/worker.js";
+import { processTelegramUpdateBatch } from "../src/polling-offset.js";
+
+const UNLINKED_CHAT_ID = 5851857072;
+
+function mockCtx(): PluginContext {
+  return {
+    http: { fetch: vi.fn().mockResolvedValue({ json: () => Promise.resolve({ ok: true }) }) },
+    metrics: { write: vi.fn().mockResolvedValue(undefined) },
+    state: {
+      // No chat_* mapping stored anywhere — every chat is unlinked.
+      get: vi.fn().mockResolvedValue(null),
+      set: vi.fn().mockResolvedValue(undefined),
+    },
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    companies: { get: vi.fn().mockResolvedValue(null) },
+    projects: { list: vi.fn().mockResolvedValue([]) },
+    agents: { list: vi.fn().mockResolvedValue([]) },
+    issues: { list: vi.fn().mockResolvedValue([]) },
+  } as unknown as PluginContext;
+}
+
+const config = { enableCommands: true } as Parameters<typeof handleUpdate>[2];
+const baseUrl = "http://localhost:3100";
+
+function commandUpdate(updateId: number): Parameters<typeof handleUpdate>[3] {
+  return {
+    update_id: updateId,
+    message: {
+      message_id: 1,
+      chat: { id: UNLINKED_CHAT_ID },
+      from: { id: 42 },
+      text: "/status",
+      entities: [{ type: "bot_command", offset: 0, length: 7 }],
+    },
+  } as Parameters<typeof handleUpdate>[3];
+}
+
+beforeEach(() => {
+  sentMessages = [];
+});
+
+describe("handleUpdate on an unlinked chat (regression: BEL-183 poller wedge)", () => {
+  it("/status does not throw and answers with not-linked guidance", async () => {
+    const ctx = mockCtx();
+
+    await expect(
+      handleUpdate(ctx, "token", config, commandUpdate(101), baseUrl),
+    ).resolves.toBeUndefined();
+
+    expect(sentMessages.length).toBeGreaterThan(0);
+    expect(sentMessages.some((m) => m.text.includes("Make sure this chat is linked"))).toBe(true);
+    // The raw chatId must never reach the API as a companyId
+    expect(ctx.agents.list).not.toHaveBeenCalledWith(
+      expect.objectContaining({ companyId: String(UNLINKED_CHAT_ID) }),
+    );
+  });
+
+  it("media message does not throw and is skipped", async () => {
+    const ctx = mockCtx();
+    const update = {
+      update_id: 102,
+      message: {
+        message_id: 2,
+        chat: { id: UNLINKED_CHAT_ID },
+        from: { id: 42 },
+        voice: { file_id: "f1", duration: 3 },
+      },
+    } as Parameters<typeof handleUpdate>[3];
+
+    await expect(handleUpdate(ctx, "token", config, update, baseUrl)).resolves.toBeUndefined();
+  });
+
+  it("thread message does not throw and is not routed", async () => {
+    const ctx = mockCtx();
+    const update = {
+      update_id: 103,
+      message: {
+        message_id: 3,
+        chat: { id: UNLINKED_CHAT_ID },
+        from: { id: 42 },
+        message_thread_id: 9,
+        text: "hello agents",
+      },
+    } as Parameters<typeof handleUpdate>[3];
+
+    await expect(handleUpdate(ctx, "token", config, update, baseUrl)).resolves.toBeUndefined();
+  });
+
+  it("polling offset advances past an unlinked-chat command", async () => {
+    const ctx = mockCtx();
+    const persisted: number[] = [];
+
+    const lastUpdateId = await processTelegramUpdateBatch({
+      updates: [commandUpdate(101)],
+      lastUpdateId: 100,
+      handleUpdate: (u) => handleUpdate(ctx, "token", config, u, baseUrl),
+      persistOffset: async (updateId) => {
+        persisted.push(updateId);
+      },
+      logger: ctx.logger,
+    });
+
+    expect(lastUpdateId).toBe(101);
+    expect(persisted).toEqual([101]);
+  });
+});


### PR DESCRIPTION
## Summary

- Both `worker.ts` and `commands.ts` `resolveCompanyId()` previously fell back to returning the raw Telegram `chatId` when no chat→company mapping existed in plugin state
- This caused spurious Paperclip API calls with the numeric Telegram chat ID used as a company UUID, triggering a spam-loop incident (BEL-183)
- Both functions now throw a friendly error: "This chat is not linked to a Paperclip company. Use /connect first."
- Added regression test in `commands.test.ts` covering the no-mapping path (verifies chatId never reaches the API as a companyId)

## Test plan

- [x] `npm test` passes (222 tests, all green)  
- [x] Plugin rebuilt and reinstalled from new tgz — fix confirmed in installed `dist/worker.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)