### PR TITLE
fix(commands): answer /start instead of "Unknown command"

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -63,6 +63,12 @@ export async function handleCommand(
     case "approve":
       await handleApprove(ctx, token, chatId, args, messageThreadId, baseUrl, boardApiToken);
       break;
+    // /start is Telegram's own entry point — the client shows it as a button on
+    // every new chat, so it is the first thing most users ever send. Without a
+    // case here it falls through to "Unknown command: /start", which is a poor
+    // first impression of the bot. Deliberately not added to BOT_COMMANDS:
+    // Telegram treats /start as implicit and listing it clutters the menu.
+    case "start":
     case "help":
       await handleHelp(ctx, token, chatId, messageThreadId);
       break;

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -501,6 +501,40 @@ describe("resolveNotificationThreadId", () => {
   });
 });
 
+describe("/start", () => {
+  // Telegram sends /start automatically the first time anyone opens the bot,
+  // so it is the first thing every new user sees. It answered "Unknown command"
+  // — the bot's own greeting told you it was broken.
+  it("answers with help rather than an unknown-command error", async () => {
+    const ctx = mockCtx();
+    await handleCommand(ctx, "token", "123", "start", "");
+
+    expect(sentMessages.length).toBe(1);
+    expect(sentMessages[0].text).toContain("Paperclip Bot Commands");
+    expect(sentMessages[0].text).not.toContain("Unknown command");
+  });
+
+  it("answers identically to /help, since it is the same entry point", async () => {
+    const start = mockCtx();
+    await handleCommand(start, "token", "123", "start", "");
+    const startText = sentMessages[0].text;
+
+    sentMessages = [];
+    const help = mockCtx();
+    await handleCommand(help, "token", "123", "help", "");
+
+    expect(startText).toBe(sentMessages[0].text);
+  });
+
+  it("still reports genuinely unknown commands", async () => {
+    // The fix must not be "answer everything with help".
+    const ctx = mockCtx();
+    await handleCommand(ctx, "token", "123", "definitely_not_a_command", "");
+
+    expect(sentMessages[0].text).toContain("Unknown command");
+  });
+});
+
 describe("BOT_COMMANDS", () => {
   it("has all expected commands", () => {
     const names = BOT_COMMANDS.map(c => c.command);


### PR DESCRIPTION
`/start` is Telegram's own entry point — the client renders it as a button on every new chat, so it's the first thing most users send. Right now it falls through to the default branch:

```
> /start
Unknown command: /start. Try /help
```

Observed on a self-hosted instance: a new user sent `/start` **five times** before thinking to try `/help`.

## Change

One case, mapped to the existing help handler, so `/start` returns the command list.

Deliberately **not** added to `BOT_COMMANDS` — Telegram treats `/start` as implicit and listing it just clutters the command menu.

## Verification

`tsc --noEmit` clean, 228/228 tests pass. Branched off `main`, independent of any other work — nothing else is in this PR.