### PR TITLE
feat: support company-scoped Telegram workflows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "paperclip-plugin-telegram",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "paperclip-plugin-telegram",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "devDependencies": {
         "@paperclipai/plugin-sdk": "^2026.707.0",

--- a/src/acp-bridge.ts
+++ b/src/acp-bridge.ts
@@ -72,10 +72,17 @@ type OutputQueueEntry = {
 
 export function setupAcpOutputListener(
   ctx: PluginContext,
-  token: string,
+  resolveToken: (event: { companyId: string }) => Promise<string | null>,
 ): void {
   ctx.events.on(ACP_OUTPUT_EVENT, async (event) => {
     const payload = event.payload as AcpOutputEvent;
+    const token = await resolveToken(event);
+    if (!token) {
+      ctx.logger.warn("Skipping ACP output because Telegram bot token could not be resolved", {
+        companyId: event.companyId,
+      });
+      return;
+    }
     await handleAcpOutput(ctx, token, payload);
   });
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -340,6 +340,15 @@ async function handleConnect(
       return;
     }
 
+    const existing = await ctx.state.get({
+      scopeKind: "instance",
+      stateKey: `chat_${chatId}`,
+    }) as { companyId?: string } | null;
+    if (existing?.companyId === match.id) {
+      ctx.logger.info("Chat already linked to company", { chatId, companyId: match.id, companyName: match.name });
+      return;
+    }
+
     // Inbound: chat → company (for commands like /status)
     await ctx.state.set(
       { scopeKind: "instance", stateKey: `chat_${chatId}` },

--- a/src/config-compat.ts
+++ b/src/config-compat.ts
@@ -1,0 +1,50 @@
+import type { PluginContext } from "@paperclipai/plugin-sdk";
+
+type Logger = PluginContext["logger"];
+
+function logConfigFallback(
+  logger: Logger,
+  message: string,
+  companyId: string | null | undefined,
+  err: unknown,
+): void {
+  logger.warn(message, {
+    companyId,
+    error: String(err),
+  });
+}
+
+export async function loadStartupConfig<T extends Record<string, unknown>>(
+  ctx: PluginContext,
+  fallback: T,
+): Promise<T> {
+  try {
+    const rawConfig = await ctx.config.get();
+    return { ...fallback, ...rawConfig } as T;
+  } catch (err) {
+    logConfigFallback(ctx.logger, "Failed to load Telegram plugin config; using defaults", null, err);
+    return fallback;
+  }
+}
+
+export async function resolveCompatibleConfig<T extends Record<string, unknown>>(
+  ctx: PluginContext,
+  fallback: T,
+  companyId?: string | null,
+): Promise<T> {
+  try {
+    const getConfig = ctx.config.get as unknown as (
+      params?: { companyId?: string | null },
+    ) => Promise<Record<string, unknown>>;
+    const scopedConfig = await getConfig(companyId ? { companyId } : undefined);
+    return { ...fallback, ...scopedConfig } as T;
+  } catch (err) {
+    logConfigFallback(
+      ctx.logger,
+      "Company-scoped Telegram plugin config unavailable; using global config",
+      companyId,
+      err,
+    );
+    return fallback;
+  }
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,5 @@
 export const PLUGIN_ID = "paperclip-plugin-telegram";
-export const PLUGIN_VERSION = "0.3.0";
+export const PLUGIN_VERSION = "0.6.1";
 export const MAX_AGENTS_PER_THREAD = 5;
 
 export const DEFAULT_CONFIG = {

--- a/src/escalation.ts
+++ b/src/escalation.ts
@@ -344,7 +344,7 @@ export class EscalationManager {
     });
   }
 
-  async checkTimeouts(ctx: PluginContext, token: string): Promise<void> {
+  async checkTimeouts(ctx: PluginContext, token: string, companyId?: string): Promise<void> {
     const pendingIds = (await ctx.state.get({
       scopeKind: "instance",
       stateKey: "escalation_pending_ids",
@@ -364,6 +364,7 @@ export class EscalationManager {
         await this.removePending(ctx, escalationId);
         continue;
       }
+      if (companyId && stored.companyId !== companyId) continue;
 
       const timeoutAt = new Date(stored.timeoutAt).getTime();
       if (now < timeoutAt) continue;

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -56,6 +56,15 @@ function runButton(agentId: string, runId: string | null, publicUrl?: string): {
   return null;
 }
 
+function runIdLine(runId: string): string {
+  return `${esc("run_id")}: ${code(runId)}`;
+}
+
+function issueRunLabel(payload: Payload): string | null {
+  const identifier = payload.issueIdentifier ?? payload.identifier;
+  return identifier ? String(identifier) : null;
+}
+
 function classifyAgentError(errorMessage: string): string {
   if (/timed?\s*out|timeout/i.test(errorMessage)) return "Agent Timeout";
   if (/limit|rate.?limit|quota/i.test(errorMessage)) return "Agent Rate Limit";
@@ -257,7 +266,8 @@ export function formatAgentRunStarted(event: PluginEvent, opts?: IssueLinksOpts)
   const p = event.payload as Payload;
   const agentId = String(p.agentId ?? event.entityId);
   const agentName = String(p.agentName ?? agentId);
-  const runId = p.runId ? String(p.runId) : null;
+  const runId = String(p.runId ?? event.entityId);
+  const issueLabel = issueRunLabel(p);
 
   const buttons: Array<{ text: string; url: string }> = [];
   if (opts?.baseUrl && isExternalUrl(opts.baseUrl)) {
@@ -268,7 +278,10 @@ export function formatAgentRunStarted(event: PluginEvent, opts?: IssueLinksOpts)
   }
 
   return {
-    text: `${esc("▶️")} ${bold(agentName)} ${esc("started a new run")}`,
+    text: [
+      `${esc("▶️")} ${bold(agentName)} ${esc("started a new run")}${issueLabel ? ` ${bold(issueLabel)}` : ""}`,
+      runIdLine(runId),
+    ].join("\n"),
     options: {
       parseMode: "MarkdownV2",
       disableNotification: true,
@@ -281,7 +294,8 @@ export function formatAgentRunFinished(event: PluginEvent, opts?: IssueLinksOpts
   const p = event.payload as Payload;
   const agentId = String(p.agentId ?? event.entityId);
   const agentName = String(p.agentName ?? agentId);
-  const runId = p.runId ? String(p.runId) : null;
+  const runId = String(p.runId ?? event.entityId);
+  const issueLabel = issueRunLabel(p);
 
   const buttons: Array<{ text: string; url: string }> = [];
   if (opts?.baseUrl && isExternalUrl(opts.baseUrl)) {
@@ -292,7 +306,10 @@ export function formatAgentRunFinished(event: PluginEvent, opts?: IssueLinksOpts
   }
 
   return {
-    text: `${esc("⏹️")} ${bold(agentName)} ${esc("completed successfully")}`,
+    text: [
+      `${esc("⏹️")} ${bold(agentName)} ${esc("completed successfully")}${issueLabel ? ` ${bold(issueLabel)}` : ""}`,
+      runIdLine(runId),
+    ].join("\n"),
     options: {
       parseMode: "MarkdownV2",
       disableNotification: true,

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -53,6 +53,10 @@ const manifest: PaperclipPluginManifestV1 = {
         type: "string",
         format: "secret-ref",
       },
+      transcriptionApiKeyRef: {
+        type: "string",
+        format: "secret-ref",
+      },
     },
   },
   ui: {

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -41,6 +41,20 @@ const manifest: PaperclipPluginManifestV1 = {
     worker: "./dist/worker.js",
     ui: "./dist/ui",
   },
+  instanceConfigSchema: {
+    type: "object",
+    additionalProperties: true,
+    properties: {
+      telegramBotTokenRef: {
+        type: "string",
+        format: "secret-ref",
+      },
+      paperclipBoardApiTokenRef: {
+        type: "string",
+        format: "secret-ref",
+      },
+    },
+  },
   ui: {
     slots: [
       {
@@ -55,8 +69,8 @@ const manifest: PaperclipPluginManifestV1 = {
     {
       jobKey: "telegram-daily-digest",
       displayName: "Telegram Digest",
-      description: "Send a summary of agent activity to Telegram (daily or bidaily).",
-      schedule: "0 * * * *",
+      description: "Send a summary of agent activity to Telegram (daily, bidaily, or tridaily).",
+      schedule: "* * * * *",
     },
     {
       jobKey: "check-escalation-timeouts",

--- a/src/media-pipeline.ts
+++ b/src/media-pipeline.ts
@@ -59,7 +59,7 @@ export async function handleMediaMessage(
   // Transcribe audio/voice if applicable
   if (isAudio && config.transcriptionApiKeyRef) {
     try {
-      const transcription = await transcribeAudio(ctx, token, fileId, config.transcriptionApiKeyRef);
+      const transcription = await transcribeAudio(ctx, token, fileId, config.transcriptionApiKeyRef, companyId);
       if (transcription) {
         textContent = transcription;
 
@@ -175,6 +175,7 @@ async function transcribeAudio(
   botToken: string,
   fileId: string,
   transcriptionApiKeyRef: string,
+  companyId: string,
 ): Promise<string | null> {
   // 1. Get file path from Telegram (JSON response — ctx.http.fetch works fine for this)
   const fileRes = await ctx.http.fetch(
@@ -193,7 +194,8 @@ async function transcribeAudio(
   const audioBuffer = Buffer.from(await audioRes.arrayBuffer());
 
   // 3. Resolve the OpenAI API key from Paperclip secrets
-  const apiKey = await ctx.secrets.resolve(transcriptionApiKeyRef);
+  const resolveSecret = ctx.secrets.resolve as (secretRef: string, companyId?: string | null) => Promise<string>;
+  const apiKey = await resolveSecret(transcriptionApiKeyRef, companyId);
 
   // 4. Build multipart form data manually (native FormData + Blob works in Node 18+)
   const formData = new FormData();

--- a/src/polling-dispatch.ts
+++ b/src/polling-dispatch.ts
@@ -1,0 +1,68 @@
+export type TelegramDispatchConfig = {
+  defaultChatId?: unknown;
+  approvalsChatId?: unknown;
+  errorsChatId?: unknown;
+  digestChatId?: unknown;
+  escalationChatId?: unknown;
+  allowedTelegramChatIds?: unknown;
+  briefAgentChatIds?: unknown;
+};
+
+export type TelegramDispatchRuntime = {
+  companyId: string;
+  config: TelegramDispatchConfig;
+};
+
+export type TelegramDispatchUpdate = {
+  message?: {
+    chat: { id: number };
+  };
+  callback_query?: {
+    message?: {
+      chat: { id: number };
+    };
+  };
+};
+
+function addStringValue(values: Set<string>, value: unknown): void {
+  if (typeof value !== "string" && typeof value !== "number") return;
+  const normalized = String(value).trim();
+  if (normalized) values.add(normalized);
+}
+
+function addStringArray(values: Set<string>, source: unknown): void {
+  if (!Array.isArray(source)) return;
+  for (const value of source) addStringValue(values, value);
+}
+
+export function getTelegramUpdateChatId(update: TelegramDispatchUpdate): string | null {
+  const chatId = update.message?.chat.id ?? update.callback_query?.message?.chat.id;
+  return typeof chatId === "number" ? String(chatId) : null;
+}
+
+export function telegramRuntimeChatIds(config: TelegramDispatchConfig): Set<string> {
+  const values = new Set<string>();
+  addStringValue(values, config.defaultChatId);
+  addStringValue(values, config.approvalsChatId);
+  addStringValue(values, config.errorsChatId);
+  addStringValue(values, config.digestChatId);
+  addStringValue(values, config.escalationChatId);
+  addStringArray(values, config.allowedTelegramChatIds);
+  addStringArray(values, config.briefAgentChatIds);
+  return values;
+}
+
+export function selectTelegramRuntimeForUpdate<TRuntime extends TelegramDispatchRuntime>(
+  runtimes: TRuntime[],
+  update: TelegramDispatchUpdate,
+): TRuntime | null {
+  if (runtimes.length === 0) return null;
+
+  const chatId = getTelegramUpdateChatId(update);
+  if (!chatId) return runtimes.length === 1 ? runtimes[0] : null;
+
+  const matches = runtimes.filter((runtime) => telegramRuntimeChatIds(runtime.config).has(chatId));
+  if (matches.length === 1) return matches[0];
+
+  return runtimes.length === 1 ? runtimes[0] : null;
+}

--- a/src/telegram-api.ts
+++ b/src/telegram-api.ts
@@ -11,6 +11,14 @@ type InlineButton = {
 
 type InlineKeyboard = InlineButton[][];
 
+async function writeMetric(ctx: PluginContext, name: string, value: number): Promise<void> {
+  try {
+    await ctx.metrics.write(name, value);
+  } catch (err) {
+    ctx.logger.warn("Telegram metric write failed", { error: String(err), metric: name });
+  }
+}
+
 export type SendMessageOptions = {
   parseMode?: "MarkdownV2" | "HTML";
   replyToMessageId?: number;
@@ -44,7 +52,7 @@ export async function sendMessage(
 
   for (let attempt = 0; attempt < 3; attempt++) {
     try {
-      const res = await ctx.http.fetch(`${TELEGRAM_API}/bot${token}/sendMessage`, {
+      const res = await fetch(`${TELEGRAM_API}/bot${token}/sendMessage`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
@@ -75,15 +83,15 @@ export async function sendMessage(
           });
         }
         ctx.logger.error("Telegram sendMessage failed", { error: data.description });
-        await ctx.metrics.write(METRIC_NAMES.failed, 1);
+        await writeMetric(ctx, METRIC_NAMES.failed, 1);
         return null;
       }
 
-      await ctx.metrics.write(METRIC_NAMES.sent, 1);
+      await writeMetric(ctx, METRIC_NAMES.sent, 1);
       return data.result?.message_id ?? null;
     } catch (err) {
       ctx.logger.error("Telegram API error", { error: String(err) });
-      await ctx.metrics.write(METRIC_NAMES.failed, 1);
+      await writeMetric(ctx, METRIC_NAMES.failed, 1);
       return null;
     }
   }

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -48,6 +48,14 @@ type Notice = {
   text?: string;
 };
 
+type CompanySecretSummary = {
+  id: string;
+  name: string;
+  key?: string | null;
+  status?: string | null;
+  latestVersion?: number | null;
+};
+
 type TelegramRoutingConfig = {
   defaultChatId: string;
   topicRouting: boolean;
@@ -565,6 +573,12 @@ async function fetchPluginConfig(companyId?: string | null): Promise<Record<stri
     pluginConfigPath(companyId),
   );
   return record?.configJson && typeof record.configJson === "object" ? record.configJson : {};
+}
+
+async function fetchCompanySecrets(companyId: string): Promise<CompanySecretSummary[]> {
+  return fetchHostJson<CompanySecretSummary[]>(
+    `/api/companies/${encodeURIComponent(companyId)}/secrets`,
+  );
 }
 
 async function savePluginConfig(configJson: Record<string, unknown>, companyId?: string | null): Promise<void> {
@@ -1224,20 +1238,21 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
         <div style={{ display: "grid", gap: 4 }}>
           <h2 style={{ fontSize: 18, fontWeight: 700, lineHeight: "28px", margin: 0 }}>Connection & URLs</h2>
           <p style={{ color: "#6b7280", margin: 0 }}>
-            Core connection values used by the Telegram worker. Save the bot token as a Paperclip secret and paste its secret UUID here.
+            Core connection values used by the Telegram worker. Select company secrets for sensitive values; secret values are never shown here.
           </p>
         </div>
 
         <div style={{ display: "grid", gap: 12 }}>
-          <TextField
+          <SecretRefField
+            companyId={companyId}
             disabled={connectionLoading || connectionSaving}
             label="Telegram bot token secret ref"
             onChange={(value) => updateConnectionField("telegramBotTokenRef", value)}
-            placeholder="Secret UUID from Paperclip settings"
+            placeholder="Secret UUID fallback"
             value={connectionConfig.telegramBotTokenRef}
           >
-            Secret UUID for your Telegram bot token from @BotFather. The plugin resolves this secret before polling Telegram.
-          </TextField>
+            Select the company secret that stores your Telegram bot token from @BotFather. The plugin resolves this secret before polling Telegram.
+          </SecretRefField>
           <TextField
             disabled={connectionLoading || connectionSaving}
             label="Paperclip API URL"
@@ -1383,15 +1398,16 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
         </div>
 
         <div style={{ borderTop: "1px solid #e5e7eb", display: "grid", gap: 12, paddingTop: 14 }}>
-          <TextField
+          <SecretRefField
+            companyId={companyId}
             disabled={boardConfigLoading || boardConfigSaving}
             label="Board API token secret ref fallback"
             onChange={(value) => updateBoardField("paperclipBoardApiTokenRef", value)}
-            placeholder="Optional Paperclip secret UUID"
+            placeholder="Optional secret UUID fallback"
             value={boardConfig.paperclipBoardApiTokenRef}
           >
             Optional manual fallback for approval buttons and /approve. The Board Access Connection above is preferred because it creates and tracks the company-scoped secret for you.
-          </TextField>
+          </SecretRefField>
 
           {boardConfigMessage ? <NoticeBlock notice={boardConfigMessage} /> : null}
 
@@ -1971,15 +1987,16 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
         </div>
 
         <div style={{ display: "grid", gap: 12 }}>
-          <TextField
+          <SecretRefField
+            companyId={companyId}
             disabled={mediaLoading || mediaSaving}
-            label="Transcription API key secret ref"
+            label="OpenAI transcription secret"
             onChange={(value) => updateMediaField("transcriptionApiKeyRef", value)}
-            placeholder="OpenAI API key secret UUID"
+            placeholder="OpenAI API key secret UUID fallback"
             value={mediaConfig.transcriptionApiKeyRef}
           >
-            Secret UUID for the OpenAI API key used to transcribe voice and audio before routing media to the Brief Agent or an active topic agent session.
-          </TextField>
+            Select the company secret used for audio transcription. Secret values are never shown to the plugin UI.
+          </SecretRefField>
           <TextField
             disabled={mediaLoading || mediaSaving}
             label="Brief Agent ID"
@@ -2289,6 +2306,103 @@ function NoticeBlock({ notice }: { notice: Notice }): React.JSX.Element {
       <strong>{notice.title}</strong>
       {notice.text ? <p style={{ margin: "6px 0 0" }}>{notice.text}</p> : null}
     </div>
+  );
+}
+
+function SecretRefField({
+  label,
+  value,
+  placeholder,
+  disabled,
+  companyId,
+  children,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  placeholder: string;
+  disabled: boolean;
+  companyId: string;
+  children: React.ReactNode;
+  onChange(value: string): void;
+}): React.JSX.Element {
+  const [secrets, setSecrets] = useState<CompanySecretSummary[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadSecrets(): Promise<void> {
+      if (!companyId) {
+        setSecrets([]);
+        return;
+      }
+      setLoading(true);
+      setError(null);
+      try {
+        const nextSecrets = await fetchCompanySecrets(companyId);
+        if (!cancelled) {
+          setSecrets(nextSecrets.filter((secret) => secret.status !== "deleted"));
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(getErrorMessage(err));
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void loadSecrets();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [companyId]);
+
+  const selectedValue = secrets.some((secret) => secret.id === value) ? value : "";
+  const fieldDisabled = disabled || loading || !companyId;
+
+  return (
+    <label style={{ display: "grid", gap: 5 }}>
+      <span style={{ color: "#4b5563", fontSize: 12, fontWeight: 700 }}>{label}</span>
+      <select
+        disabled={fieldDisabled}
+        onChange={(event) => onChange(event.currentTarget.value)}
+        style={standardInputStyle}
+        value={selectedValue}
+      >
+        <option value="">
+          {!companyId
+            ? "Open inside a company to select a secret"
+            : loading
+              ? "Loading company secrets..."
+              : value && !selectedValue
+                ? "Manual UUID selected"
+                : "Select a company secret"}
+        </option>
+        {secrets.map((secret) => (
+          <option key={secret.id} value={secret.id}>
+            {secret.name || secret.key || secret.id}
+            {secret.key && secret.key !== secret.name ? ` (${secret.key})` : ""}
+            {secret.latestVersion ? ` · v${secret.latestVersion}` : ""}
+          </option>
+        ))}
+      </select>
+      <input
+        disabled={disabled}
+        onChange={(event) => onChange(event.currentTarget.value)}
+        placeholder={placeholder}
+        style={standardInputStyle}
+        type="text"
+        value={value}
+      />
+      <span style={{ color: "#6b7280", fontSize: 12 }}>{children}</span>
+      {error ? <span style={{ color: "#b91c1c", fontSize: 12 }}>Could not load company secrets: {error}</span> : null}
+    </label>
   );
 }
 

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -835,7 +835,7 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
       setConnectionLoading(true);
       setConnectionMessage(null);
       try {
-        const config = await fetchPluginConfig();
+        const config = await fetchPluginConfig(companyId);
         if (cancelled) return;
         const nextConnectionConfig = extractConnectionConfig(config);
         setConnectionConfig(nextConnectionConfig);
@@ -860,7 +860,7 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [companyId]);
 
   useEffect(() => {
     let cancelled = false;
@@ -1028,9 +1028,9 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
     setConnectionSaving(true);
     setConnectionMessage(null);
     try {
-      const currentConfig = await fetchPluginConfig();
+      const currentConfig = await fetchPluginConfig(companyId);
       const nextConfig = { ...currentConfig, ...connectionConfig };
-      await savePluginConfig(nextConfig);
+      await savePluginConfig(nextConfig, companyId);
       setConnectionSnapshot(connectionConfig);
       setConnectionMessage({
         tone: "success",

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -554,17 +554,24 @@ async function fetchBoardAccessIdentity(boardApiToken: string): Promise<string |
   return getIdentityLabel(identity);
 }
 
-async function fetchPluginConfig(): Promise<Record<string, unknown>> {
+function pluginConfigPath(companyId?: string | null): string {
+  const base = `/api/plugins/${encodeURIComponent(TELEGRAM_PLUGIN_ID)}/config`;
+  const scopedCompanyId = companyId?.trim();
+  return scopedCompanyId ? `${base}?companyId=${encodeURIComponent(scopedCompanyId)}` : base;
+}
+
+async function fetchPluginConfig(companyId?: string | null): Promise<Record<string, unknown>> {
   const record = await fetchHostJson<PluginConfigResponse>(
-    `/api/plugins/${encodeURIComponent(TELEGRAM_PLUGIN_ID)}/config`,
+    pluginConfigPath(companyId),
   );
   return record?.configJson && typeof record.configJson === "object" ? record.configJson : {};
 }
 
-async function savePluginConfig(configJson: Record<string, unknown>): Promise<void> {
-  await fetchHostJson(`/api/plugins/${encodeURIComponent(TELEGRAM_PLUGIN_ID)}/config`, {
+async function savePluginConfig(configJson: Record<string, unknown>, companyId?: string | null): Promise<void> {
+  const scopedCompanyId = companyId?.trim();
+  await fetchHostJson(pluginConfigPath(), {
     method: "POST",
-    body: JSON.stringify({ configJson }),
+    body: JSON.stringify(scopedCompanyId ? { configJson, companyId: scopedCompanyId } : { configJson }),
   });
 }
 
@@ -658,7 +665,7 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
       setRoutingLoading(true);
       setRoutingMessage(null);
       try {
-        const config = await fetchPluginConfig();
+        const config = await fetchPluginConfig(companyId);
         if (cancelled) return;
         const nextRoutingConfig = extractRoutingConfig(config);
         setRoutingConfig(nextRoutingConfig);
@@ -683,7 +690,7 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [companyId]);
 
   useEffect(() => {
     let cancelled = false;
@@ -692,7 +699,7 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
       setProactiveLoading(true);
       setProactiveMessage(null);
       try {
-        const config = await fetchPluginConfig();
+        const config = await fetchPluginConfig(companyId);
         if (cancelled) return;
         const nextProactiveConfig = extractProactiveConfig(config);
         setProactiveConfig(nextProactiveConfig);
@@ -717,7 +724,7 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [companyId]);
 
   useEffect(() => {
     let cancelled = false;
@@ -726,7 +733,7 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
       setEscalationLoading(true);
       setEscalationMessage(null);
       try {
-        const config = await fetchPluginConfig();
+        const config = await fetchPluginConfig(companyId);
         if (cancelled) return;
         const nextEscalationConfig = extractEscalationConfig(config);
         setEscalationConfig(nextEscalationConfig);
@@ -751,7 +758,7 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [companyId]);
 
   useEffect(() => {
     let cancelled = false;
@@ -760,7 +767,7 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
       setMediaLoading(true);
       setMediaMessage(null);
       try {
-        const config = await fetchPluginConfig();
+        const config = await fetchPluginConfig(companyId);
         if (cancelled) return;
         const nextMediaConfig = extractMediaConfig(config);
         setMediaConfig(nextMediaConfig);
@@ -785,7 +792,7 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [companyId]);
 
   useEffect(() => {
     let cancelled = false;
@@ -794,7 +801,7 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
       setAccessLoading(true);
       setAccessMessage(null);
       try {
-        const config = await fetchPluginConfig();
+        const config = await fetchPluginConfig(companyId);
         if (cancelled) return;
         const nextAccessConfig = extractAccessConfig(config);
         setAccessConfig(nextAccessConfig);
@@ -819,7 +826,7 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [companyId]);
 
   useEffect(() => {
     let cancelled = false;
@@ -862,7 +869,7 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
       setBoardConfigLoading(true);
       setBoardConfigMessage(null);
       try {
-        const config = await fetchPluginConfig();
+        const config = await fetchPluginConfig(companyId);
         if (cancelled) return;
         const nextBoardConfig = extractBoardConfig(config);
         setBoardConfig(nextBoardConfig);
@@ -887,7 +894,7 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [companyId]);
 
   function updateRoutingField<K extends keyof TelegramRoutingConfig>(
     key: K,
@@ -949,9 +956,9 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
     setBoardConfigSaving(true);
     setBoardConfigMessage(null);
     try {
-      const currentConfig = await fetchPluginConfig();
+      const currentConfig = await fetchPluginConfig(companyId);
       const nextConfig = { ...currentConfig, ...boardConfig };
-      await savePluginConfig(nextConfig);
+      await savePluginConfig(nextConfig, companyId);
       setBoardSnapshot(boardConfig);
       setBoardConfigMessage({
         tone: "success",
@@ -973,9 +980,9 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
     setAccessSaving(true);
     setAccessMessage(null);
     try {
-      const currentConfig = await fetchPluginConfig();
+      const currentConfig = await fetchPluginConfig(companyId);
       const nextConfig = { ...currentConfig, ...accessConfig };
-      await savePluginConfig(nextConfig);
+      await savePluginConfig(nextConfig, companyId);
       setAccessSnapshot(accessConfig);
       setAccessMessage({
         tone: "success",
@@ -997,9 +1004,9 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
     setRoutingSaving(true);
     setRoutingMessage(null);
     try {
-      const currentConfig = await fetchPluginConfig();
+      const currentConfig = await fetchPluginConfig(companyId);
       const nextConfig = { ...currentConfig, ...routingConfig };
-      await savePluginConfig(nextConfig);
+      await savePluginConfig(nextConfig, companyId);
       setRoutingSnapshot(routingConfig);
       setRoutingMessage({
         tone: "success",
@@ -1045,9 +1052,9 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
     setMediaSaving(true);
     setMediaMessage(null);
     try {
-      const currentConfig = await fetchPluginConfig();
+      const currentConfig = await fetchPluginConfig(companyId);
       const nextConfig = { ...currentConfig, ...mediaConfig };
-      await savePluginConfig(nextConfig);
+      await savePluginConfig(nextConfig, companyId);
       setMediaSnapshot(mediaConfig);
       setMediaMessage({
         tone: "success",
@@ -1069,9 +1076,9 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
     setEscalationSaving(true);
     setEscalationMessage(null);
     try {
-      const currentConfig = await fetchPluginConfig();
+      const currentConfig = await fetchPluginConfig(companyId);
       const nextConfig = { ...currentConfig, ...escalationConfig };
-      await savePluginConfig(nextConfig);
+      await savePluginConfig(nextConfig, companyId);
       setEscalationSnapshot(escalationConfig);
       setEscalationMessage({
         tone: "success",
@@ -1093,9 +1100,9 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
     setProactiveSaving(true);
     setProactiveMessage(null);
     try {
-      const currentConfig = await fetchPluginConfig();
+      const currentConfig = await fetchPluginConfig(companyId);
       const nextConfig = { ...currentConfig, ...proactiveConfig };
-      await savePluginConfig(nextConfig);
+      await savePluginConfig(nextConfig, companyId);
       setProactiveSnapshot(proactiveConfig);
       setProactiveMessage({
         tone: "success",

--- a/src/watch-registry.ts
+++ b/src/watch-registry.ts
@@ -125,15 +125,17 @@ export async function checkWatches(
   ctx: PluginContext,
   token: string,
   config: { maxSuggestionsPerHourPerCompany: number; watchDeduplicationWindowMs: number },
+  companyId?: string,
 ): Promise<void> {
-  // Get all companies that have watches
-  const companies = await ctx.companies.list();
+  const companyIds = companyId
+    ? [companyId]
+    : (await ctx.companies.list()).map((company) => company.id);
 
-  for (const company of companies) {
+  for (const currentCompanyId of companyIds) {
     try {
-      await checkWatchesForCompany(ctx, token, company.id, config);
+      await checkWatchesForCompany(ctx, token, currentCompanyId, config);
     } catch (err) {
-      ctx.logger.error("Watch check failed for company", { companyId: company.id, error: String(err) });
+      ctx.logger.error("Watch check failed for company", { companyId: currentCompanyId, error: String(err) });
     }
   }
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -50,6 +50,7 @@ import { isTelegramUpdateAllowed, validateTelegramAllowlists } from "./allowlist
 import { validateSecretRefFields } from "./secret-ref-validation.js";
 import { shouldNotifyApproval } from "./approval-routing.js";
 import { buildPaperclipAuthHeaders, fetchPaperclipApi } from "./paperclip-api.js";
+import { loadStartupConfig, resolveCompatibleConfig } from "./config-compat.js";
 
 type TelegramConfig = {
   telegramBotTokenRef: string;
@@ -159,19 +160,7 @@ async function resolveConfig(
   fallback: TelegramConfig,
   companyId?: string | null,
 ): Promise<TelegramConfig> {
-  try {
-    const getConfig = ctx.config.get as unknown as (
-      params?: { companyId?: string | null },
-    ) => Promise<Record<string, unknown>>;
-    const scopedConfig = await getConfig(companyId ? { companyId } : undefined);
-    return { ...fallback, ...scopedConfig } as unknown as TelegramConfig;
-  } catch (err) {
-    ctx.logger.warn("Failed to load scoped Telegram plugin config; using startup config", {
-      companyId,
-      error: String(err),
-    });
-    return fallback;
-  }
+  return resolveCompatibleConfig(ctx, fallback as unknown as Record<string, unknown>, companyId) as Promise<TelegramConfig>;
 }
 
 function normalizeBoardAccessState(value: unknown): TelegramBoardAccessState {
@@ -250,6 +239,26 @@ async function resolveBoardApiToken(
   }
 
   return undefined;
+}
+
+async function resolveTelegramBotToken(
+  ctx: PluginContext,
+  config: TelegramConfig,
+  companyId?: string | null,
+): Promise<string | null> {
+  const effectiveConfig = companyId ? await resolveConfig(ctx, config, companyId) : config;
+  const tokenRef = effectiveConfig.telegramBotTokenRef;
+  if (!tokenRef) return null;
+
+  try {
+    return await ctx.secrets.resolve(tokenRef);
+  } catch (err) {
+    ctx.logger.warn("Failed to resolve Telegram bot token secret", {
+      companyId,
+      error: String(err),
+    });
+    return null;
+  }
 }
 
 async function resolveCallbackCompanyId(
@@ -353,7 +362,7 @@ async function resolveCompanyId(ctx: PluginContext, chatId: string): Promise<str
 
 const plugin = definePlugin({
   async setup(ctx) {
-    const rawConfig = await ctx.config.get();
+    const rawConfig = await loadStartupConfig(ctx, {} as Record<string, unknown>);
     ctx.logger.info("Telegram plugin config loaded");
     const config = rawConfig as unknown as TelegramConfig;
     const baseUrl = config.paperclipBaseUrl || "http://localhost:3100";
@@ -376,15 +385,13 @@ const plugin = definePlugin({
       });
     });
 
-    if (!config.telegramBotTokenRef) {
-      ctx.logger.warn("No telegramBotTokenRef configured, plugin disabled");
-      return;
+    const startupToken = await resolveTelegramBotToken(ctx, config);
+    if (!startupToken) {
+      ctx.logger.warn("Telegram bot token is not resolvable during startup; setup will continue without global polling");
     }
 
-    const token = await ctx.secrets.resolve(config.telegramBotTokenRef);
-
     // --- Register bot commands with Telegram ---
-    if (config.enableCommands) {
+    if (config.enableCommands && startupToken) {
       const allCommands = [
         ...BOT_COMMANDS,
         { command: "commands", description: "Manage custom workflow commands" },
@@ -393,7 +400,7 @@ const plugin = definePlugin({
       // The host's worker-init RPC timeout is 15s; if api.telegram.org is
       // slow/unreachable, awaiting this call causes the worker to be SIGKILLed
       // before setup() completes. Fire-and-forget matches pollUpdates() below.
-      setMyCommands(ctx, token, allCommands)
+      setMyCommands(ctx, startupToken, allCommands)
         .then((registered) => {
           if (registered) {
             ctx.logger.info("Bot commands registered with Telegram");
@@ -414,7 +421,7 @@ const plugin = definePlugin({
       while (pollingActive) {
         try {
           const res = await ctx.http.fetch(
-            `${TELEGRAM_API}/bot${token}/getUpdates?offset=${lastUpdateId + 1}&timeout=10&allowed_updates=["message","callback_query"]`,
+            `${TELEGRAM_API}/bot${startupToken}/getUpdates?offset=${lastUpdateId + 1}&timeout=10&allowed_updates=["message","callback_query"]`,
             { method: "GET" },
           );
           const data = (await res.json()) as {
@@ -426,7 +433,7 @@ const plugin = definePlugin({
             lastUpdateId = await processTelegramUpdateBatch({
               updates: data.result,
               lastUpdateId,
-              handleUpdate: (update) => handleUpdate(ctx, token, config, update, baseUrl, publicUrl),
+              handleUpdate: (update) => handleUpdate(ctx, startupToken!, config, update, baseUrl, publicUrl),
               persistOffset: (updateId) => persistTelegramUpdateOffset(ctx, updateId),
               logger: ctx.logger,
             });
@@ -438,7 +445,7 @@ const plugin = definePlugin({
       }
     }
 
-    if (config.enableCommands || config.enableInbound) {
+    if (startupToken && (config.enableCommands || config.enableInbound)) {
       pollUpdates().catch((err) =>
         ctx.logger.error("Polling loop crashed", { error: String(err) }),
       );
@@ -449,7 +456,7 @@ const plugin = definePlugin({
     });
 
     // --- Phase 2: ACP output listener (cross-plugin events) ---
-    setupAcpOutputListener(ctx, token);
+    setupAcpOutputListener(ctx, (event) => resolveTelegramBotToken(ctx, config, event.companyId));
 
     // --- Event subscriptions ---
 
@@ -472,6 +479,8 @@ const plugin = definePlugin({
       overrideTopicId?: string,
     ) => {
       const effectiveConfig = await resolveConfig(ctx, config, event.companyId);
+      const token = await resolveTelegramBotToken(ctx, effectiveConfig, event.companyId);
+      if (!token) return;
       const chatId = await resolveChat(
         ctx,
         event.companyId,
@@ -800,6 +809,8 @@ const plugin = definePlugin({
         const companies = await ctx.companies.list();
         for (const company of companies) {
           const effectiveConfig = await resolveConfig(ctx, config, company.id);
+          const token = await resolveTelegramBotToken(ctx, effectiveConfig, company.id);
+          if (!token) continue;
           const effectivePublicUrl = effectiveConfig.paperclipPublicUrl || effectiveConfig.paperclipBaseUrl || publicUrl;
           const chatId = await resolveChat(ctx, company.id, effectiveConfig.digestChatId || effectiveConfig.defaultChatId);
           if (!chatId) continue;
@@ -935,6 +946,10 @@ const plugin = definePlugin({
     }, async (params: unknown, runCtx) => {
       const p = params as Record<string, unknown>;
       const effectiveConfig = await resolveConfig(ctx, config, runCtx.companyId);
+      const token = await resolveTelegramBotToken(ctx, effectiveConfig, runCtx.companyId);
+      if (!token) {
+        return { error: "Telegram bot token is not configured or could not be resolved for this company." };
+      }
       const escalationId = crypto.randomUUID();
       const timeoutMs = effectiveConfig.escalationTimeoutMs || 900000;
       const defaultAction = effectiveConfig.escalationDefaultAction || "defer";
@@ -1004,6 +1019,10 @@ const plugin = definePlugin({
         required: ["targetAgent", "reason", "contextSummary"],
       },
     }, async (params: unknown, runCtx) => {
+      const token = await resolveTelegramBotToken(ctx, config, runCtx.companyId);
+      if (!token) {
+        return { error: "Telegram bot token is not configured or could not be resolved for this company." };
+      }
       return handleHandoffToolCall(ctx, token, params as Record<string, unknown>, runCtx.companyId, runCtx.agentId);
     });
 
@@ -1025,6 +1044,10 @@ const plugin = definePlugin({
         required: ["targetAgent", "topic", "initialMessage"],
       },
     }, async (params: unknown, runCtx) => {
+      const token = await resolveTelegramBotToken(ctx, config, runCtx.companyId);
+      if (!token) {
+        return { error: "Telegram bot token is not configured or could not be resolved for this company." };
+      }
       return handleDiscussToolCall(ctx, token, params as Record<string, unknown>, runCtx.companyId, runCtx.agentId);
     });
 
@@ -1065,6 +1088,8 @@ const plugin = definePlugin({
     // --- Phase 1: Escalation timeout checker job ---
     ctx.jobs.register("check-escalation-timeouts", async () => {
       try {
+        const token = await resolveTelegramBotToken(ctx, config);
+        if (!token) return;
         await escalationManager.checkTimeouts(ctx, token);
       } catch (err) {
         ctx.logger.error("Escalation timeout check failed", { error: String(err) });
@@ -1074,6 +1099,8 @@ const plugin = definePlugin({
     // --- Phase 5: Watch checker job ---
     ctx.jobs.register("check-watches", async () => {
       try {
+        const token = await resolveTelegramBotToken(ctx, config);
+        if (!token) return;
         await checkWatches(ctx, token, {
           maxSuggestionsPerHourPerCompany: config.maxSuggestionsPerHourPerCompany ?? 10,
           watchDeduplicationWindowMs: config.watchDeduplicationWindowMs ?? 86400000,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -51,7 +51,11 @@ import { isTelegramUpdateAllowed, validateTelegramAllowlists } from "./allowlist
 import { validateSecretRefFields } from "./secret-ref-validation.js";
 import { shouldNotifyApproval } from "./approval-routing.js";
 import { buildPaperclipAuthHeaders, fetchPaperclipApi } from "./paperclip-api.js";
-import { resolveStartupTelegramBotToken, type TelegramRuntimeHealth } from "./runtime-token.js";
+import {
+  SECRET_RESOLUTION_DISABLED_MESSAGE,
+  SECRET_RESOLUTION_ISSUE_URL,
+  type TelegramRuntimeHealth,
+} from "./runtime-token.js";
 import { loadStartupConfig, resolveCompatibleConfig } from "./config-compat.js";
 
 type TelegramConfig = {
@@ -167,18 +171,6 @@ async function resolveConfig(
   return resolveCompatibleConfig(ctx, fallback as unknown as Record<string, unknown>, companyId) as Promise<TelegramConfig>;
 }
 
-async function resolveTelegramBotToken(
-  ctx: PluginContext,
-  config: TelegramConfig,
-  companyId?: string | null,
-): Promise<string | undefined> {
-  const effectiveConfig = companyId ? await resolveConfig(ctx, config, companyId) : config;
-  if (!effectiveConfig.telegramBotTokenRef) return undefined;
-  return resolveStartupTelegramBotToken(ctx, effectiveConfig.telegramBotTokenRef, (health) => {
-    runtimeHealth = health;
-  });
-}
-
 function normalizeBoardAccessState(value: unknown): TelegramBoardAccessState {
   const record = isRecord(value) ? value : {};
   return {
@@ -284,6 +276,14 @@ async function resolveTelegramBotTokenRef(
     const resolveSecret = ctx.secrets.resolve as (secretRef: string, companyId?: string | null) => Promise<string>;
     return await resolveSecret(tokenRef, companyId);
   } catch (err) {
+    runtimeHealth = {
+      status: "degraded",
+      message: SECRET_RESOLUTION_DISABLED_MESSAGE,
+      details: {
+        issue: "paperclip-plugin-secret-resolution-disabled",
+        reference: SECRET_RESOLUTION_ISSUE_URL,
+      },
+    };
     ctx.logger.warn("Failed to resolve Telegram bot token secret", {
       companyId,
       error: String(err),

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -41,6 +41,7 @@ import {
   persistTelegramUpdateOffset,
   processTelegramUpdateBatch,
 } from "./polling-offset.js";
+import { getTelegramUpdateChatId, selectTelegramRuntimeForUpdate } from "./polling-dispatch.js";
 import { handleCommandsCommand, tryCustomCommand } from "./command-registry.js";
 import { handleRegisterWatch, checkWatches } from "./watch-registry.js";
 import { AGENT_ERROR_DEDUPLICATION_WINDOW_MS, METRIC_NAMES } from "./constants.js";
@@ -297,6 +298,12 @@ type TelegramCompanyRuntime = {
   token: string;
   baseUrl: string;
   publicUrl: string;
+};
+
+type TelegramPollingRuntimeGroup = {
+  tokenRef: string;
+  token: string;
+  runtimes: TelegramCompanyRuntime[];
 };
 
 async function resolveCompanyRuntimes(
@@ -591,11 +598,11 @@ const plugin = definePlugin({
     let pollingActive = true;
     let lastUpdateId = await getPersistedTelegramUpdateOffset(ctx);
 
-    async function pollUpdates(runtime: TelegramCompanyRuntime): Promise<void> {
+    async function pollUpdates(group: TelegramPollingRuntimeGroup): Promise<void> {
       while (pollingActive) {
         try {
           const res = await ctx.http.fetch(
-            `${TELEGRAM_API}/bot${runtime.token}/getUpdates?offset=${lastUpdateId + 1}&timeout=10&allowed_updates=["message","callback_query"]`,
+            `${TELEGRAM_API}/bot${group.token}/getUpdates?offset=${lastUpdateId + 1}&timeout=10&allowed_updates=["message","callback_query"]`,
             { method: "GET" },
           );
           const data = (await res.json()) as {
@@ -607,31 +614,65 @@ const plugin = definePlugin({
             lastUpdateId = await processTelegramUpdateBatch({
               updates: data.result,
               lastUpdateId,
-              handleUpdate: (update) => handleUpdate(
-                ctx,
-                runtime.token,
-                runtime.config,
-                update,
-                runtime.baseUrl,
-                runtime.publicUrl,
-              ),
+              handleUpdate: async (update) => {
+                const runtime = selectTelegramRuntimeForUpdate(group.runtimes, update);
+                if (!runtime) {
+                  ctx.logger.warn("No company-scoped Telegram runtime matched update", {
+                    updateId: update.update_id,
+                    chatId: getTelegramUpdateChatId(update),
+                    tokenRef: group.tokenRef,
+                  });
+                  return;
+                }
+
+                await handleUpdate(
+                  ctx,
+                  group.token,
+                  runtime.config,
+                  update,
+                  runtime.baseUrl,
+                  runtime.publicUrl,
+                  undefined,
+                  runtime.companyId,
+                );
+              },
               persistOffset: (updateId) => persistTelegramUpdateOffset(ctx, updateId),
               logger: ctx.logger,
             });
           }
         } catch (err) {
-          ctx.logger.error("Telegram polling error", { companyId: runtime.companyId, error: String(err) });
+          ctx.logger.error("Telegram polling error", {
+            tokenRef: group.tokenRef,
+            companyIds: group.runtimes.map((runtime) => runtime.companyId),
+            error: String(err),
+          });
           await new Promise((r) => setTimeout(r, 5000));
         }
       }
     }
 
-    const pollingRefs = new Set<string>();
+    const pollingGroups = new Map<string, TelegramPollingRuntimeGroup>();
     for (const runtime of pollingRuntimes) {
-      if (pollingRefs.has(runtime.config.telegramBotTokenRef)) continue;
-      pollingRefs.add(runtime.config.telegramBotTokenRef);
-      pollUpdates(runtime).catch((err) =>
-        ctx.logger.error("Polling loop crashed", { companyId: runtime.companyId, error: String(err) }),
+      const tokenRef = runtime.config.telegramBotTokenRef;
+      const existing = pollingGroups.get(tokenRef);
+      if (existing) {
+        existing.runtimes.push(runtime);
+      } else {
+        pollingGroups.set(tokenRef, {
+          tokenRef,
+          token: runtime.token,
+          runtimes: [runtime],
+        });
+      }
+    }
+
+    for (const group of pollingGroups.values()) {
+      pollUpdates(group).catch((err) =>
+        ctx.logger.error("Polling loop crashed", {
+          tokenRef: group.tokenRef,
+          companyIds: group.runtimes.map((runtime) => runtime.companyId),
+          error: String(err),
+        }),
       );
     }
 
@@ -1357,6 +1398,7 @@ export async function handleUpdate(
   baseUrl: string,
   publicUrl?: string,
   boardApiToken?: string,
+  runtimeCompanyId?: string,
 ): Promise<void> {
   if (!isTelegramUpdateAllowed(config, update)) {
     const fromId = update.message?.from?.id ?? update.callback_query?.from.id;
@@ -1387,7 +1429,7 @@ export async function handleUpdate(
   // Phase 3: Handle media messages
   const hasMedia = !!(msg.voice || msg.audio || msg.video_note || msg.document || msg.photo);
   if (hasMedia) {
-    const companyId = await resolveCompanyIdOrNull(ctx, chatId);
+    const companyId = runtimeCompanyId ?? await resolveCompanyIdOrNull(ctx, chatId);
     if (companyId) {
       const effectiveConfig = await resolveConfig(ctx, config, companyId);
       const effectivePublicUrl = effectiveConfig.paperclipPublicUrl || effectiveConfig.paperclipBaseUrl || publicUrl;
@@ -1411,7 +1453,7 @@ export async function handleUpdate(
   if (threadId) {
     const isCommand = text.startsWith("/");
     if (!isCommand) {
-      const companyId = await resolveCompanyIdOrNull(ctx, chatId);
+      const companyId = runtimeCompanyId ?? await resolveCompanyIdOrNull(ctx, chatId);
       if (companyId) {
         const replyToId = msg.reply_to_message?.message_id;
         const routed = await routeMessageToAgent(ctx, token, chatId, threadId, text, replyToId, companyId);
@@ -1429,7 +1471,7 @@ export async function handleUpdate(
     const args = text.slice(botCommand.offset + botCommand.length).trim();
     // undefined on unlinked chats: /connect and /help still work, and the
     // company-scoped handlers answer with their "not linked" guidance.
-    const companyId = (await resolveCompanyIdOrNull(ctx, chatId)) ?? undefined;
+    const companyId = runtimeCompanyId ?? (await resolveCompanyIdOrNull(ctx, chatId)) ?? undefined;
     const effectiveConfig = companyId ? await resolveConfig(ctx, config, companyId) : config;
     const effectiveBaseUrl = effectiveConfig.paperclipBaseUrl || baseUrl;
     const effectivePublicUrl = effectiveConfig.paperclipPublicUrl || effectiveBaseUrl;
@@ -1450,7 +1492,7 @@ export async function handleUpdate(
   }
 
   if (config.enableInbound && msg.reply_to_message?.from?.is_bot) {
-    const companyId = await resolveCompanyId(ctx, chatId);
+    const companyId = runtimeCompanyId ?? await resolveCompanyId(ctx, chatId);
     const replyToId = msg.reply_to_message.message_id;
     const mapping = await ctx.state.get({
       scopeKind: "company",

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -51,6 +51,7 @@ import { validateSecretRefFields } from "./secret-ref-validation.js";
 import { shouldNotifyApproval } from "./approval-routing.js";
 import { buildPaperclipAuthHeaders, fetchPaperclipApi } from "./paperclip-api.js";
 import { resolveStartupTelegramBotToken, type TelegramRuntimeHealth } from "./runtime-token.js";
+import { loadStartupConfig, resolveCompatibleConfig } from "./config-compat.js";
 
 type TelegramConfig = {
   telegramBotTokenRef: string;
@@ -162,19 +163,19 @@ async function resolveConfig(
   fallback: TelegramConfig,
   companyId?: string | null,
 ): Promise<TelegramConfig> {
-  try {
-    const getConfig = ctx.config.get as unknown as (
-      params?: { companyId?: string | null },
-    ) => Promise<Record<string, unknown>>;
-    const scopedConfig = await getConfig(companyId ? { companyId } : undefined);
-    return { ...fallback, ...scopedConfig } as unknown as TelegramConfig;
-  } catch (err) {
-    ctx.logger.warn("Failed to load scoped Telegram plugin config; using startup config", {
-      companyId,
-      error: String(err),
-    });
-    return fallback;
-  }
+  return resolveCompatibleConfig(ctx, fallback as unknown as Record<string, unknown>, companyId) as Promise<TelegramConfig>;
+}
+
+async function resolveTelegramBotToken(
+  ctx: PluginContext,
+  config: TelegramConfig,
+  companyId?: string | null,
+): Promise<string | undefined> {
+  const effectiveConfig = companyId ? await resolveConfig(ctx, config, companyId) : config;
+  if (!effectiveConfig.telegramBotTokenRef) return undefined;
+  return resolveStartupTelegramBotToken(ctx, effectiveConfig.telegramBotTokenRef, (health) => {
+    runtimeHealth = health;
+  });
 }
 
 function normalizeBoardAccessState(value: unknown): TelegramBoardAccessState {
@@ -253,6 +254,26 @@ async function resolveBoardApiToken(
   }
 
   return undefined;
+}
+
+async function resolveTelegramBotToken(
+  ctx: PluginContext,
+  config: TelegramConfig,
+  companyId?: string | null,
+): Promise<string | null> {
+  const effectiveConfig = companyId ? await resolveConfig(ctx, config, companyId) : config;
+  const tokenRef = effectiveConfig.telegramBotTokenRef;
+  if (!tokenRef) return null;
+
+  try {
+    return await ctx.secrets.resolve(tokenRef);
+  } catch (err) {
+    ctx.logger.warn("Failed to resolve Telegram bot token secret", {
+      companyId,
+      error: String(err),
+    });
+    return null;
+  }
 }
 
 async function resolveCallbackCompanyId(
@@ -373,7 +394,7 @@ async function resolveCompanyIdOrNull(ctx: PluginContext, chatId: string): Promi
 
 const plugin = definePlugin({
   async setup(ctx) {
-    const rawConfig = await ctx.config.get();
+    const rawConfig = await loadStartupConfig(ctx, {} as Record<string, unknown>);
     ctx.logger.info("Telegram plugin config loaded");
     const config = rawConfig as unknown as TelegramConfig;
     const baseUrl = config.paperclipBaseUrl || "http://localhost:3100";
@@ -396,22 +417,13 @@ const plugin = definePlugin({
       });
     });
 
-    if (!config.telegramBotTokenRef) {
-      ctx.logger.warn("No telegramBotTokenRef configured, plugin disabled");
-      return;
+    const startupToken = await resolveTelegramBotToken(ctx, config);
+    if (!startupToken) {
+      ctx.logger.warn("Telegram bot token is not resolvable during startup; setup will continue without global polling");
     }
-
-    const token = await resolveStartupTelegramBotToken(ctx, config.telegramBotTokenRef, (health) => {
-      runtimeHealth = health;
-    });
-    if (!token) {
-      ctx.logger.warn("Telegram plugin runtime disabled because bot token could not be resolved");
-      return;
-    }
-    const telegramToken = token;
 
     // --- Register bot commands with Telegram ---
-    if (config.enableCommands) {
+    if (config.enableCommands && startupToken) {
       const allCommands = [
         ...BOT_COMMANDS,
         { command: "commands", description: "Manage custom workflow commands" },
@@ -420,7 +432,7 @@ const plugin = definePlugin({
       // The host's worker-init RPC timeout is 15s; if api.telegram.org is
       // slow/unreachable, awaiting this call causes the worker to be SIGKILLed
       // before setup() completes. Fire-and-forget matches pollUpdates() below.
-      setMyCommands(ctx, token, allCommands)
+      setMyCommands(ctx, startupToken, allCommands)
         .then((registered) => {
           if (registered) {
             ctx.logger.info("Bot commands registered with Telegram");
@@ -441,7 +453,7 @@ const plugin = definePlugin({
       while (pollingActive) {
         try {
           const res = await ctx.http.fetch(
-            `${TELEGRAM_API}/bot${token}/getUpdates?offset=${lastUpdateId + 1}&timeout=10&allowed_updates=["message","callback_query"]`,
+            `${TELEGRAM_API}/bot${startupToken}/getUpdates?offset=${lastUpdateId + 1}&timeout=10&allowed_updates=["message","callback_query"]`,
             { method: "GET" },
           );
           const data = (await res.json()) as {
@@ -453,7 +465,7 @@ const plugin = definePlugin({
             lastUpdateId = await processTelegramUpdateBatch({
               updates: data.result,
               lastUpdateId,
-              handleUpdate: (update) => handleUpdate(ctx, telegramToken, config, update, baseUrl, publicUrl),
+              handleUpdate: (update) => handleUpdate(ctx, startupToken!, config, update, baseUrl, publicUrl),
               persistOffset: (updateId) => persistTelegramUpdateOffset(ctx, updateId),
               logger: ctx.logger,
             });
@@ -465,7 +477,7 @@ const plugin = definePlugin({
       }
     }
 
-    if (config.enableCommands || config.enableInbound) {
+    if (startupToken && (config.enableCommands || config.enableInbound)) {
       pollUpdates().catch((err) =>
         ctx.logger.error("Polling loop crashed", { error: String(err) }),
       );
@@ -476,7 +488,7 @@ const plugin = definePlugin({
     });
 
     // --- Phase 2: ACP output listener (cross-plugin events) ---
-    setupAcpOutputListener(ctx, token);
+    setupAcpOutputListener(ctx, (event) => resolveTelegramBotToken(ctx, config, event.companyId));
 
     // --- Event subscriptions ---
 
@@ -499,6 +511,8 @@ const plugin = definePlugin({
       overrideTopicId?: string,
     ) => {
       const effectiveConfig = await resolveConfig(ctx, config, event.companyId);
+      const token = await resolveTelegramBotToken(ctx, effectiveConfig, event.companyId);
+      if (!token) return;
       const chatId = await resolveChat(
         ctx,
         event.companyId,
@@ -827,6 +841,8 @@ const plugin = definePlugin({
         const companies = await ctx.companies.list();
         for (const company of companies) {
           const effectiveConfig = await resolveConfig(ctx, config, company.id);
+          const token = await resolveTelegramBotToken(ctx, effectiveConfig, company.id);
+          if (!token) continue;
           const effectivePublicUrl = effectiveConfig.paperclipPublicUrl || effectiveConfig.paperclipBaseUrl || publicUrl;
           const chatId = await resolveChat(ctx, company.id, effectiveConfig.digestChatId || effectiveConfig.defaultChatId);
           if (!chatId) continue;
@@ -962,6 +978,10 @@ const plugin = definePlugin({
     }, async (params: unknown, runCtx) => {
       const p = params as Record<string, unknown>;
       const effectiveConfig = await resolveConfig(ctx, config, runCtx.companyId);
+      const token = await resolveTelegramBotToken(ctx, effectiveConfig, runCtx.companyId);
+      if (!token) {
+        return { error: "Telegram bot token is not configured or could not be resolved for this company." };
+      }
       const escalationId = crypto.randomUUID();
       const timeoutMs = effectiveConfig.escalationTimeoutMs || 900000;
       const defaultAction = effectiveConfig.escalationDefaultAction || "defer";
@@ -1031,6 +1051,10 @@ const plugin = definePlugin({
         required: ["targetAgent", "reason", "contextSummary"],
       },
     }, async (params: unknown, runCtx) => {
+      const token = await resolveTelegramBotToken(ctx, config, runCtx.companyId);
+      if (!token) {
+        return { error: "Telegram bot token is not configured or could not be resolved for this company." };
+      }
       return handleHandoffToolCall(ctx, token, params as Record<string, unknown>, runCtx.companyId, runCtx.agentId);
     });
 
@@ -1052,6 +1076,10 @@ const plugin = definePlugin({
         required: ["targetAgent", "topic", "initialMessage"],
       },
     }, async (params: unknown, runCtx) => {
+      const token = await resolveTelegramBotToken(ctx, config, runCtx.companyId);
+      if (!token) {
+        return { error: "Telegram bot token is not configured or could not be resolved for this company." };
+      }
       return handleDiscussToolCall(ctx, token, params as Record<string, unknown>, runCtx.companyId, runCtx.agentId);
     });
 
@@ -1092,6 +1120,8 @@ const plugin = definePlugin({
     // --- Phase 1: Escalation timeout checker job ---
     ctx.jobs.register("check-escalation-timeouts", async () => {
       try {
+        const token = await resolveTelegramBotToken(ctx, config);
+        if (!token) return;
         await escalationManager.checkTimeouts(ctx, token);
       } catch (err) {
         ctx.logger.error("Escalation timeout check failed", { error: String(err) });
@@ -1101,6 +1131,8 @@ const plugin = definePlugin({
     // --- Phase 5: Watch checker job ---
     ctx.jobs.register("check-watches", async () => {
       try {
+        const token = await resolveTelegramBotToken(ctx, config);
+        if (!token) return;
         await checkWatches(ctx, token, {
           maxSuggestionsPerHourPerCompany: config.maxSuggestionsPerHourPerCompany ?? 10,
           watchDeduplicationWindowMs: config.watchDeduplicationWindowMs ?? 86400000,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -243,7 +243,8 @@ async function resolveBoardApiToken(
     if (seen.has(candidate.ref)) continue;
     seen.add(candidate.ref);
     try {
-      return await ctx.secrets.resolve(candidate.ref);
+      const resolveSecret = ctx.secrets.resolve as (secretRef: string, companyId?: string | null) => Promise<string>;
+      return await resolveSecret(candidate.ref, companyId);
     } catch (err) {
       ctx.logger.warn("Failed to resolve board API token secret", {
         source: candidate.source,
@@ -265,8 +266,22 @@ async function resolveTelegramBotToken(
   const tokenRef = effectiveConfig.telegramBotTokenRef;
   if (!tokenRef) return null;
 
+  return resolveTelegramBotTokenRef(ctx, tokenRef, companyId);
+}
+
+async function resolveTelegramBotTokenRef(
+  ctx: PluginContext,
+  tokenRef: string,
+  companyId?: string | null,
+): Promise<string | null> {
+  if (!companyId) {
+    ctx.logger.warn("Telegram bot token secret requires company context");
+    return null;
+  }
+
   try {
-    return await ctx.secrets.resolve(tokenRef);
+    const resolveSecret = ctx.secrets.resolve as (secretRef: string, companyId?: string | null) => Promise<string>;
+    return await resolveSecret(tokenRef, companyId);
   } catch (err) {
     ctx.logger.warn("Failed to resolve Telegram bot token secret", {
       companyId,
@@ -274,6 +289,78 @@ async function resolveTelegramBotToken(
     });
     return null;
   }
+}
+
+type TelegramCompanyRuntime = {
+  companyId: string;
+  config: TelegramConfig;
+  token: string;
+  baseUrl: string;
+  publicUrl: string;
+};
+
+async function resolveCompanyRuntimes(
+  ctx: PluginContext,
+  startupConfig: TelegramConfig,
+  predicate: (config: TelegramConfig) => boolean,
+): Promise<TelegramCompanyRuntime[]> {
+  const companies = await ctx.companies.list();
+  const runtimes: TelegramCompanyRuntime[] = [];
+
+  for (const company of companies) {
+    let scopedConfig: Record<string, unknown>;
+    try {
+      const getConfig = ctx.config.get as unknown as (
+        params?: { companyId?: string | null },
+      ) => Promise<Record<string, unknown>>;
+      scopedConfig = await getConfig({ companyId: company.id });
+    } catch (err) {
+      ctx.logger.warn("Company-scoped Telegram plugin config unavailable; skipping company runtime", {
+        companyId: company.id,
+        error: String(err),
+      });
+      continue;
+    }
+    if (!("telegramBotTokenRef" in scopedConfig)) continue;
+
+    const effectiveConfig = { ...startupConfig, ...scopedConfig } as unknown as TelegramConfig;
+    const hasCompanyTelegramRoute = [
+      "telegramBotTokenRef",
+      "defaultChatId",
+      "approvalsChatId",
+      "approvalsTopicId",
+      "errorsChatId",
+      "errorsTopicId",
+      "digestChatId",
+      "digestTopicId",
+      "escalationChatId",
+    ].some((key) => {
+      const value = effectiveConfig[key as keyof TelegramConfig];
+      const startupValue = startupConfig[key as keyof TelegramConfig];
+      return typeof value === "string" && value.trim() && value !== startupValue;
+    });
+    if (!hasCompanyTelegramRoute) continue;
+
+    if (!predicate(effectiveConfig)) continue;
+
+    const tokenRef = effectiveConfig.telegramBotTokenRef;
+    if (!tokenRef) continue;
+
+    const token = await resolveTelegramBotTokenRef(ctx, tokenRef, company.id);
+    if (!token) continue;
+
+    const baseUrl = effectiveConfig.paperclipBaseUrl || startupConfig.paperclipBaseUrl || "http://localhost:3100";
+    const publicUrl = effectiveConfig.paperclipPublicUrl || baseUrl;
+    runtimes.push({
+      companyId: company.id,
+      config: effectiveConfig,
+      token,
+      baseUrl,
+      publicUrl,
+    });
+  }
+
+  return runtimes;
 }
 
 async function resolveCallbackCompanyId(
@@ -289,7 +376,10 @@ async function resolveCallbackCompanyId(
     stateKey: `msg_${chatId}_${messageId}`,
   }) as { companyId?: string } | null;
 
-  return mapping?.companyId ?? null;
+  if (mapping?.companyId) return mapping.companyId;
+
+  const boardAccessState = await loadBoardAccessState(ctx);
+  return boardAccessState.companyId ?? null;
 }
 
 /**
@@ -367,6 +457,53 @@ async function resolveDigestThreadId(
   return await isForum(ctx, token, chatId) ? GENERAL_TOPIC_THREAD_ID : undefined;
 }
 
+function resolveDigestMode(config: TelegramConfig): TelegramConfig["digestMode"] {
+  return (config as Record<string, unknown>).dailyDigestEnabled === true && config.digestMode === "off"
+    ? "daily"
+    : config.digestMode ?? "off";
+}
+
+function parseDigestTime(value: string | undefined): { hour: number; minute: number } | null {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  const match = /^(\d{1,2})(?::(\d{2}))?$/.exec(trimmed);
+  if (!match) return null;
+  const hour = Number(match[1]);
+  const minute = match[2] === undefined ? 0 : Number(match[2]);
+  if (!Number.isInteger(hour) || !Number.isInteger(minute)) return null;
+  if (hour < 0 || hour > 23 || minute < 0 || minute > 59) return null;
+  return { hour, minute };
+}
+
+function digestTimesForConfig(config: TelegramConfig): Array<{ hour: number; minute: number }> {
+  const mode = resolveDigestMode(config);
+  if (mode === "off") return [];
+  if (mode === "daily") {
+    return [parseDigestTime(config.dailyDigestTime)].filter((time): time is { hour: number; minute: number } => Boolean(time));
+  }
+  if (mode === "bidaily") {
+    return [parseDigestTime(config.dailyDigestTime), parseDigestTime(config.bidailySecondTime)]
+      .filter((time): time is { hour: number; minute: number } => Boolean(time));
+  }
+  return (config.tridailyTimes || "07:00,13:00,19:00")
+    .split(",")
+    .map((time) => parseDigestTime(time))
+    .filter((time): time is { hour: number; minute: number } => Boolean(time));
+}
+
+function resolveDigestSlot(
+  config: TelegramConfig,
+  date: Date,
+): { dateKey: string; timeKey: string } | null {
+  const hour = date.getUTCHours();
+  const minute = date.getUTCMinutes();
+  const match = digestTimesForConfig(config).find((time) => time.hour === hour && time.minute === minute);
+  if (!match) return null;
+  const dateKey = date.toISOString().slice(0, 10);
+  const timeKey = `${String(match.hour).padStart(2, "0")}:${String(match.minute).padStart(2, "0")}`;
+  return { dateKey, timeKey };
+}
+
 async function resolveCompanyId(ctx: PluginContext, chatId: string): Promise<string> {
   const mapping = await ctx.state.get({
     scopeKind: "instance",
@@ -417,29 +554,34 @@ const plugin = definePlugin({
       });
     });
 
-    const startupToken = await resolveTelegramBotToken(ctx, config);
-    if (!startupToken) {
-      ctx.logger.warn("Telegram bot token is not resolvable during startup; setup will continue without global polling");
+    const pollingRuntimes = await resolveCompanyRuntimes(
+      ctx,
+      config,
+      (effectiveConfig) => Boolean(effectiveConfig.enableCommands || effectiveConfig.enableInbound),
+    );
+    if (pollingRuntimes.length === 0) {
+      ctx.logger.warn("No company-scoped Telegram bot token is resolvable during startup; setup will continue without polling");
     }
 
-    // --- Register bot commands with Telegram ---
-    if (config.enableCommands && startupToken) {
+    const commandRegistrationRefs = new Set<string>();
+    for (const runtime of pollingRuntimes) {
+      if (!runtime.config.enableCommands) continue;
+      if (commandRegistrationRefs.has(runtime.config.telegramBotTokenRef)) continue;
+      commandRegistrationRefs.add(runtime.config.telegramBotTokenRef);
+
       const allCommands = [
         ...BOT_COMMANDS,
         { command: "commands", description: "Manage custom workflow commands" },
       ];
-      // Non-blocking init: don't hold up worker initialize on external API.
-      // The host's worker-init RPC timeout is 15s; if api.telegram.org is
-      // slow/unreachable, awaiting this call causes the worker to be SIGKILLed
-      // before setup() completes. Fire-and-forget matches pollUpdates() below.
-      setMyCommands(ctx, startupToken, allCommands)
+      setMyCommands(ctx, runtime.token, allCommands)
         .then((registered) => {
           if (registered) {
-            ctx.logger.info("Bot commands registered with Telegram");
+            ctx.logger.info("Bot commands registered with Telegram", { companyId: runtime.companyId });
           }
         })
         .catch((err) => {
           ctx.logger.error("Failed to register bot commands", {
+            companyId: runtime.companyId,
             error: String(err),
           });
         });
@@ -449,11 +591,11 @@ const plugin = definePlugin({
     let pollingActive = true;
     let lastUpdateId = await getPersistedTelegramUpdateOffset(ctx);
 
-    async function pollUpdates(): Promise<void> {
+    async function pollUpdates(runtime: TelegramCompanyRuntime): Promise<void> {
       while (pollingActive) {
         try {
           const res = await ctx.http.fetch(
-            `${TELEGRAM_API}/bot${startupToken}/getUpdates?offset=${lastUpdateId + 1}&timeout=10&allowed_updates=["message","callback_query"]`,
+            `${TELEGRAM_API}/bot${runtime.token}/getUpdates?offset=${lastUpdateId + 1}&timeout=10&allowed_updates=["message","callback_query"]`,
             { method: "GET" },
           );
           const data = (await res.json()) as {
@@ -465,21 +607,31 @@ const plugin = definePlugin({
             lastUpdateId = await processTelegramUpdateBatch({
               updates: data.result,
               lastUpdateId,
-              handleUpdate: (update) => handleUpdate(ctx, startupToken!, config, update, baseUrl, publicUrl),
+              handleUpdate: (update) => handleUpdate(
+                ctx,
+                runtime.token,
+                runtime.config,
+                update,
+                runtime.baseUrl,
+                runtime.publicUrl,
+              ),
               persistOffset: (updateId) => persistTelegramUpdateOffset(ctx, updateId),
               logger: ctx.logger,
             });
           }
         } catch (err) {
-          ctx.logger.error("Telegram polling error", { error: String(err) });
+          ctx.logger.error("Telegram polling error", { companyId: runtime.companyId, error: String(err) });
           await new Promise((r) => setTimeout(r, 5000));
         }
       }
     }
 
-    if (startupToken && (config.enableCommands || config.enableInbound)) {
-      pollUpdates().catch((err) =>
-        ctx.logger.error("Polling loop crashed", { error: String(err) }),
+    const pollingRefs = new Set<string>();
+    for (const runtime of pollingRuntimes) {
+      if (pollingRefs.has(runtime.config.telegramBotTokenRef)) continue;
+      pollingRefs.add(runtime.config.telegramBotTokenRef);
+      pollUpdates(runtime).catch((err) =>
+        ctx.logger.error("Polling loop crashed", { companyId: runtime.companyId, error: String(err) }),
       );
     }
 
@@ -539,7 +691,8 @@ const plugin = definePlugin({
         : null;
       if (anchorKey) {
         const anchor = (await ctx.state.get({
-          scopeKind: "instance",
+          scopeKind: "company",
+          scopeId: event.companyId,
           stateKey: anchorKey,
         })) as { messageId: number; messageThreadId?: number } | null;
         // Only thread when targeting the same topic — Telegram rejects cross-topic replies.
@@ -551,17 +704,27 @@ const plugin = definePlugin({
       const messageId = await sendMessage(ctx, token, chatId, msg.text, msg.options);
 
       if (messageId) {
+        const messageMapping = {
+          entityId: event.entityId,
+          entityType: event.entityType,
+          companyId: event.companyId,
+          eventType: event.eventType,
+        };
+
+        await ctx.state.set(
+          {
+            scopeKind: "company",
+            scopeId: event.companyId,
+            stateKey: `msg_${chatId}_${messageId}`,
+          },
+          messageMapping,
+        );
         await ctx.state.set(
           {
             scopeKind: "instance",
             stateKey: `msg_${chatId}_${messageId}`,
           },
-          {
-            entityId: event.entityId,
-            entityType: event.entityType,
-            companyId: event.companyId,
-            eventType: event.eventType,
-          },
+          messageMapping,
         );
 
         await ctx.activity.log({
@@ -575,12 +738,13 @@ const plugin = definePlugin({
         // same entity reply to this one. Never overwritten — the first message stays root.
         if (anchorKey) {
           const existing = (await ctx.state.get({
-            scopeKind: "instance",
+            scopeKind: "company",
+            scopeId: event.companyId,
             stateKey: anchorKey,
           })) as { messageId: number; messageThreadId?: number } | null;
           if (!existing) {
             await ctx.state.set(
-              { scopeKind: "instance", stateKey: anchorKey },
+              { scopeKind: "company", scopeId: event.companyId, stateKey: anchorKey },
               { messageId, messageThreadId },
             );
           }
@@ -588,7 +752,7 @@ const plugin = definePlugin({
       }
     };
 
-    if (config.notifyOnIssueCreated) {
+    {
       ctx.events.on("issue.created", async (event: PluginEvent) => {
         const effectiveConfig = await resolveConfig(ctx, config, event.companyId);
         if (!effectiveConfig.notifyOnIssueCreated) return;
@@ -596,7 +760,7 @@ const plugin = definePlugin({
       });
     }
 
-    if (config.notifyOnIssueDone) {
+    {
       const doneDedupe = makeUpdateDedupe();
       ctx.events.on("issue.updated", async (event: PluginEvent) => {
         const effectiveConfig = await resolveConfig(ctx, config, event.companyId);
@@ -627,7 +791,7 @@ const plugin = definePlugin({
       });
     }
 
-    if (config.notifyOnIssueAssigned) {
+    {
       const assignmentDedupe = makeUpdateDedupe();
 
       ctx.events.on("issue.updated", async (event: PluginEvent) => {
@@ -671,7 +835,7 @@ const plugin = definePlugin({
       });
     }
 
-    if (config.notifyOnApprovalCreated) {
+    {
       ctx.events.on("approval.created", async (event: PluginEvent) => {
         const effectiveConfig = await resolveConfig(ctx, config, event.companyId);
         if (!effectiveConfig.notifyOnApprovalCreated) return;
@@ -719,7 +883,7 @@ const plugin = definePlugin({
       });
     }
 
-    if (config.notifyOnAgentError) {
+    {
       const agentErrorDedupe = makeUpdateDedupe(AGENT_ERROR_DEDUPLICATION_WINDOW_MS, 1000);
       ctx.events.on("agent.run.failed", async (event: PluginEvent) => {
         const effectiveConfig = await resolveConfig(ctx, config, event.companyId);
@@ -764,19 +928,35 @@ const plugin = definePlugin({
       }
     };
 
-    if (config.notifyOnAgentRunStarted) {
+    const enrichRunIssue = async (event: PluginEvent) => {
+      const payload = event.payload as Record<string, unknown>;
+      if (payload.issueId && !payload.issueIdentifier) {
+        try {
+          const issue = await ctx.issues.get(String(payload.issueId), event.companyId);
+          if (issue?.identifier) payload.issueIdentifier = issue.identifier;
+        } catch { /* best effort */ }
+      }
+    };
+
+    {
       ctx.events.on("agent.run.started", async (event: PluginEvent) => {
         const effectiveConfig = await resolveConfig(ctx, config, event.companyId);
-        if (!effectiveConfig.notifyOnAgentRunStarted) return;
+        if (!effectiveConfig.notifyOnAgentRunStarted) {
+          return;
+        }
         await enrichAgentName(event);
+        await enrichRunIssue(event);
         await notify(event, formatAgentRunStarted);
       });
     }
-    if (config.notifyOnAgentRunFinished) {
+    {
       ctx.events.on("agent.run.finished", async (event: PluginEvent) => {
         const effectiveConfig = await resolveConfig(ctx, config, event.companyId);
-        if (!effectiveConfig.notifyOnAgentRunFinished) return;
+        if (!effectiveConfig.notifyOnAgentRunFinished) {
+          return;
+        }
         await enrichAgentName(event);
+        await enrichRunIssue(event);
         await notify(event, formatAgentRunFinished);
       });
     }
@@ -805,133 +985,126 @@ const plugin = definePlugin({
     });
 
     // --- Daily digest job ---
+    ctx.jobs.register("telegram-daily-digest", async (job) => {
+      const scheduledAt = job.scheduledAt ? new Date(job.scheduledAt) : new Date();
+      const manualRun = job.trigger === "manual";
+      const companies = await ctx.companies.list();
+      for (const company of companies) {
+        const effectiveConfig = await resolveConfig(ctx, config, company.id);
+        const effectiveDigestMode = resolveDigestMode(effectiveConfig);
+        if (effectiveDigestMode === "off") continue;
 
-    // Support legacy dailyDigestEnabled boolean
-    const effectiveDigestMode = (config as Record<string, unknown>).dailyDigestEnabled === true && config.digestMode === "off"
-      ? "daily"
-      : config.digestMode ?? "off";
+        const digestSlot = resolveDigestSlot(effectiveConfig, scheduledAt);
+        if (!manualRun && !digestSlot) continue;
 
-    if (effectiveDigestMode !== "off") {
-      ctx.jobs.register("telegram-daily-digest", async () => {
-        // Check if current UTC hour matches a configured digest time
-        const nowHour = new Date().getUTCHours();
-        const nowMin = new Date().getUTCMinutes();
-        if (nowMin >= 5) return; // only fire within first 5 min of the hour
-
-        const parseHour = (t: string) => {
-          const [h] = (t || "").split(":");
-          return parseInt(h ?? "", 10);
-        };
-        const firstHour = parseHour(config.dailyDigestTime);
-        const secondHour = parseHour(config.bidailySecondTime);
-        const tridailyHours = (config.tridailyTimes || "07:00,13:00,19:00")
-          .split(",")
-          .map((t) => parseHour(t.trim()));
-
-        let shouldSend = false;
-        if (effectiveDigestMode === "daily") {
-          shouldSend = nowHour === firstHour;
-        } else if (effectiveDigestMode === "bidaily") {
-          shouldSend = nowHour === firstHour || nowHour === secondHour;
-        } else if (effectiveDigestMode === "tridaily") {
-          shouldSend = tridailyHours.includes(nowHour);
+        let sentKey: string | null = null;
+        if (!manualRun && digestSlot) {
+          sentKey = `digest_sent_${digestSlot.dateKey}_${digestSlot.timeKey}`;
+          const alreadySent = await ctx.state.get({
+            scopeKind: "company",
+            scopeId: company.id,
+            stateKey: sentKey,
+          });
+          if (alreadySent) continue;
         }
-        if (!shouldSend) return;
 
-        const companies = await ctx.companies.list();
-        for (const company of companies) {
-          const effectiveConfig = await resolveConfig(ctx, config, company.id);
-          const token = await resolveTelegramBotToken(ctx, effectiveConfig, company.id);
-          if (!token) continue;
-          const effectivePublicUrl = effectiveConfig.paperclipPublicUrl || effectiveConfig.paperclipBaseUrl || publicUrl;
-          const chatId = await resolveChat(ctx, company.id, effectiveConfig.digestChatId || effectiveConfig.defaultChatId);
-          if (!chatId) continue;
+        const token = await resolveTelegramBotToken(ctx, effectiveConfig, company.id);
+        if (!token) continue;
+        const effectivePublicUrl = effectiveConfig.paperclipPublicUrl || effectiveConfig.paperclipBaseUrl || publicUrl;
+        const chatId = await resolveChat(ctx, company.id, effectiveConfig.digestChatId || effectiveConfig.defaultChatId);
+        if (!chatId) continue;
 
-          try {
-            const agents = await ctx.agents.list({ companyId: company.id });
-            const activeAgents = agents.filter((a: Agent) => a.status === "active");
-            const issues = await ctx.issues.list({ companyId: company.id, limit: 50 });
+        try {
+          const agents = await ctx.agents.list({ companyId: company.id });
+          const activeAgents = agents.filter((a: Agent) => a.status === "active");
+          const issues = await ctx.issues.list({ companyId: company.id, limit: 50 });
 
-            const now = Date.now();
-            const oneDayMs = 24 * 60 * 60 * 1000;
-            const completedToday = issues.filter((i: Issue) =>
-              i.status === "done" && i.completedAt && (now - new Date(i.completedAt).getTime()) < oneDayMs
-            );
-            const createdToday = issues.filter((i: Issue) =>
-              (now - new Date(i.createdAt).getTime()) < oneDayMs
-            );
+          const now = Date.now();
+          const oneDayMs = 24 * 60 * 60 * 1000;
+          const completedToday = issues.filter((i: Issue) =>
+            i.status === "done" && i.completedAt && (now - new Date(i.completedAt).getTime()) < oneDayMs
+          );
+          const createdToday = issues.filter((i: Issue) =>
+            (now - new Date(i.createdAt).getTime()) < oneDayMs
+          );
 
-            const issuePrefix = company.issuePrefix;
-            const inProgress = issues.filter((i: Issue) => i.status === "in_progress");
-            const inReview = issues.filter((i: Issue) => i.status === "in_review");
-            const blocked = issues.filter((i: Issue) => i.status === "blocked");
+          const issuePrefix = company.issuePrefix;
+          const inProgress = issues.filter((i: Issue) => i.status === "in_progress");
+          const inReview = issues.filter((i: Issue) => i.status === "in_review");
+          const blocked = issues.filter((i: Issue) => i.status === "blocked");
 
-            const dateStr = new Date().toISOString().split("T")[0];
-            const companyLabel = company.name ? ` \\- ${escapeMarkdownV2(company.name)}` : "";
-            const digestLabel = effectiveDigestMode === "bidaily" ? "Digest" : "Daily Digest";
-            const lines = [
-              escapeMarkdownV2("\ud83d\udcca") + ` *${escapeMarkdownV2(digestLabel)}${companyLabel} \\- ${escapeMarkdownV2(dateStr!)}*`,
-              "",
-              `${escapeMarkdownV2("\u2705")} Tasks completed: *${completedToday.length}*`,
-              `${escapeMarkdownV2("\ud83d\udccb")} Tasks created: *${createdToday.length}*`,
-              `${escapeMarkdownV2("\ud83e\udd16")} Active agents: *${activeAgents.length}*/${escapeMarkdownV2(String(agents.length))}`,
-            ];
+          const dateStr = scheduledAt.toISOString().split("T")[0];
+          const companyLabel = company.name ? ` \\- ${escapeMarkdownV2(company.name)}` : "";
+          const digestLabel = effectiveDigestMode === "bidaily" ? "Digest" : "Daily Digest";
+          const lines = [
+            escapeMarkdownV2("\ud83d\udcca") + ` *${escapeMarkdownV2(digestLabel)}${companyLabel} \\- ${escapeMarkdownV2(dateStr!)}*`,
+            "",
+            `${escapeMarkdownV2("\u2705")} Tasks completed: *${completedToday.length}*`,
+            `${escapeMarkdownV2("\ud83d\udccb")} Tasks created: *${createdToday.length}*`,
+            `${escapeMarkdownV2("\ud83e\udd16")} Active agents: *${activeAgents.length}*/${escapeMarkdownV2(String(agents.length))}`,
+          ];
 
-            if (activeAgents.length > 0) {
-              const topAgent = activeAgents[0]!.name;
-              lines.push(`${escapeMarkdownV2("\u2b50")} Top performer: *${escapeMarkdownV2(topAgent)}*`);
-            }
-
-            const formatIssueItem = (i: Issue) => {
-              const id = i.identifier ?? i.id;
-              const idText = issuePrefix
-                ? `[${escapeMarkdownV2(id)}](${effectivePublicUrl}/${issuePrefix}/issues/${id})`
-                : escapeMarkdownV2(id);
-              return `  ${idText} \\- ${escapeMarkdownV2(i.title)}`;
-            };
-
-            if (inProgress.length > 0) {
-              lines.push("", `${escapeMarkdownV2("\ud83d\udd04")} *In Progress \\(${inProgress.length}\\)*`);
-              for (const i of inProgress.slice(0, 10)) lines.push(formatIssueItem(i));
-            }
-            if (inReview.length > 0) {
-              lines.push("", `${escapeMarkdownV2("\ud83d\udd0d")} *In Review \\(${inReview.length}\\)*`);
-              for (const i of inReview.slice(0, 10)) lines.push(formatIssueItem(i));
-            }
-            if (blocked.length > 0) {
-              lines.push("", `${escapeMarkdownV2("\ud83d\udeab")} *Blocked \\(${blocked.length}\\)*`);
-              for (const i of blocked.slice(0, 10)) lines.push(formatIssueItem(i));
-            }
-
-            const digestThreadId = await resolveDigestThreadId(ctx, token, chatId, effectiveConfig.digestTopicId);
-
-            await sendMessage(ctx, token, chatId, lines.join("\n"), {
-              parseMode: "MarkdownV2",
-              messageThreadId: digestThreadId,
-            });
-          } catch (err) {
-            ctx.logger.error("Daily digest failed for company", { companyId: company.id, error: String(err) });
-            const text = [
-              escapeMarkdownV2("\ud83d\udcca") + " *Daily Digest*",
-              "",
-              escapeMarkdownV2("Could not generate digest. Check plugin logs for details."),
-            ].join("\n");
-
-            const errorThreadId = await resolveDigestThreadId(
-              ctx,
-              token,
-              chatId,
-              effectiveConfig.errorsTopicId || effectiveConfig.digestTopicId,
-            );
-
-            await sendMessage(ctx, token, chatId, text, {
-              parseMode: "MarkdownV2",
-              messageThreadId: errorThreadId,
-            });
+          if (activeAgents.length > 0) {
+            const topAgent = activeAgents[0]!.name;
+            lines.push(`${escapeMarkdownV2("\u2b50")} Top performer: *${escapeMarkdownV2(topAgent)}*`);
           }
+
+          const formatIssueItem = (i: Issue) => {
+            const id = i.identifier ?? i.id;
+            const idText = issuePrefix
+              ? `[${escapeMarkdownV2(id)}](${effectivePublicUrl}/${issuePrefix}/issues/${id})`
+              : escapeMarkdownV2(id);
+            return `  ${idText} \\- ${escapeMarkdownV2(i.title)}`;
+          };
+
+          if (inProgress.length > 0) {
+            lines.push("", `${escapeMarkdownV2("\ud83d\udd04")} *In Progress \\(${inProgress.length}\\)*`);
+            for (const i of inProgress.slice(0, 10)) lines.push(formatIssueItem(i));
+          }
+          if (inReview.length > 0) {
+            lines.push("", `${escapeMarkdownV2("\ud83d\udd0d")} *In Review \\(${inReview.length}\\)*`);
+            for (const i of inReview.slice(0, 10)) lines.push(formatIssueItem(i));
+          }
+          if (blocked.length > 0) {
+            lines.push("", `${escapeMarkdownV2("\ud83d\udeab")} *Blocked \\(${blocked.length}\\)*`);
+            for (const i of blocked.slice(0, 10)) lines.push(formatIssueItem(i));
+          }
+
+          const digestThreadId = await resolveDigestThreadId(ctx, token, chatId, effectiveConfig.digestTopicId);
+
+          await sendMessage(ctx, token, chatId, lines.join("\n"), {
+            parseMode: "MarkdownV2",
+            messageThreadId: digestThreadId,
+          });
+
+          if (sentKey) {
+            await ctx.state.set(
+              { scopeKind: "company", scopeId: company.id, stateKey: sentKey },
+              { sentAt: new Date().toISOString(), jobRunId: job.runId },
+            );
+          }
+        } catch (err) {
+          ctx.logger.error("Daily digest failed for company", { companyId: company.id, error: String(err) });
+          const text = [
+            escapeMarkdownV2("\ud83d\udcca") + " *Daily Digest*",
+            "",
+            escapeMarkdownV2("Could not generate digest. Check plugin logs for details."),
+          ].join("\n");
+
+          const errorThreadId = await resolveDigestThreadId(
+            ctx,
+            token,
+            chatId,
+            effectiveConfig.errorsTopicId || effectiveConfig.digestTopicId,
+          );
+
+          await sendMessage(ctx, token, chatId, text, {
+            parseMode: "MarkdownV2",
+            messageThreadId: errorThreadId,
+          });
         }
-      });
-    }
+      }
+    });
 
     // --- Phase 1: Escalation support ---
     const escalationManager = new EscalationManager();
@@ -1120,9 +1293,14 @@ const plugin = definePlugin({
     // --- Phase 1: Escalation timeout checker job ---
     ctx.jobs.register("check-escalation-timeouts", async () => {
       try {
-        const token = await resolveTelegramBotToken(ctx, config);
-        if (!token) return;
-        await escalationManager.checkTimeouts(ctx, token);
+        const runtimes = await resolveCompanyRuntimes(
+          ctx,
+          config,
+          (effectiveConfig) => Boolean(effectiveConfig.enableInbound || effectiveConfig.escalationChatId),
+        );
+        for (const runtime of runtimes) {
+          await escalationManager.checkTimeouts(ctx, runtime.token, runtime.companyId);
+        }
       } catch (err) {
         ctx.logger.error("Escalation timeout check failed", { error: String(err) });
       }
@@ -1131,12 +1309,17 @@ const plugin = definePlugin({
     // --- Phase 5: Watch checker job ---
     ctx.jobs.register("check-watches", async () => {
       try {
-        const token = await resolveTelegramBotToken(ctx, config);
-        if (!token) return;
-        await checkWatches(ctx, token, {
-          maxSuggestionsPerHourPerCompany: config.maxSuggestionsPerHourPerCompany ?? 10,
-          watchDeduplicationWindowMs: config.watchDeduplicationWindowMs ?? 86400000,
-        });
+        const runtimes = await resolveCompanyRuntimes(
+          ctx,
+          config,
+          (effectiveConfig) => (effectiveConfig.maxSuggestionsPerHourPerCompany ?? 10) > 0,
+        );
+        for (const runtime of runtimes) {
+          await checkWatches(ctx, runtime.token, {
+            maxSuggestionsPerHourPerCompany: runtime.config.maxSuggestionsPerHourPerCompany ?? 10,
+            watchDeduplicationWindowMs: runtime.config.watchDeduplicationWindowMs ?? 86400000,
+          }, runtime.companyId);
+        }
       } catch (err) {
         ctx.logger.error("Watch check failed", { error: String(err) });
       }
@@ -1267,9 +1450,11 @@ export async function handleUpdate(
   }
 
   if (config.enableInbound && msg.reply_to_message?.from?.is_bot) {
+    const companyId = await resolveCompanyId(ctx, chatId);
     const replyToId = msg.reply_to_message.message_id;
     const mapping = await ctx.state.get({
-      scopeKind: "instance",
+      scopeKind: "company",
+      scopeId: companyId,
       stateKey: `msg_${chatId}_${replyToId}`,
     }) as { entityId: string; entityType: string; companyId: string } | null;
 
@@ -1321,6 +1506,7 @@ async function handleCallbackQuery(
   const actor = query.from.username ?? query.from.first_name ?? String(query.from.id);
   const chatId = query.message?.chat.id ? String(query.message.chat.id) : null;
   const messageId = query.message?.message_id;
+  const originalMessageText = query.message?.text?.trim() ?? "";
 
   if (data.startsWith("approve_")) {
     const approvalId = data.replace("approve_", "");
@@ -1348,8 +1534,7 @@ async function handleCallbackQuery(
           token,
           chatId,
           messageId,
-          `${escapeMarkdownV2("\u2705")} *Approved* by ${escapeMarkdownV2(actor)}`,
-          { parseMode: "MarkdownV2" },
+          formatApprovalDecisionMessage("approved", actor, originalMessageText, approvalId),
         );
       }
     } catch (err) {
@@ -1403,8 +1588,7 @@ async function handleCallbackQuery(
           token,
           chatId,
           messageId,
-          `${escapeMarkdownV2("\u274c")} *Rejected* by ${escapeMarkdownV2(actor)}`,
-          { parseMode: "MarkdownV2" },
+          formatApprovalDecisionMessage("rejected", actor, originalMessageText, approvalId),
         );
       }
     } catch (err) {
@@ -1428,6 +1612,22 @@ async function handleCallbackQuery(
   }
 
   await answerCallbackQuery(ctx, token, query.id, "Unknown action");
+}
+
+function formatApprovalDecisionMessage(
+  decision: "approved" | "rejected",
+  actor: string,
+  originalMessageText: string,
+  approvalId: string,
+): string {
+  const status = decision === "approved" ? "✅ Approved" : "❌ Rejected";
+  const body = stripApprovalDecisionPrefix(originalMessageText).trim();
+  const fallbackBody = `Approval ID: ${approvalId}`;
+  return `${status} by ${actor}\n${body || fallbackBody}`;
+}
+
+function stripApprovalDecisionPrefix(text: string): string {
+  return text.replace(/^(?:✅ Approved|❌ Rejected) by [^\n]*\n*/u, "");
 }
 
 runWorker(plugin, import.meta.url);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -154,6 +154,26 @@ function asNonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 
+async function resolveConfig(
+  ctx: PluginContext,
+  fallback: TelegramConfig,
+  companyId?: string | null,
+): Promise<TelegramConfig> {
+  try {
+    const getConfig = ctx.config.get as unknown as (
+      params?: { companyId?: string | null },
+    ) => Promise<Record<string, unknown>>;
+    const scopedConfig = await getConfig(companyId ? { companyId } : undefined);
+    return { ...fallback, ...scopedConfig } as unknown as TelegramConfig;
+  } catch (err) {
+    ctx.logger.warn("Failed to load scoped Telegram plugin config; using startup config", {
+      companyId,
+      error: String(err),
+    });
+    return fallback;
+  }
+}
+
 function normalizeBoardAccessState(value: unknown): TelegramBoardAccessState {
   const record = isRecord(value) ? value : {};
   return {
@@ -451,10 +471,11 @@ const plugin = definePlugin({
       overrideChatId?: string,
       overrideTopicId?: string,
     ) => {
+      const effectiveConfig = await resolveConfig(ctx, config, event.companyId);
       const chatId = await resolveChat(
         ctx,
         event.companyId,
-        overrideChatId || config.defaultChatId,
+        overrideChatId || effectiveConfig.defaultChatId,
       );
       if (!chatId) return;
       const linksOpts = await resolveIssueLinksOpts(event.companyId);
@@ -462,7 +483,7 @@ const plugin = definePlugin({
 
       let messageThreadId = parseTopicId(overrideTopicId);
       if (!messageThreadId) {
-        messageThreadId = await resolveNotificationThreadId(ctx, chatId, event, config.topicRouting);
+        messageThreadId = await resolveNotificationThreadId(ctx, chatId, event, effectiveConfig.topicRouting);
       }
 
       if (messageThreadId) {
@@ -527,14 +548,18 @@ const plugin = definePlugin({
     };
 
     if (config.notifyOnIssueCreated) {
-      ctx.events.on("issue.created", (event: PluginEvent) =>
-        notify(event, formatIssueCreated),
-      );
+      ctx.events.on("issue.created", async (event: PluginEvent) => {
+        const effectiveConfig = await resolveConfig(ctx, config, event.companyId);
+        if (!effectiveConfig.notifyOnIssueCreated) return;
+        await notify(event, formatIssueCreated);
+      });
     }
 
     if (config.notifyOnIssueDone) {
       const doneDedupe = makeUpdateDedupe();
       ctx.events.on("issue.updated", async (event: PluginEvent) => {
+        const effectiveConfig = await resolveConfig(ctx, config, event.companyId);
+        if (!effectiveConfig.notifyOnIssueDone) return;
         const payload = event.payload as Record<string, unknown>;
         if (payload.status !== "done") return;
         if (!doneDedupe(`done|${event.entityId}`)) return;
@@ -565,6 +590,8 @@ const plugin = definePlugin({
       const assignmentDedupe = makeUpdateDedupe();
 
       ctx.events.on("issue.updated", async (event: PluginEvent) => {
+        const effectiveConfig = await resolveConfig(ctx, config, event.companyId);
+        if (!effectiveConfig.notifyOnIssueAssigned) return;
         const payload = event.payload as Record<string, unknown>;
         const prev = (payload._previous as Record<string, unknown> | undefined) ?? {};
 
@@ -574,7 +601,7 @@ const plugin = definePlugin({
           "assigneeAgentId" in payload && payload.assigneeAgentId !== prev.assigneeAgentId;
         if (!userChanged && !agentChanged) return;
 
-        if (config.onlyNotifyIfAssignedTo && payload.assigneeUserId !== config.onlyNotifyIfAssignedTo) {
+        if (effectiveConfig.onlyNotifyIfAssignedTo && payload.assigneeUserId !== effectiveConfig.onlyNotifyIfAssignedTo) {
           return;
         }
 
@@ -605,7 +632,9 @@ const plugin = definePlugin({
 
     if (config.notifyOnApprovalCreated) {
       ctx.events.on("approval.created", async (event: PluginEvent) => {
-        if (!shouldNotifyApproval(event, config.onlyNotifyBoardApprovals)) return;
+        const effectiveConfig = await resolveConfig(ctx, config, event.companyId);
+        if (!effectiveConfig.notifyOnApprovalCreated) return;
+        if (!shouldNotifyApproval(event, effectiveConfig.onlyNotifyBoardApprovals)) return;
         const payload = event.payload as Record<string, unknown>;
         // Enrich with linked issue details (event only has issueIds)
         const issueIds = Array.isArray(payload.issueIds) ? payload.issueIds as string[] : [];
@@ -645,13 +674,15 @@ const plugin = definePlugin({
             ? `${approvalType} — ${agentLabel}`
             : approvalType;
         }
-        await notify(event, formatApprovalCreated, config.approvalsChatId, config.approvalsTopicId);
+        await notify(event, formatApprovalCreated, effectiveConfig.approvalsChatId, effectiveConfig.approvalsTopicId);
       });
     }
 
     if (config.notifyOnAgentError) {
       const agentErrorDedupe = makeUpdateDedupe(AGENT_ERROR_DEDUPLICATION_WINDOW_MS, 1000);
       ctx.events.on("agent.run.failed", async (event: PluginEvent) => {
+        const effectiveConfig = await resolveConfig(ctx, config, event.companyId);
+        if (!effectiveConfig.notifyOnAgentError) return;
         const payload = event.payload as Record<string, unknown>;
         const agentId = String(payload.agentId ?? event.entityId);
         if (payload.agentId && !payload.agentName) {
@@ -678,7 +709,7 @@ const plugin = definePlugin({
         const errorMessage = normalizeAgentErrorMessage(payload.error ?? payload.message);
         const dedupeKey = ["agent.run.failed", event.companyId, agentId, errorMessage].join(":");
         if (!agentErrorDedupe(dedupeKey)) return;
-        await notify(event, formatAgentError, config.errorsChatId, config.errorsTopicId);
+        await notify(event, formatAgentError, effectiveConfig.errorsChatId, effectiveConfig.errorsTopicId);
       });
     }
 
@@ -694,12 +725,16 @@ const plugin = definePlugin({
 
     if (config.notifyOnAgentRunStarted) {
       ctx.events.on("agent.run.started", async (event: PluginEvent) => {
+        const effectiveConfig = await resolveConfig(ctx, config, event.companyId);
+        if (!effectiveConfig.notifyOnAgentRunStarted) return;
         await enrichAgentName(event);
         await notify(event, formatAgentRunStarted);
       });
     }
     if (config.notifyOnAgentRunFinished) {
       ctx.events.on("agent.run.finished", async (event: PluginEvent) => {
+        const effectiveConfig = await resolveConfig(ctx, config, event.companyId);
+        if (!effectiveConfig.notifyOnAgentRunFinished) return;
         await enrichAgentName(event);
         await notify(event, formatAgentRunFinished);
       });
@@ -764,7 +799,9 @@ const plugin = definePlugin({
 
         const companies = await ctx.companies.list();
         for (const company of companies) {
-          const chatId = await resolveChat(ctx, company.id, config.digestChatId || config.defaultChatId);
+          const effectiveConfig = await resolveConfig(ctx, config, company.id);
+          const effectivePublicUrl = effectiveConfig.paperclipPublicUrl || effectiveConfig.paperclipBaseUrl || publicUrl;
+          const chatId = await resolveChat(ctx, company.id, effectiveConfig.digestChatId || effectiveConfig.defaultChatId);
           if (!chatId) continue;
 
           try {
@@ -805,7 +842,7 @@ const plugin = definePlugin({
             const formatIssueItem = (i: Issue) => {
               const id = i.identifier ?? i.id;
               const idText = issuePrefix
-                ? `[${escapeMarkdownV2(id)}](${publicUrl}/${issuePrefix}/issues/${id})`
+                ? `[${escapeMarkdownV2(id)}](${effectivePublicUrl}/${issuePrefix}/issues/${id})`
                 : escapeMarkdownV2(id);
               return `  ${idText} \\- ${escapeMarkdownV2(i.title)}`;
             };
@@ -823,7 +860,7 @@ const plugin = definePlugin({
               for (const i of blocked.slice(0, 10)) lines.push(formatIssueItem(i));
             }
 
-            const digestThreadId = await resolveDigestThreadId(ctx, token, chatId, config.digestTopicId);
+            const digestThreadId = await resolveDigestThreadId(ctx, token, chatId, effectiveConfig.digestTopicId);
 
             await sendMessage(ctx, token, chatId, lines.join("\n"), {
               parseMode: "MarkdownV2",
@@ -841,7 +878,7 @@ const plugin = definePlugin({
               ctx,
               token,
               chatId,
-              config.errorsTopicId || config.digestTopicId,
+              effectiveConfig.errorsTopicId || effectiveConfig.digestTopicId,
             );
 
             await sendMessage(ctx, token, chatId, text, {
@@ -897,14 +934,15 @@ const plugin = definePlugin({
       },
     }, async (params: unknown, runCtx) => {
       const p = params as Record<string, unknown>;
+      const effectiveConfig = await resolveConfig(ctx, config, runCtx.companyId);
       const escalationId = crypto.randomUUID();
-      const timeoutMs = config.escalationTimeoutMs || 900000;
-      const defaultAction = config.escalationDefaultAction || "defer";
+      const timeoutMs = effectiveConfig.escalationTimeoutMs || 900000;
+      const defaultAction = effectiveConfig.escalationDefaultAction || "defer";
 
       const resolvedEscalationChatId = await resolveChat(
         ctx,
         runCtx.companyId,
-        config.escalationChatId,
+        effectiveConfig.escalationChatId,
       );
       if (!resolvedEscalationChatId) {
         ctx.logger.warn("Escalation received but no escalationChatId configured");
@@ -937,8 +975,8 @@ const plugin = definePlugin({
       await escalationManager.create(ctx, token, escalationEvent, resolvedEscalationChatId);
 
       // Send hold message to the originating chat if configured
-      if (config.escalationHoldMessage && escalationEvent.originChatId) {
-        const holdText = escapeMarkdownV2(config.escalationHoldMessage);
+      if (effectiveConfig.escalationHoldMessage && escalationEvent.originChatId) {
+        const holdText = escapeMarkdownV2(effectiveConfig.escalationHoldMessage);
         await sendMessage(ctx, token, escalationEvent.originChatId, holdText, {
           parseMode: "MarkdownV2",
           messageThreadId: escalationEvent.originThreadId ? Number(escalationEvent.originThreadId) : undefined,
@@ -1091,8 +1129,10 @@ async function handleUpdate(
 
   if (update.callback_query) {
     const companyId = await resolveCallbackCompanyId(ctx, update.callback_query);
-    const boardApiToken = await resolveBoardApiToken(ctx, config, companyId);
-    await handleCallbackQuery(ctx, token, update.callback_query, baseUrl, boardApiToken);
+    const effectiveConfig = await resolveConfig(ctx, config, companyId);
+    const effectiveBaseUrl = effectiveConfig.paperclipBaseUrl || baseUrl;
+    const boardApiToken = await resolveBoardApiToken(ctx, effectiveConfig, companyId);
+    await handleCallbackQuery(ctx, token, update.callback_query, effectiveBaseUrl, boardApiToken);
     return;
   }
 
@@ -1106,11 +1146,13 @@ async function handleUpdate(
   const hasMedia = !!(msg.voice || msg.audio || msg.video_note || msg.document || msg.photo);
   if (hasMedia) {
     const companyId = await resolveCompanyId(ctx, chatId);
+    const effectiveConfig = await resolveConfig(ctx, config, companyId);
+    const effectivePublicUrl = effectiveConfig.paperclipPublicUrl || effectiveConfig.paperclipBaseUrl || publicUrl;
     const handled = await handleMediaMessage(ctx, token, msg as Parameters<typeof handleMediaMessage>[2], {
-      briefAgentId: config.briefAgentId ?? "",
-      briefAgentChatIds: config.briefAgentChatIds ?? [],
-      transcriptionApiKeyRef: config.transcriptionApiKeyRef ?? "",
-      publicUrl,
+      briefAgentId: effectiveConfig.briefAgentId ?? "",
+      briefAgentChatIds: effectiveConfig.briefAgentChatIds ?? [],
+      transcriptionApiKeyRef: effectiveConfig.transcriptionApiKeyRef ?? "",
+      publicUrl: effectivePublicUrl,
     }, companyId);
     if (handled) return;
   }
@@ -1136,6 +1178,9 @@ async function handleUpdate(
     const command = fullCommand.replace(/^\//, "").replace(/@.*$/, "");
     const args = text.slice(botCommand.offset + botCommand.length).trim();
     const companyId = await resolveCompanyId(ctx, chatId);
+    const effectiveConfig = await resolveConfig(ctx, config, companyId);
+    const effectiveBaseUrl = effectiveConfig.paperclipBaseUrl || baseUrl;
+    const effectivePublicUrl = effectiveConfig.paperclipPublicUrl || effectiveBaseUrl;
 
     // Phase 4: Check custom commands first
     if (command === "commands") {
@@ -1147,8 +1192,8 @@ async function handleUpdate(
     if (handledCustom) return;
 
     // Built-in commands
-    const boardApiToken = command === "approve" ? await resolveBoardApiToken(ctx, config, companyId) : undefined;
-    await handleCommand(ctx, token, chatId, command, args, threadId, baseUrl, publicUrl, companyId, boardApiToken, config.maxAgentsPerThread);
+    const boardApiToken = command === "approve" ? await resolveBoardApiToken(ctx, effectiveConfig, companyId) : undefined;
+    await handleCommand(ctx, token, chatId, command, args, threadId, effectiveBaseUrl, effectivePublicUrl, companyId, boardApiToken, effectiveConfig.maxAgentsPerThread);
     return;
   }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -157,6 +157,26 @@ function asNonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 
+async function resolveConfig(
+  ctx: PluginContext,
+  fallback: TelegramConfig,
+  companyId?: string | null,
+): Promise<TelegramConfig> {
+  try {
+    const getConfig = ctx.config.get as unknown as (
+      params?: { companyId?: string | null },
+    ) => Promise<Record<string, unknown>>;
+    const scopedConfig = await getConfig(companyId ? { companyId } : undefined);
+    return { ...fallback, ...scopedConfig } as unknown as TelegramConfig;
+  } catch (err) {
+    ctx.logger.warn("Failed to load scoped Telegram plugin config; using startup config", {
+      companyId,
+      error: String(err),
+    });
+    return fallback;
+  }
+}
+
 function normalizeBoardAccessState(value: unknown): TelegramBoardAccessState {
   const record = isRecord(value) ? value : {};
   return {
@@ -478,10 +498,11 @@ const plugin = definePlugin({
       overrideChatId?: string,
       overrideTopicId?: string,
     ) => {
+      const effectiveConfig = await resolveConfig(ctx, config, event.companyId);
       const chatId = await resolveChat(
         ctx,
         event.companyId,
-        overrideChatId || config.defaultChatId,
+        overrideChatId || effectiveConfig.defaultChatId,
       );
       if (!chatId) return;
       const linksOpts = await resolveIssueLinksOpts(event.companyId);
@@ -489,7 +510,7 @@ const plugin = definePlugin({
 
       let messageThreadId = parseTopicId(overrideTopicId);
       if (!messageThreadId) {
-        messageThreadId = await resolveNotificationThreadId(ctx, chatId, event, config.topicRouting);
+        messageThreadId = await resolveNotificationThreadId(ctx, chatId, event, effectiveConfig.topicRouting);
       }
 
       if (messageThreadId) {
@@ -554,14 +575,18 @@ const plugin = definePlugin({
     };
 
     if (config.notifyOnIssueCreated) {
-      ctx.events.on("issue.created", (event: PluginEvent) =>
-        notify(event, formatIssueCreated),
-      );
+      ctx.events.on("issue.created", async (event: PluginEvent) => {
+        const effectiveConfig = await resolveConfig(ctx, config, event.companyId);
+        if (!effectiveConfig.notifyOnIssueCreated) return;
+        await notify(event, formatIssueCreated);
+      });
     }
 
     if (config.notifyOnIssueDone) {
       const doneDedupe = makeUpdateDedupe();
       ctx.events.on("issue.updated", async (event: PluginEvent) => {
+        const effectiveConfig = await resolveConfig(ctx, config, event.companyId);
+        if (!effectiveConfig.notifyOnIssueDone) return;
         const payload = event.payload as Record<string, unknown>;
         if (payload.status !== "done") return;
         if (!doneDedupe(`done|${event.entityId}`)) return;
@@ -592,6 +617,8 @@ const plugin = definePlugin({
       const assignmentDedupe = makeUpdateDedupe();
 
       ctx.events.on("issue.updated", async (event: PluginEvent) => {
+        const effectiveConfig = await resolveConfig(ctx, config, event.companyId);
+        if (!effectiveConfig.notifyOnIssueAssigned) return;
         const payload = event.payload as Record<string, unknown>;
         const prev = (payload._previous as Record<string, unknown> | undefined) ?? {};
 
@@ -601,7 +628,7 @@ const plugin = definePlugin({
           "assigneeAgentId" in payload && payload.assigneeAgentId !== prev.assigneeAgentId;
         if (!userChanged && !agentChanged) return;
 
-        if (config.onlyNotifyIfAssignedTo && payload.assigneeUserId !== config.onlyNotifyIfAssignedTo) {
+        if (effectiveConfig.onlyNotifyIfAssignedTo && payload.assigneeUserId !== effectiveConfig.onlyNotifyIfAssignedTo) {
           return;
         }
 
@@ -632,7 +659,9 @@ const plugin = definePlugin({
 
     if (config.notifyOnApprovalCreated) {
       ctx.events.on("approval.created", async (event: PluginEvent) => {
-        if (!shouldNotifyApproval(event, config.onlyNotifyBoardApprovals)) return;
+        const effectiveConfig = await resolveConfig(ctx, config, event.companyId);
+        if (!effectiveConfig.notifyOnApprovalCreated) return;
+        if (!shouldNotifyApproval(event, effectiveConfig.onlyNotifyBoardApprovals)) return;
         const payload = event.payload as Record<string, unknown>;
         // Enrich with linked issue details (event only has issueIds)
         const issueIds = Array.isArray(payload.issueIds) ? payload.issueIds as string[] : [];
@@ -672,13 +701,15 @@ const plugin = definePlugin({
             ? `${approvalType} — ${agentLabel}`
             : approvalType;
         }
-        await notify(event, formatApprovalCreated, config.approvalsChatId, config.approvalsTopicId);
+        await notify(event, formatApprovalCreated, effectiveConfig.approvalsChatId, effectiveConfig.approvalsTopicId);
       });
     }
 
     if (config.notifyOnAgentError) {
       const agentErrorDedupe = makeUpdateDedupe(AGENT_ERROR_DEDUPLICATION_WINDOW_MS, 1000);
       ctx.events.on("agent.run.failed", async (event: PluginEvent) => {
+        const effectiveConfig = await resolveConfig(ctx, config, event.companyId);
+        if (!effectiveConfig.notifyOnAgentError) return;
         const payload = event.payload as Record<string, unknown>;
         const agentId = String(payload.agentId ?? event.entityId);
         if (payload.agentId && !payload.agentName) {
@@ -705,7 +736,7 @@ const plugin = definePlugin({
         const errorMessage = normalizeAgentErrorMessage(payload.error ?? payload.message);
         const dedupeKey = ["agent.run.failed", event.companyId, agentId, errorMessage].join(":");
         if (!agentErrorDedupe(dedupeKey)) return;
-        await notify(event, formatAgentError, config.errorsChatId, config.errorsTopicId);
+        await notify(event, formatAgentError, effectiveConfig.errorsChatId, effectiveConfig.errorsTopicId);
       });
     }
 
@@ -721,12 +752,16 @@ const plugin = definePlugin({
 
     if (config.notifyOnAgentRunStarted) {
       ctx.events.on("agent.run.started", async (event: PluginEvent) => {
+        const effectiveConfig = await resolveConfig(ctx, config, event.companyId);
+        if (!effectiveConfig.notifyOnAgentRunStarted) return;
         await enrichAgentName(event);
         await notify(event, formatAgentRunStarted);
       });
     }
     if (config.notifyOnAgentRunFinished) {
       ctx.events.on("agent.run.finished", async (event: PluginEvent) => {
+        const effectiveConfig = await resolveConfig(ctx, config, event.companyId);
+        if (!effectiveConfig.notifyOnAgentRunFinished) return;
         await enrichAgentName(event);
         await notify(event, formatAgentRunFinished);
       });
@@ -791,7 +826,9 @@ const plugin = definePlugin({
 
         const companies = await ctx.companies.list();
         for (const company of companies) {
-          const chatId = await resolveChat(ctx, company.id, config.digestChatId || config.defaultChatId);
+          const effectiveConfig = await resolveConfig(ctx, config, company.id);
+          const effectivePublicUrl = effectiveConfig.paperclipPublicUrl || effectiveConfig.paperclipBaseUrl || publicUrl;
+          const chatId = await resolveChat(ctx, company.id, effectiveConfig.digestChatId || effectiveConfig.defaultChatId);
           if (!chatId) continue;
 
           try {
@@ -832,7 +869,7 @@ const plugin = definePlugin({
             const formatIssueItem = (i: Issue) => {
               const id = i.identifier ?? i.id;
               const idText = issuePrefix
-                ? `[${escapeMarkdownV2(id)}](${publicUrl}/${issuePrefix}/issues/${id})`
+                ? `[${escapeMarkdownV2(id)}](${effectivePublicUrl}/${issuePrefix}/issues/${id})`
                 : escapeMarkdownV2(id);
               return `  ${idText} \\- ${escapeMarkdownV2(i.title)}`;
             };
@@ -850,7 +887,7 @@ const plugin = definePlugin({
               for (const i of blocked.slice(0, 10)) lines.push(formatIssueItem(i));
             }
 
-            const digestThreadId = await resolveDigestThreadId(ctx, token, chatId, config.digestTopicId);
+            const digestThreadId = await resolveDigestThreadId(ctx, token, chatId, effectiveConfig.digestTopicId);
 
             await sendMessage(ctx, token, chatId, lines.join("\n"), {
               parseMode: "MarkdownV2",
@@ -868,7 +905,7 @@ const plugin = definePlugin({
               ctx,
               token,
               chatId,
-              config.errorsTopicId || config.digestTopicId,
+              effectiveConfig.errorsTopicId || effectiveConfig.digestTopicId,
             );
 
             await sendMessage(ctx, token, chatId, text, {
@@ -924,14 +961,15 @@ const plugin = definePlugin({
       },
     }, async (params: unknown, runCtx) => {
       const p = params as Record<string, unknown>;
+      const effectiveConfig = await resolveConfig(ctx, config, runCtx.companyId);
       const escalationId = crypto.randomUUID();
-      const timeoutMs = config.escalationTimeoutMs || 900000;
-      const defaultAction = config.escalationDefaultAction || "defer";
+      const timeoutMs = effectiveConfig.escalationTimeoutMs || 900000;
+      const defaultAction = effectiveConfig.escalationDefaultAction || "defer";
 
       const resolvedEscalationChatId = await resolveChat(
         ctx,
         runCtx.companyId,
-        config.escalationChatId,
+        effectiveConfig.escalationChatId,
       );
       if (!resolvedEscalationChatId) {
         ctx.logger.warn("Escalation received but no escalationChatId configured");
@@ -964,8 +1002,8 @@ const plugin = definePlugin({
       await escalationManager.create(ctx, token, escalationEvent, resolvedEscalationChatId);
 
       // Send hold message to the originating chat if configured
-      if (config.escalationHoldMessage && escalationEvent.originChatId) {
-        const holdText = escapeMarkdownV2(config.escalationHoldMessage);
+      if (effectiveConfig.escalationHoldMessage && escalationEvent.originChatId) {
+        const holdText = escapeMarkdownV2(effectiveConfig.escalationHoldMessage);
         await sendMessage(ctx, token, escalationEvent.originChatId, holdText, {
           parseMode: "MarkdownV2",
           messageThreadId: escalationEvent.originThreadId ? Number(escalationEvent.originThreadId) : undefined,
@@ -1118,8 +1156,10 @@ export async function handleUpdate(
 
   if (update.callback_query) {
     const companyId = await resolveCallbackCompanyId(ctx, update.callback_query);
-    const boardApiToken = await resolveBoardApiToken(ctx, config, companyId);
-    await handleCallbackQuery(ctx, token, update.callback_query, baseUrl, boardApiToken);
+    const effectiveConfig = await resolveConfig(ctx, config, companyId);
+    const effectiveBaseUrl = effectiveConfig.paperclipBaseUrl || baseUrl;
+    const boardApiToken = await resolveBoardApiToken(ctx, effectiveConfig, companyId);
+    await handleCallbackQuery(ctx, token, update.callback_query, effectiveBaseUrl, boardApiToken);
     return;
   }
 
@@ -1134,11 +1174,13 @@ export async function handleUpdate(
   if (hasMedia) {
     const companyId = await resolveCompanyIdOrNull(ctx, chatId);
     if (companyId) {
+      const effectiveConfig = await resolveConfig(ctx, config, companyId);
+      const effectivePublicUrl = effectiveConfig.paperclipPublicUrl || effectiveConfig.paperclipBaseUrl || publicUrl;
       const handled = await handleMediaMessage(ctx, token, msg as Parameters<typeof handleMediaMessage>[2], {
-        briefAgentId: config.briefAgentId ?? "",
-        briefAgentChatIds: config.briefAgentChatIds ?? [],
-        transcriptionApiKeyRef: config.transcriptionApiKeyRef ?? "",
-        publicUrl,
+        briefAgentId: effectiveConfig.briefAgentId ?? "",
+        briefAgentChatIds: effectiveConfig.briefAgentChatIds ?? [],
+        transcriptionApiKeyRef: effectiveConfig.transcriptionApiKeyRef ?? "",
+        publicUrl: effectivePublicUrl,
       }, companyId);
       if (handled) return;
     } else {
@@ -1173,6 +1215,9 @@ export async function handleUpdate(
     // undefined on unlinked chats: /connect and /help still work, and the
     // company-scoped handlers answer with their "not linked" guidance.
     const companyId = (await resolveCompanyIdOrNull(ctx, chatId)) ?? undefined;
+    const effectiveConfig = companyId ? await resolveConfig(ctx, config, companyId) : config;
+    const effectiveBaseUrl = effectiveConfig.paperclipBaseUrl || baseUrl;
+    const effectivePublicUrl = effectiveConfig.paperclipPublicUrl || effectiveBaseUrl;
 
     // Phase 4: Check custom commands first
     if (command === "commands") {
@@ -1184,8 +1229,8 @@ export async function handleUpdate(
     if (handledCustom) return;
 
     // Built-in commands
-    const boardApiToken = command === "approve" ? await resolveBoardApiToken(ctx, config, companyId) : undefined;
-    await handleCommand(ctx, token, chatId, command, args, threadId, baseUrl, publicUrl, companyId, boardApiToken, config.maxAgentsPerThread);
+    const boardApiToken = command === "approve" ? await resolveBoardApiToken(ctx, effectiveConfig, companyId) : undefined;
+    await handleCommand(ctx, token, chatId, command, args, threadId, effectiveBaseUrl, effectivePublicUrl, companyId, boardApiToken, effectiveConfig.maxAgentsPerThread);
     return;
   }
 

--- a/tests/config-compat.test.ts
+++ b/tests/config-compat.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+import { loadStartupConfig, resolveCompatibleConfig } from "../src/config-compat.js";
+
+function createContext(configGet: (...args: unknown[]) => Promise<Record<string, unknown>>) {
+  return {
+    config: { get: configGet },
+    logger: {
+      warn: vi.fn(),
+    },
+  } as any;
+}
+
+describe("loadStartupConfig", () => {
+  it("merges startup config with defaults", async () => {
+    const ctx = createContext(async () => ({ enableCommands: true }));
+
+    await expect(loadStartupConfig(ctx, {
+      enableCommands: false,
+      telegramBotTokenRef: "",
+    })).resolves.toEqual({
+      enableCommands: true,
+      telegramBotTokenRef: "",
+    });
+  });
+
+  it("falls back to defaults when startup config cannot load", async () => {
+    const ctx = createContext(async () => {
+      throw new Error("config unavailable");
+    });
+    const fallback = { telegramBotTokenRef: "global-secret" };
+
+    await expect(loadStartupConfig(ctx, fallback)).resolves.toEqual(fallback);
+    expect(ctx.logger.warn).toHaveBeenCalledWith(
+      "Failed to load Telegram plugin config; using defaults",
+      expect.objectContaining({ companyId: null }),
+    );
+  });
+});
+
+describe("resolveCompatibleConfig", () => {
+  it("uses company-scoped config when Paperclip supports it", async () => {
+    const ctx = createContext(async (params) => (
+      params && typeof params === "object" && "companyId" in params
+        ? { defaultChatId: "company-chat" }
+        : { defaultChatId: "global-chat" }
+    ));
+
+    await expect(resolveCompatibleConfig(ctx, {
+      defaultChatId: "fallback-chat",
+      telegramBotTokenRef: "global-secret",
+    }, "company-1")).resolves.toEqual({
+      defaultChatId: "company-chat",
+      telegramBotTokenRef: "global-secret",
+    });
+  });
+
+  it("falls back to global config when scoped config is unsupported", async () => {
+    const ctx = createContext(async (params) => {
+      if (params) throw new Error("scoped plugin config unsupported");
+      return { defaultChatId: "global-chat" };
+    });
+    const fallback = {
+      defaultChatId: "global-chat",
+      telegramBotTokenRef: "global-secret",
+    };
+
+    await expect(resolveCompatibleConfig(ctx, fallback, "company-1")).resolves.toEqual(fallback);
+    expect(ctx.logger.warn).toHaveBeenCalledWith(
+      "Company-scoped Telegram plugin config unavailable; using global config",
+      expect.objectContaining({ companyId: "company-1" }),
+    );
+  });
+});

--- a/tests/formatters.test.ts
+++ b/tests/formatters.test.ts
@@ -233,6 +233,18 @@ describe("formatAgentRunStarted", () => {
     const msg = formatAgentRunStarted(mockEvent());
     expect(msg.options.disableNotification).toBe(true);
   });
+
+  it("includes issue identifier and run_id", () => {
+    const msg = formatAgentRunStarted(mockEvent({
+      issueIdentifier: "PAC-175",
+      runId: "run-456",
+    }));
+    expect(msg.text).toContain("started a new run");
+    expect(msg.text).toContain("*PAC\\-175*");
+    expect(msg.text).toContain("\nrun\\_id: `run\\-456`");
+    expect(msg.text).not.toContain("\n\nrun\\_id");
+    expect(msg.text).not.toContain("issue\\_id");
+  });
 });
 
 describe("formatAgentRunFinished", () => {
@@ -245,5 +257,17 @@ describe("formatAgentRunFinished", () => {
   it("disables notification", () => {
     const msg = formatAgentRunFinished(mockEvent());
     expect(msg.options.disableNotification).toBe(true);
+  });
+
+  it("includes issue identifier and run_id", () => {
+    const msg = formatAgentRunFinished(mockEvent({
+      issueIdentifier: "PAC-175",
+      runId: "run-456",
+    }));
+    expect(msg.text).toContain("completed successfully");
+    expect(msg.text).toContain("*PAC\\-175*");
+    expect(msg.text).toContain("\nrun\\_id: `run\\-456`");
+    expect(msg.text).not.toContain("\n\nrun\\_id");
+    expect(msg.text).not.toContain("issue\\_id");
   });
 });

--- a/tests/media-pipeline.test.ts
+++ b/tests/media-pipeline.test.ts
@@ -184,6 +184,7 @@ describe("Audio type detection", () => {
 
     // Should show transcription preview
     expect(sentMessages.some(m => m.text.includes("Transcription"))).toBe(true);
+    expect(ctx.secrets.resolve).toHaveBeenCalledWith("openai-key", "company-1");
   });
 
   it("detects audio messages as audio", async () => {

--- a/tests/polling-dispatch.test.ts
+++ b/tests/polling-dispatch.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import {
+  getTelegramUpdateChatId,
+  selectTelegramRuntimeForUpdate,
+  telegramRuntimeChatIds,
+} from "../src/polling-dispatch.js";
+
+const pacoRuntime = {
+  companyId: "paco",
+  config: {
+    defaultChatId: "-1003800613668",
+    allowedTelegramChatIds: ["-1003800613668"],
+    errorsChatId: "-1003800613668",
+  },
+};
+
+const superpowersRuntime = {
+  companyId: "superpowers",
+  config: {
+    defaultChatId: "-1004295856824",
+    allowedTelegramChatIds: ["-1004295856824"],
+    digestChatId: "-1004295856824",
+  },
+};
+
+describe("Telegram polling dispatch", () => {
+  it("extracts message and callback chat ids", () => {
+    expect(getTelegramUpdateChatId({
+      message: { chat: { id: -1004295856824 } },
+    })).toBe("-1004295856824");
+
+    expect(getTelegramUpdateChatId({
+      callback_query: {
+        message: { chat: { id: -1003800613668 } },
+      },
+    })).toBe("-1003800613668");
+  });
+
+  it("collects all configured chat ids for a runtime", () => {
+    expect([...telegramRuntimeChatIds({
+      defaultChatId: "-1001",
+      approvalsChatId: "-1002",
+      errorsChatId: "-1003",
+      digestChatId: "-1004",
+      escalationChatId: "-1005",
+      allowedTelegramChatIds: ["-1006"],
+      briefAgentChatIds: ["-1007"],
+    })].sort()).toEqual([
+      "-1001",
+      "-1002",
+      "-1003",
+      "-1004",
+      "-1005",
+      "-1006",
+      "-1007",
+    ]);
+  });
+
+  it("selects the matching company runtime before allowlist handling", () => {
+    const runtime = selectTelegramRuntimeForUpdate(
+      [pacoRuntime, superpowersRuntime],
+      {
+        update_id: 77604974,
+        message: { chat: { id: -1004295856824 } },
+      },
+    );
+
+    expect(runtime?.companyId).toBe("superpowers");
+  });
+
+  it("does not route an unmatched chat when multiple companies share one bot token", () => {
+    const runtime = selectTelegramRuntimeForUpdate(
+      [pacoRuntime, superpowersRuntime],
+      {
+        update_id: 77604975,
+        message: { chat: { id: -1009999999999 } },
+      },
+    );
+
+    expect(runtime).toBeNull();
+  });
+
+  it("keeps single-company fallback behavior for legacy configs with sparse chat metadata", () => {
+    const runtime = selectTelegramRuntimeForUpdate(
+      [pacoRuntime],
+      {
+        update_id: 77604976,
+        message: { chat: { id: -1009999999999 } },
+      },
+    );
+
+    expect(runtime?.companyId).toBe("paco");
+  });
+});


### PR DESCRIPTION
## Summary

- read Telegram plugin configuration through company-scoped host APIs
- keep setup available when scoped configuration is temporarily unavailable
- run Telegram workflows with the matching company context
- dispatch inbound polling updates by the configured company chat
- preserve scoped token health handling on the current `v0.7.1` codebase

## Why

A single global Telegram runtime cannot safely serve multiple Paperclip companies when each company has its own Telegram chat and configuration. This change makes configuration, polling dispatch, commands, notifications, approvals, media intake, digests, and ACP handling consistently company-aware.

The branch is refreshed onto the current upstream `main` following `v0.7.1`. The narrower disabled-secret-resolution resilience change was split into #66 and is already merged; it is not duplicated here.

Related context: #61 and #63.

## Validation

- `npm run typecheck`
- `npm test` — 18 files, 239 tests passed
- `npm run build`
