### PR TITLE
fix: align plugin manifest with v0.7.1

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,5 @@
 export const PLUGIN_ID = "paperclip-plugin-telegram";
-export const PLUGIN_VERSION = "0.3.0";
+export const PLUGIN_VERSION = "0.7.1";
 export const MAX_AGENTS_PER_THREAD = 5;
 
 export const DEFAULT_CONFIG = {


### PR DESCRIPTION
## Summary

Align the Telegram plugin manifest constant with the released package version:

- `PLUGIN_VERSION`: `0.3.0` -> `0.7.1`

## Why

The current upstream `package.json` reports `0.7.1`, but the generated plugin manifest still advertises `0.3.0`. Paperclip therefore displays and records a stale plugin version after installing the current release.

## Validation

- `npm run typecheck`
- `npm test` — 16 files, 228 tests passed
- `npm run build`
