### PR TITLE
fix: make Telegram agent notifications human-readable

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -1,0 +1,14 @@
+# Concepts
+
+Shared domain vocabulary for this project — entities, named processes, and status concepts with project-specific meaning. Seeded with core domain vocabulary, then accretes as ce-compound and ce-compound-refresh process learnings; direct edits are fine. Glossary only, not a spec or catch-all.
+
+## Telegram notification domain
+
+### Paperclip Agent
+A Paperclip-controlled worker identity that owns or performs work and may emit events that the Telegram plugin turns into messages.
+
+### Agent Run
+One execution attempt by a Paperclip Agent. Run lifecycle events are useful for machine correlation and debugging, but they are usually lower signal than failures or approvals in human chat channels.
+
+### Telegram Notification
+A message sent by the plugin from Paperclip state or events into Telegram. Notifications should lead with human-readable context and reserve internal identifiers for links, metadata, or compact fallback labels.

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ This is that plugin.
 - **Issue created** - Title, description, status, priority, assignee, project fields, and a "View Issue" link
 - **Issue done** - Completion confirmation with status fields
 - **Approval requested** - Interactive **Approve** and **Reject** inline buttons. Click to act without leaving Telegram.
-- **Agent error** - Error message with warning indicator
-- **Agent run started/finished** - Lifecycle notifications
+- **Agent error** - Error message with warning indicator and human-readable agent label
+- **Agent run started/finished** - Optional lifecycle notifications, disabled by default to avoid chat spam
 
 ### Interactive approvals
 - Approve/reject inline buttons on every approval notification
@@ -194,6 +194,9 @@ Before filing a bug, confirm which Paperclip host this plugin is actually talkin
 | `enableCommands` | No | Enable bot commands (default: true) |
 | `enableInbound` | No | Route Telegram replies to issues (default: true) |
 | `onlyNotifyBoardApprovals` | No | When enabled, send Telegram approval notifications only for `request_board_approval` approvals |
+| `notifyOnAgentError` | No | Send agent failure notifications (default: true) |
+| `notifyOnAgentRunStarted` | No | Send agent run-start lifecycle notifications (default: false) |
+| `notifyOnAgentRunFinished` | No | Send agent run-finish lifecycle notifications (default: false) |
 | `allowedTelegramUserIds` | No | Optional allowlist of Telegram user IDs allowed to use commands, inbound replies, media intake, and inline buttons. Empty means any user is allowed |
 | `allowedTelegramChatIds` | No | Optional allowlist of Telegram chat IDs where commands, inbound replies, media intake, and inline buttons are accepted. Empty means any chat is allowed |
 | `topicRouting` | No | Map forum topics to projects (default: false) |

