### PR TITLE
fix(commands): count agents by the statuses that actually occur

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -102,14 +102,23 @@ async function handleStatus(
   try {
     const companyId = resolvedCompanyId ?? await resolveCompanyId(ctx, chatId);
     const agents = await ctx.agents.list({ companyId });
-    const activeAgents = agents.filter((a: Agent) => a.status === "active");
+    // Agents report "running" or "idle" (and "paused"/"error" when unavailable).
+    // Counting `status === "active"` matched nothing, so this line always read
+    // "0/N" no matter how many agents were working.
+    const running = agents.filter((a: Agent) => a.status === "running" || a.status === "active");
+    const unavailable = agents.filter((a: Agent) => a.status === "paused" || a.status === "error");
     const issues = await ctx.issues.list({ companyId, limit: 10 });
     const doneIssues = issues.filter((i: Issue) => i.status === "done");
+
+    const agentLine =
+      `${escapeMarkdownV2("🤖")} Agents: *${running.length}* running, ` +
+      `*${escapeMarkdownV2(String(agents.length - unavailable.length))}* available` +
+      (unavailable.length > 0 ? escapeMarkdownV2(` (${unavailable.length} paused/error)`) : "");
 
     const lines = [
       escapeMarkdownV2("📊") + " *Paperclip Status*",
       "",
-      `${escapeMarkdownV2("🤖")} Active agents: *${activeAgents.length}*/${escapeMarkdownV2(String(agents.length))}`,
+      agentLine,
       `${escapeMarkdownV2("📋")} Recent issues: *${escapeMarkdownV2(String(issues.length))}* \\(${escapeMarkdownV2(String(doneIssues.length))} done\\)`,
     ];
 

--- a/tests/status-agents.test.ts
+++ b/tests/status-agents.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { Agent, PluginContext } from "@paperclipai/plugin-sdk";
+
+const sent: string[] = [];
+
+vi.mock("../src/telegram-api.js", () => ({
+  sendMessage: vi.fn(async (_c: unknown, _t: string, _chat: string, text: string) => {
+    sent.push(text);
+    return { ok: true };
+  }),
+  sendChatAction: vi.fn(async () => ({ ok: true })),
+  escapeMarkdownV2: (s: string) => s,
+}));
+
+const { handleCommand } = await import("../src/commands.js");
+
+function agent(status: string): Agent {
+  return { id: `a-${status}-${Math.random()}`, name: `Agent ${status}`, status } as Agent;
+}
+
+function makeCtx(agents: Agent[]): PluginContext {
+  return {
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    metrics: { write: vi.fn(async () => undefined) },
+    agents: { list: vi.fn(async () => agents) },
+    issues: { list: vi.fn(async () => []) },
+    state: { get: vi.fn(async () => null), set: vi.fn(async () => undefined) },
+  } as unknown as PluginContext;
+}
+
+describe("/status agent counts", () => {
+  beforeEach(() => {
+    sent.length = 0;
+  });
+
+  it("counts running agents — the old filter looked for a status that never occurs", async () => {
+    // Agents report "running"/"idle"; nothing is ever "active", so the previous
+    // `status === "active"` filter reported 0 while agents were working.
+    const ctx = makeCtx([agent("running"), agent("idle"), agent("idle")]);
+    await handleCommand(ctx, "tok", "chat-1", "status", "", undefined, undefined, undefined, "company-1");
+    expect(sent.at(-1)).toContain("1* running");
+  });
+
+  it("still counts a legacy 'active' status as running", async () => {
+    const ctx = makeCtx([agent("active"), agent("idle")]);
+    await handleCommand(ctx, "tok", "chat-1", "status", "", undefined, undefined, undefined, "company-1");
+    expect(sent.at(-1)).toContain("1* running");
+  });
+
+  it("reports availability separately from running, and flags paused/error", async () => {
+    const ctx = makeCtx([agent("running"), agent("idle"), agent("paused"), agent("error")]);
+    await handleCommand(ctx, "tok", "chat-1", "status", "", undefined, undefined, undefined, "company-1");
+    const text = sent.at(-1)!;
+    expect(text).toContain("1* running");
+    expect(text).toContain("2* available");
+    expect(text).toContain("2 paused/error");
+  });
+
+  it("omits the paused/error note when everything is healthy", async () => {
+    const ctx = makeCtx([agent("idle"), agent("idle")]);
+    await handleCommand(ctx, "tok", "chat-1", "status", "", undefined, undefined, undefined, "company-1");
+    expect(sent.at(-1)).not.toContain("paused/error");
+  });
+});


### PR DESCRIPTION
`/status` always reported `Active agents: 0/N`.

It filtered on `status === "active"`, but agents report `running` or `idle`, and `paused`/`error` when unavailable. `"active"` never occurs, so the count was structurally zero regardless of what the company was doing — observed live as `0/21` with an agent mid-run.

A count that is always zero is worse than a missing one: it reads as a working readout of an idle company.

Now reports running and available separately, and mentions paused/error only when there are any:

```
🤖 Agents: 1 running, 21 available
🤖 Agents: 1 running, 2 available (2 paused/error)
```

`"active"` is still counted as running, in case any deployment does emit it.

Covered by tests in `tests/status-agents.test.ts`. Typecheck clean, 232/232 tests pass on `main`.