### PR TITLE
fix: handle disabled Paperclip secret resolution gracefully

### DIFF
--- a/src/runtime-token.ts
+++ b/src/runtime-token.ts
@@ -1,0 +1,36 @@
+import type { PluginContext, PluginHealthDiagnostics } from "@paperclipai/plugin-sdk";
+
+export type TelegramRuntimeHealth = PluginHealthDiagnostics & {
+  message?: string;
+  details?: Record<string, unknown>;
+};
+
+export const SECRET_RESOLUTION_DISABLED_MESSAGE = "Plugin secret references are disabled until company-scoped plugin config lands";
+export const SECRET_RESOLUTION_ISSUE_URL = "https://github.com/mvanhorn/paperclip-plugin-telegram/issues/63";
+
+export async function resolveStartupTelegramBotToken(
+  ctx: PluginContext,
+  tokenRef: string,
+  setHealth: (health: TelegramRuntimeHealth) => void,
+): Promise<string | undefined> {
+  try {
+    const token = await ctx.secrets.resolve(tokenRef);
+    setHealth({ status: "ok" });
+    return token;
+  } catch (err) {
+    const error = String(err);
+    setHealth({
+      status: "degraded",
+      message: SECRET_RESOLUTION_DISABLED_MESSAGE,
+      details: {
+        issue: "paperclip-plugin-secret-resolution-disabled",
+        reference: SECRET_RESOLUTION_ISSUE_URL,
+      },
+    });
+    ctx.logger.error("Telegram plugin cannot resolve bot token secret; runtime features are disabled", {
+      error,
+      reference: SECRET_RESOLUTION_ISSUE_URL,
+    });
+    return undefined;
+  }
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -50,6 +50,7 @@ import { isTelegramUpdateAllowed, validateTelegramAllowlists } from "./allowlist
 import { validateSecretRefFields } from "./secret-ref-validation.js";
 import { shouldNotifyApproval } from "./approval-routing.js";
 import { buildPaperclipAuthHeaders, fetchPaperclipApi } from "./paperclip-api.js";
+import { resolveStartupTelegramBotToken, type TelegramRuntimeHealth } from "./runtime-token.js";
 
 type TelegramConfig = {
   telegramBotTokenRef: string;
@@ -145,6 +146,8 @@ type TelegramBoardAccessState = {
 type TelegramBoardAccessRegistration = TelegramBoardAccessState & {
   configured: boolean;
 };
+
+let runtimeHealth: TelegramRuntimeHealth = { status: "ok" };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -361,7 +364,14 @@ const plugin = definePlugin({
       return;
     }
 
-    const token = await ctx.secrets.resolve(config.telegramBotTokenRef);
+    const token = await resolveStartupTelegramBotToken(ctx, config.telegramBotTokenRef, (health) => {
+      runtimeHealth = health;
+    });
+    if (!token) {
+      ctx.logger.warn("Telegram plugin runtime disabled because bot token could not be resolved");
+      return;
+    }
+    const telegramToken = token;
 
     // --- Register bot commands with Telegram ---
     if (config.enableCommands) {
@@ -406,7 +416,7 @@ const plugin = definePlugin({
             lastUpdateId = await processTelegramUpdateBatch({
               updates: data.result,
               lastUpdateId,
-              handleUpdate: (update) => handleUpdate(ctx, token, config, update, baseUrl, publicUrl),
+              handleUpdate: (update) => handleUpdate(ctx, telegramToken, config, update, baseUrl, publicUrl),
               persistOffset: (updateId) => persistTelegramUpdateOffset(ctx, updateId),
               logger: ctx.logger,
             });
@@ -1065,7 +1075,7 @@ const plugin = definePlugin({
   },
 
   async onHealth(): Promise<PluginHealthDiagnostics> {
-    return { status: "ok" };
+    return runtimeHealth;
   },
 });
 

--- a/tests/runtime-token.test.ts
+++ b/tests/runtime-token.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PluginContext } from "@paperclipai/plugin-sdk";
+import {
+  SECRET_RESOLUTION_DISABLED_MESSAGE,
+  SECRET_RESOLUTION_ISSUE_URL,
+  resolveStartupTelegramBotToken,
+  type TelegramRuntimeHealth,
+} from "../src/runtime-token.js";
+
+function makeContext(resolve: () => Promise<string>): PluginContext {
+  return {
+    secrets: { resolve },
+    logger: {
+      error: vi.fn(),
+    },
+  } as unknown as PluginContext;
+}
+
+describe("resolveStartupTelegramBotToken", () => {
+  it("returns the resolved bot token and marks health ok", async () => {
+    const health: TelegramRuntimeHealth[] = [];
+    const ctx = makeContext(async () => "bot-token");
+
+    const token = await resolveStartupTelegramBotToken(ctx, "secret-ref", (next) => health.push(next));
+
+    expect(token).toBe("bot-token");
+    expect(health).toEqual([{ status: "ok" }]);
+  });
+
+  it("degrades health and does not throw when Paperclip secret resolution fails", async () => {
+    const health: TelegramRuntimeHealth[] = [];
+    const ctx = makeContext(async () => {
+      throw new Error(SECRET_RESOLUTION_DISABLED_MESSAGE);
+    });
+
+    const token = await resolveStartupTelegramBotToken(ctx, "secret-ref", (next) => health.push(next));
+
+    expect(token).toBeUndefined();
+    expect(health).toEqual([{
+      status: "degraded",
+      message: SECRET_RESOLUTION_DISABLED_MESSAGE,
+      details: {
+        issue: "paperclip-plugin-secret-resolution-disabled",
+        reference: SECRET_RESOLUTION_ISSUE_URL,
+      },
+    }]);
+    expect(ctx.logger.error).toHaveBeenCalledWith(
+      "Telegram plugin cannot resolve bot token secret; runtime features are disabled",
+      {
+        error: `Error: ${SECRET_RESOLUTION_DISABLED_MESSAGE}`,
+        reference: SECRET_RESOLUTION_ISSUE_URL,
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Handle Paperclip builds where plugin secret resolution is currently disabled by the host.

Instead of letting worker setup fail when `ctx.secrets.resolve(config.telegramBotTokenRef)` throws, the Telegram plugin now:

- records degraded plugin health with a clear diagnostic pointing to #63
- logs the secret-resolution failure explicitly
- skips Telegram runtime startup when no bot token can be resolved
- avoids registering polling, Telegram commands, event handlers, tools, and scheduled jobs without a usable token

This keeps the plugin lifecycle stable and prevents scheduled job noise while the host-side resolver remains unavailable.

## Non-goals

- Does not restore plugin secret resolution. That still needs Paperclip core support.
- Does not add company-scoped secret resolution or depend on Paperclip core PRs.
- Does not add a plaintext Telegram bot token fallback.
- Does not change digest scheduling, approval formatting, polling dispatch, or multi-company routing.

## Validation

- `npm run typecheck`
- `npm test`
- `npm run build`

Fixes #63.