--- a/docs/solutions/developer-experience/human-readable-telegram-agent-notifications.md
+++ b/docs/solutions/developer-experience/human-readable-telegram-agent-notifications.md
@@ -1,0 +1,151 @@
+---
+title: Make Telegram agent notifications human-readable
+date: 2026-07-08
+category: developer-experience
+module: paperclip-plugin-telegram
+problem_type: developer_experience
+component: tooling
+severity: medium
+applies_when:
+  - Telegram or chat notifications render agent lifecycle events with opaque identifiers or noisy started/finished messages.
+symptoms:
+  - Direct message feed fills with agent run started and finished notifications.
+  - Primary notification label is a full UUID instead of a human-readable agent name.
+  - Lifecycle event noise hides useful status updates.
+tags: [telegram, notifications, agents, uuid-fallback, developer-experience]
+---
+
+# Make Telegram agent notifications human-readable
+
+## Context
+
+Paperclip Telegram notifications used raw agent identifiers as primary message text. In live chat, Second Vector Board notifications showed full UUID values such as `287196d3-6e28-4094-80cd-e7a3710b2ba1` before lifecycle copy like `started a new run`, `completed successfully`, and `Pi exited with code 143`.
+
+That made Telegram direct messages noisy and hard to scan. The useful information was the agent status, but the first thing the user had to parse was a 36-character machine identifier. The problem was amplified because routine run-start and run-finish events outnumber actionable failures.
+
+## Guidance
+
+Normalize agent display at the formatter boundary. Do not let raw UUID-like values reach user-facing Telegram copy.
+
+Use small helper functions in the formatter layer:
+
+```ts
+function isUuidLike(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
+}
+
+function displayAgentName(value: string): string {
+  return isUuidLike(value) ? `Agent ${value.slice(0, 8)}` : value;
+}
+```
+
+Apply the helper everywhere an agent label appears in Telegram user copy:
+
+```ts
+formatAgentError(event);
+formatAgentRunStarted(event);
+formatAgentRunFinished(event);
+```
+
+Keep lifecycle copy compact:
+
+```ts
+`${displayAgentName(agentName)} started run`;
+`✅ ${displayAgentName(agentName)} completed run`;
+```
+
+Avoid reintroducing verbose lifecycle language such as `started a new run` or `completed successfully`. Those phrases read like chat spam when many agents run.
+
+Document defaults clearly in README:
+
+- run-start notifications are optional
+- run-finish notifications are optional
+- both are disabled by default
+- agent errors use human-readable labels, including shortened UUID fallback
+
+Operational note: if a live install uses an older package than branch source, patch built `dist/` only as a temporary hotfix, then replace it with a proper package build or deploy as soon as possible.
+
+## Why This Matters
+
+Telegram DM is a high-interruption channel. Full UUID as headline forces the user to parse machine identity before understanding event meaning. Repeated lifecycle notices amplify the problem because routine starts and finishes outnumber actionable failures.
+
+A short fallback like `Agent 287196d3` preserves correlation value without flooding the UI with opaque IDs. Keeping lifecycle notifications disabled by default reserves chat for higher-signal updates. Errors still surface with enough identity to debug.
+
+Formatter-level fallback also protects every notification path. Worker-side enrichment can improve labels when `agentName` is available, but formatter fallback prevents raw UUID leakage when metadata is missing or an older event shape reaches the formatter.
+
+## When to Apply
+
+- User-facing notifications include agent IDs, run IDs, task IDs, or machine-generated UUIDs.
+- Display names may be missing and fallback comes from an internal identifier.
+- Chat, push, SMS, or desktop notifications show repeated lifecycle events.
+- Operational hotfix patches live `dist/` while source branch carries the durable fix.
+
+Do not apply this rule to audit logs, machine APIs, or copy/paste debugging surfaces where the full identifier is the useful data. In those cases, keep the full ID in metadata, logs, or expandable details, not primary notification text.
+
+## Examples
+
+Before:
+
+```text
+287196d3-6e28-4094-80cd-e7a3710b2ba1 started a new run
+287196d3-6e28-4094-80cd-e7a3710b2ba1 completed successfully
+287196d3-6e28-4094-80cd-e7a3710b2ba1 Pi exited with code 143
+```
+
+After:
+
+```text
+Agent 287196d3 started run
+✅ Agent 287196d3 completed run
+Agent 287196d3 Pi exited with code 143
+```
+
+Regression test intent:
+
+```ts
+it("does not expose full UUID fallback in agent error copy", () => {
+  const message = formatAgentError({
+    agentName: "287196d3-6e28-4094-80cd-e7a3710b2ba1",
+  });
+
+  expect(message).toContain("Agent 287196d3");
+  expect(message).not.toContain("287196d3-6e28-4094-80cd-e7a3710b2ba1");
+});
+
+it("uses compact lifecycle copy", () => {
+  expect(formatAgentRunStarted(event)).toContain("started run");
+  expect(formatAgentRunStarted(event)).not.toContain("started a new run");
+  expect(formatAgentRunFinished(event)).toContain("completed run");
+  expect(formatAgentRunFinished(event)).not.toContain("completed successfully");
+});
+```
+
+Verification used for the fixed branch:
+
+```sh
+npm run typecheck
+npm test
+npm run build
+```
+
+Live hotfix verification used:
+
+```sh
+node --check dist/formatters.js
+node --check dist/worker.js
+```
+
+Observed validation:
+
+- `npm test`: 224 tests passed; existing duplicate-key warning remained in `tests/commands.test.ts`.
+- Synthetic formatter output included `Agent 287196d3` rather than the full UUID.
+- Paperclip Mesh health returned `status=ok`.
+- Independent reviewer subagent returned no findings.
+
+## Related
+
+- `src/formatters.ts`: `isUuidLike()`, `displayAgentName()`, and Telegram message formatting.
+- `tests/formatters.test.ts`: UUID fallback and lifecycle copy regression tests.
+- `README.md`: lifecycle notification defaults and human-readable error labels.
+- Config flags: `notifyOnAgentRunStarted` and `notifyOnAgentRunFinished` default false.
+- Upstream PR: https://github.com/mvanhorn/paperclip-plugin-telegram/pull/67

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -49,6 +49,14 @@ function agentButton(agentId: string, label: string, publicUrl?: string): { text
   return null;
 }
 
