### PR TITLE
fix(deps): align plugin SDK devDependency with the runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "paperclip-plugin-telegram",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "paperclip-plugin-telegram",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "devDependencies": {
-        "@paperclipai/plugin-sdk": "^2026.707.0",
-        "@paperclipai/shared": "^2026.707.0",
+        "@paperclipai/plugin-sdk": "^2026.722.0",
+        "@paperclipai/shared": "^2026.722.0",
         "@types/node": "^22.0.0",
         "@types/react": "^19.0.8",
         "react": "^19.2.5",
@@ -475,13 +475,13 @@
       "license": "MIT"
     },
     "node_modules/@paperclipai/plugin-sdk": {
-      "version": "2026.707.0",
-      "resolved": "https://registry.npmjs.org/@paperclipai/plugin-sdk/-/plugin-sdk-2026.707.0.tgz",
-      "integrity": "sha512-5pS4nG+l8k7GBvIHiuvPjWsiVX9KYG1WBD/c/DJGPBRRAuUj3Sd/PiaukAV6g/Ax94CnPS799hQLq40i09FKVg==",
+      "version": "2026.722.0",
+      "resolved": "https://registry.npmjs.org/@paperclipai/plugin-sdk/-/plugin-sdk-2026.722.0.tgz",
+      "integrity": "sha512-2rMJCBo8ZAouuMsapdaY4/l+oHmrXKHW/k/HfPOLCxFng7+g04c5JhoFq+/ptGfNcW3kXzs34y7brviDCml06Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@paperclipai/shared": "2026.707.0",
+        "@paperclipai/shared": "2026.722.0",
         "zod": "^3.24.2"
       },
       "bin": {
@@ -497,9 +497,9 @@
       }
     },
     "node_modules/@paperclipai/shared": {
-      "version": "2026.707.0",
-      "resolved": "https://registry.npmjs.org/@paperclipai/shared/-/shared-2026.707.0.tgz",
-      "integrity": "sha512-CI1D+jBVKdBlCqhFi+GfaK+ADZ1E1PLxAhStzmDkHORTmDnloZZMQ2JbnbPcJGdlIJTTMxAEFVrhgGzwh7jsbw==",
+      "version": "2026.722.0",
+      "resolved": "https://registry.npmjs.org/@paperclipai/shared/-/shared-2026.722.0.tgz",
+      "integrity": "sha512-JciI6EbtNwHSeoyN5ZkshwqpyfIluyO46JHp8I7pPCvpJ7Uv7MSZEBs3lKXdXLadFEN6qzfwNmf39xjIFC8isA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "react-dom": ">=18"
   },
   "devDependencies": {
-    "@paperclipai/plugin-sdk": "^2026.707.0",
-    "@paperclipai/shared": "^2026.707.0",
+    "@paperclipai/plugin-sdk": "^2026.722.0",
+    "@paperclipai/shared": "^2026.722.0",
     "typescript": "^5.7.0",
     "vitest": "^3.2.6",
     "@types/node": "^22.0.0",


### PR DESCRIPTION
The plugin pins `@paperclipai/plugin-sdk@^2026.707.0` as a devDependency, where `config.get()` is typed to take **zero** arguments. It became `get(companyId?: string)` in `2026.722.0` — which is also the SDK that ships beside the plugin at runtime.

So build-time types are a release behind the runtime, and a bare `ctx.config.get()` is the only call that compiles. Company-scoped config is unreachable *by construction* rather than by policy, and the same mismatch applies to `ctx.secrets.resolve(ref, { companyId, configPath })`.

This appears to be the root cause behind #77, #63 and #61, and the reason the source carries the comment "Plugin secret references are disabled until company-scoped plugin config lands" — that limitation looks self-inflicted rather than imposed by the host.

**Scope:** this change is the dependency alignment only. It makes the scoped signatures visible to the compiler without altering behaviour, so it can land ahead of the call-site changes that use them.

Typecheck clean, 228/228 tests pass on `main`.