### PR TITLE
chore: release v0.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paperclip-plugin-telegram",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "type": "module",
   "main": "./dist/index.js",
   "paperclipPlugin": {


### PR DESCRIPTION
## Release v0.7.1 (patch)

Ships #60 — unlinked chats no longer wedge the polling offset (poller resumed advancing past unlinked-chat updates), and the remaining `chatId`-as-`companyId` fallbacks reachable from the worker are closed. Thanks @belangertrading for the root cause.

First release through the hardened pipeline: PR-gated, CI-checked, signed tag + GitHub Release after merge, OIDC publish with provenance via `publish.yml`.

Live-bot `/status` smoke test deferred to next week per #60 thread — worker-level regression tests cover the paths this release changes.

---
<sub><em>**[@superbiche](https://github.com/superbiche)** · co-maintainer · drafted with Claude Fable 5.</em></sub>

https://claude.ai/code/session_014EtUqWXNruHzvyfeoajMpR