+function isUuidLike(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
+}
+
+function displayAgentName(value: string): string {
+  return isUuidLike(value) ? `Agent ${value.slice(0, 8)}` : value;
+}
+
 function runButton(agentId: string, runId: string | null, publicUrl?: string): { text: string; url: string } | null {
   if (publicUrl && isExternalUrl(publicUrl) && runId) {
     return { text: "View Run ↗", url: `${publicUrl}/agents/${agentId}/runs/${runId}` };
@@ -217,7 +225,7 @@ export function formatApprovalCreated(event: PluginEvent, opts?: IssueLinksOpts)
 export function formatAgentError(event: PluginEvent, opts?: IssueLinksOpts): FormattedMessage {
   const p = event.payload as Payload;
   const agentId = String(p.agentId ?? event.entityId);
-  const agentName = String(p.agentName ?? p.name ?? agentId);
+  const agentName = displayAgentName(String(p.agentName ?? p.name ?? agentId));
   const errorMessage = String(p.error ?? p.message ?? "Unknown error");
   const runId = p.runId ? String(p.runId) : null;
   const companyName = p.companyName ? String(p.companyName) : null;
@@ -256,7 +264,7 @@ export function formatAgentError(event: PluginEvent, opts?: IssueLinksOpts): For
 export function formatAgentRunStarted(event: PluginEvent, opts?: IssueLinksOpts): FormattedMessage {
   const p = event.payload as Payload;
   const agentId = String(p.agentId ?? event.entityId);
-  const agentName = String(p.agentName ?? agentId);
+  const agentName = displayAgentName(String(p.agentName ?? agentId));
   const runId = p.runId ? String(p.runId) : null;
 
   const buttons: Array<{ text: string; url: string }> = [];
@@ -268,7 +276,7 @@ export function formatAgentRunStarted(event: PluginEvent, opts?: IssueLinksOpts)
   }
 
   return {
-    text: `${esc("▶️")} ${bold(agentName)} ${esc("started a new run")}`,
+    text: `${esc("▶️")} ${bold(agentName)} ${esc("started run")}`,
     options: {
       parseMode: "MarkdownV2",
       disableNotification: true,
@@ -280,7 +288,7 @@ export function formatAgentRunStarted(event: PluginEvent, opts?: IssueLinksOpts)
 export function formatAgentRunFinished(event: PluginEvent, opts?: IssueLinksOpts): FormattedMessage {
   const p = event.payload as Payload;
   const agentId = String(p.agentId ?? event.entityId);
-  const agentName = String(p.agentName ?? agentId);
+  const agentName = displayAgentName(String(p.agentName ?? agentId));
   const runId = p.runId ? String(p.runId) : null;
 
   const buttons: Array<{ text: string; url: string }> = [];
@@ -292,7 +300,7 @@ export function formatAgentRunFinished(event: PluginEvent, opts?: IssueLinksOpts
   }
 
   return {
-    text: `${esc("⏹️")} ${bold(agentName)} ${esc("completed successfully")}`,
+    text: `${esc("✅")} ${bold(agentName)} ${esc("completed run")}`,
     options: {
       parseMode: "MarkdownV2",
       disableNotification: true,

--- a/tests/formatters.test.ts
+++ b/tests/formatters.test.ts
@@ -216,17 +216,27 @@ describe("formatAgentError", () => {
     expect(msg.text).not.toContain("x".repeat(501));
   });
 
-  it("falls back to entityId for agent name", () => {
-    const msg = formatAgentError(mockEvent({ agentName: undefined, name: undefined }));
-    expect(msg.text).toContain("iss\\-123");
+  it("uses a compact label instead of raw UUID when agent name is missing", () => {
+    const agentId = "287196d3-6e28-4094-80cd-e7a3710b2ba1";
+    const msg = formatAgentError(mockEvent({ agentId, agentName: undefined, name: undefined }));
+    expect(msg.text).toContain("Agent 287196d3");
+    expect(msg.text).not.toContain("287196d3\\-6e28\\-4094\\-80cd\\-e7a3710b2ba1");
   });
 });
 
 describe("formatAgentRunStarted", () => {
-  it("includes agent name", () => {
+  it("uses concise human lifecycle copy", () => {
     const msg = formatAgentRunStarted(mockEvent({ agentName: "Deployer" }));
     expect(msg.text).toContain("Deployer");
-    expect(msg.text).toContain("started");
+    expect(msg.text).toContain("started run");
+    expect(msg.text).not.toContain("started a new run");
+  });
+
+  it("uses a compact label instead of raw UUID when agent name is missing", () => {
+    const agentId = "287196d3-6e28-4094-80cd-e7a3710b2ba1";
+    const msg = formatAgentRunStarted(mockEvent({ agentId, agentName: undefined }));
+    expect(msg.text).toContain("Agent 287196d3");
+    expect(msg.text).not.toContain("287196d3\\-6e28\\-4094\\-80cd\\-e7a3710b2ba1");
   });
 
   it("disables notification", () => {
@@ -236,10 +246,18 @@ describe("formatAgentRunStarted", () => {
 });
 
 describe("formatAgentRunFinished", () => {
-  it("includes agent name and completion text", () => {
+  it("uses concise human lifecycle copy", () => {
     const msg = formatAgentRunFinished(mockEvent({ agentName: "Deployer" }));
     expect(msg.text).toContain("Deployer");
-    expect(msg.text).toContain("completed");
+    expect(msg.text).toContain("completed run");
+    expect(msg.text).not.toContain("completed successfully");
+  });
+
+  it("uses a compact label instead of raw UUID when agent name is missing", () => {
+    const agentId = "287196d3-6e28-4094-80cd-e7a3710b2ba1";
+    const msg = formatAgentRunFinished(mockEvent({ agentId, agentName: undefined }));
+    expect(msg.text).toContain("Agent 287196d3");
+    expect(msg.text).not.toContain("287196d3\\-6e28\\-4094\\-80cd\\-e7a3710b2ba1");
   });
 
   it("disables notification", () => {


### PR DESCRIPTION
## Summary
- hide raw UUIDs in agent notification fallbacks behind compact labels like `Agent 287196d3`
- tighten run lifecycle copy (`started run`, `completed run`)
- document that run-start/run-finish notifications are opt-in to avoid Telegram spam

## Verification
- `npm run typecheck`
- `npm test` (224 tests passing; existing duplicate-key warning in `tests/commands.test.ts`)
- `npm run build`