### PR TITLE
fix: complete company-scoped Telegram startup fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,5 +18,9 @@ jobs:
           node-version: 24
       - run: npm ci
       - run: npm run typecheck
-      - run: npm run test
+      # test:coverage, not test: it runs the same suite and additionally
+      # enforces the coverage ratchet in vitest.config.ts. Plain `npm run test`
+      # passes on a change that drops coverage, which is what the ratchet is
+      # there to stop.
+      - run: npm run test:coverage
       - run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 *.tsbuildinfo
+coverage/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "paperclip-plugin-telegram",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "paperclip-plugin-telegram",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "devDependencies": {
         "@paperclipai/plugin-sdk": "^2026.707.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@paperclipai/plugin-sdk": "^2026.722.0",
-        "@paperclipai/shared": "^2026.722.0",
+        "@paperclipai/shared": "^2026.707.0",
         "@types/node": "^22.0.0",
         "@types/react": "^19.0.8",
         "react": "^19.2.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,10 @@
       "license": "MIT",
       "devDependencies": {
         "@paperclipai/plugin-sdk": "^2026.722.0",
-        "@paperclipai/shared": "^2026.707.0",
+        "@paperclipai/shared": "^2026.722.0",
         "@types/node": "^22.0.0",
         "@types/react": "^19.0.8",
+        "@vitest/coverage-v8": "^3.2.7",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "typescript": "^5.7.0",
@@ -23,6 +24,80 @@
         "@paperclipai/shared": "*",
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -467,12 +542,72 @@
         "node": ">=18"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@paperclipai/plugin-sdk": {
       "version": "2026.722.0",
@@ -504,6 +639,17 @@
       "license": "MIT",
       "dependencies": {
         "zod": "^3.24.2"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -901,16 +1047,50 @@
         "csstype": "^3.2.2"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.7.tgz",
+      "integrity": "sha512-NEGWJS2XNu2PfRLQwOO3CTKj1tTETxNBdk454vDxVBhxJYhPaA/eS0nAI0c+1El1P7a60z8+i+ZrQoGESweGKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.7",
+        "vitest": "3.2.7"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
-      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.6",
-        "@vitest/utils": "3.2.6",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
         "chai": "^5.2.0",
         "tinyrainbow": "^2.0.0"
       },
@@ -919,13 +1099,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
-      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.2.6",
+        "@vitest/spy": "3.2.7",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.17"
       },
@@ -959,13 +1139,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
-      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.2.6",
+        "@vitest/utils": "3.2.7",
         "pathe": "^2.0.3",
         "strip-literal": "^3.0.0"
       },
@@ -974,13 +1154,13 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
-      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.6",
+        "@vitest/pretty-format": "3.2.7",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       },
@@ -988,23 +1168,10 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@vitest/snapshot/node_modules/@vitest/pretty-format": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
-      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
     "node_modules/@vitest/spy": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
-      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1015,13 +1182,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
-      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.6",
+        "@vitest/pretty-format": "3.2.7",
         "loupe": "^3.1.4",
         "tinyrainbow": "^2.0.0"
       },
@@ -1029,17 +1196,30 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@vitest/utils/node_modules/@vitest/pretty-format": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
-      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
+    "node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^2.0.0"
+      "engines": {
+        "node": ">=12"
       },
       "funding": {
-        "url": "https://opencollective.com/vitest"
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/assertion-error": {
@@ -1050,6 +1230,41 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/cac": {
@@ -1089,6 +1304,41 @@
         "node": ">= 16"
       }
     },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -1123,6 +1373,20 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
@@ -1211,6 +1475,23 @@
         }
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1226,10 +1507,169 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "node_modules/js-tokens": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -1240,6 +1680,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -1248,6 +1695,60 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/ms": {
@@ -1274,6 +1775,40 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/pathe": {
@@ -1417,12 +1952,61 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -1448,6 +2032,110 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-literal": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
@@ -1459,6 +2147,41 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinybench": {
@@ -1642,20 +2365,20 @@
       }
     },
     "node_modules/vitest": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
-      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.6",
-        "@vitest/mocker": "3.2.6",
-        "@vitest/pretty-format": "^3.2.6",
-        "@vitest/runner": "3.2.6",
-        "@vitest/snapshot": "3.2.6",
-        "@vitest/spy": "3.2.6",
-        "@vitest/utils": "3.2.6",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
         "chai": "^5.2.0",
         "debug": "^4.4.1",
         "expect-type": "^1.2.1",
@@ -1685,8 +2408,8 @@
         "@edge-runtime/vm": "*",
         "@types/debug": "^4.1.12",
         "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.6",
-        "@vitest/ui": "3.2.6",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -1714,6 +2437,22 @@
         }
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -1726,6 +2465,104 @@
       },
       "bin": {
         "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "paperclip-plugin-telegram",
-  "version": "0.7.1",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "paperclip-plugin-telegram",
-      "version": "0.7.1",
+      "version": "0.7.0",
       "license": "MIT",
       "devDependencies": {
         "@paperclipai/plugin-sdk": "^2026.707.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "paperclip-plugin-telegram",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "paperclip-plugin-telegram",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "devDependencies": {
-        "@paperclipai/plugin-sdk": "^2026.707.0",
-        "@paperclipai/shared": "^2026.707.0",
+        "@paperclipai/plugin-sdk": "^2026.722.0",
+        "@paperclipai/shared": "^2026.722.0",
         "@types/node": "^22.0.0",
         "@types/react": "^19.0.8",
         "react": "^19.2.5",
@@ -475,13 +475,13 @@
       "license": "MIT"
     },
     "node_modules/@paperclipai/plugin-sdk": {
-      "version": "2026.707.0",
-      "resolved": "https://registry.npmjs.org/@paperclipai/plugin-sdk/-/plugin-sdk-2026.707.0.tgz",
-      "integrity": "sha512-5pS4nG+l8k7GBvIHiuvPjWsiVX9KYG1WBD/c/DJGPBRRAuUj3Sd/PiaukAV6g/Ax94CnPS799hQLq40i09FKVg==",
+      "version": "2026.722.0",
+      "resolved": "https://registry.npmjs.org/@paperclipai/plugin-sdk/-/plugin-sdk-2026.722.0.tgz",
+      "integrity": "sha512-2rMJCBo8ZAouuMsapdaY4/l+oHmrXKHW/k/HfPOLCxFng7+g04c5JhoFq+/ptGfNcW3kXzs34y7brviDCml06Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@paperclipai/shared": "2026.707.0",
+        "@paperclipai/shared": "2026.722.0",
         "zod": "^3.24.2"
       },
       "bin": {
@@ -497,9 +497,9 @@
       }
     },
     "node_modules/@paperclipai/shared": {
-      "version": "2026.707.0",
-      "resolved": "https://registry.npmjs.org/@paperclipai/shared/-/shared-2026.707.0.tgz",
-      "integrity": "sha512-CI1D+jBVKdBlCqhFi+GfaK+ADZ1E1PLxAhStzmDkHORTmDnloZZMQ2JbnbPcJGdlIJTTMxAEFVrhgGzwh7jsbw==",
+      "version": "2026.722.0",
+      "resolved": "https://registry.npmjs.org/@paperclipai/shared/-/shared-2026.722.0.tgz",
+      "integrity": "sha512-JciI6EbtNwHSeoyN5ZkshwqpyfIluyO46JHp8I7pPCvpJ7Uv7MSZEBs3lKXdXLadFEN6qzfwNmf39xjIFC8isA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dev": "tsc --watch",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
+    "test:mutations": "node scripts/mutation-check.mjs",
     "prepublishOnly": "npm run build"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "typecheck": "tsc --noEmit",
     "dev": "tsc --watch",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "prepublishOnly": "npm run build"
   },
   "peerDependencies": {
@@ -22,9 +23,10 @@
   },
   "devDependencies": {
     "@paperclipai/plugin-sdk": "^2026.722.0",
-    "@paperclipai/shared": "^2026.707.0",
+    "@paperclipai/shared": "^2026.722.0",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.8",
+    "@vitest/coverage-v8": "^3.2.7",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "typescript": "^5.7.0",

--- a/package.json
+++ b/package.json
@@ -22,13 +22,13 @@
   },
   "devDependencies": {
     "@paperclipai/plugin-sdk": "^2026.722.0",
-    "@paperclipai/shared": "^2026.722.0",
-    "typescript": "^5.7.0",
-    "vitest": "^3.2.6",
+    "@paperclipai/shared": "^2026.707.0",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.8",
     "react": "^19.2.5",
-    "react-dom": "^19.2.5"
+    "react-dom": "^19.2.5",
+    "typescript": "^5.7.0",
+    "vitest": "^3.2.6"
   },
   "files": [
     "dist/"

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "react-dom": ">=18"
   },
   "devDependencies": {
-    "@paperclipai/plugin-sdk": "^2026.707.0",
-    "@paperclipai/shared": "^2026.707.0",
+    "@paperclipai/plugin-sdk": "^2026.722.0",
+    "@paperclipai/shared": "^2026.722.0",
     "typescript": "^5.7.0",
     "vitest": "^3.2.6",
     "@types/node": "^22.0.0",

--- a/scripts/mutation-check.mjs
+++ b/scripts/mutation-check.mjs
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+/**
+ * Mutation check: reintroduce known bugs and prove the suite goes red.
+ *
+ * Every defect this plugin has shipped failed SILENTLY — no throw, no error
+ * log, a bot that looked connected and did nothing. Line coverage does not
+ * catch that class of bug: a line runs during a test whether or not anything
+ * asserts on what it did. `src/decisions.ts` sat at 100% statement coverage
+ * while three of its behaviours had no assertion behind them, including two a
+ * commit message claimed to have covered.
+ *
+ * So this is the check that coverage cannot make: break the code on purpose,
+ * and fail if the tests still pass.
+ *
+ *   npm run test:mutations
+ *   npm run test:mutations -- --filter=verbs   # one mutation, by id substring
+ *   npm run test:mutations -- --list           # show the catalogue, run nothing
+ *
+ * Adding a mutation is the cheapest way to lock in a bug you just fixed:
+ * describe the user-visible failure in `breaks`, and point `find`/`replace` at
+ * the guard that prevents it.
+ *
+ * A mutation whose `find` anchor no longer matches is a HARD FAILURE, not a
+ * skip. A silently-skipped mutation is the same false confidence this script
+ * exists to remove — if you refactor the source, re-anchor the mutation.
+ */
+
+import { spawnSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+/**
+ * @type {Array<{id: string, file: string, breaks: string, find: string, replace: string}>}
+ * `breaks` states the user-visible consequence, so a MISSED result reads as a
+ * product risk rather than a coverage statistic.
+ */
+const MUTATIONS = [
+  {
+    id: "confirmation-branch",
+    file: "src/decisions.ts",
+    breaks:
+      "request_confirmation items stop being answerable — half of BLA-154 silently reverts to a web link.",
+    find: `  if (fresh.kind === "request_confirmation") {
+    return { id: fresh.id, kind: "request_confirmation", payload: fresh.payload as RequestConfirmationPayload };
+  }`,
+    replace: `  if (fresh.kind === "request_confirmation") {
+    return null;
+  }`,
+  },
+  {
+    id: "stale-interaction",
+    file: "src/decisions.ts",
+    breaks:
+      "An interaction answered in the web UI since the /attention snapshot is still offered as buttons; the answer is rejected and the user is told nothing.",
+    find: '  if (!fresh || fresh.status !== "pending") return null;',
+    replace: "  if (!fresh) return null;",
+  },
+  {
+    id: "free-text-questions",
+    file: "src/decisions.ts",
+    breaks:
+      "Questions with a designer-declared free-text option are rendered as buttons, so the answer the designer asked for cannot be given.",
+    find: "    if (!isAskUserQuestionsAnswerable(payload)) return null;",
+    replace: "    // guard removed",
+  },
+  {
+    id: "inline-resolvable",
+    file: "src/decisions.ts",
+    breaks:
+      "The host's inlineResolvable verdict is overridden and items it declined to expose inline are answered from Telegram anyway.",
+    find: "    inlineResolvable: raw.inlineResolvable === true,",
+    replace: "    inlineResolvable: true,",
+  },
+  {
+    id: "decision-verbs",
+    file: "src/decisions.ts",
+    breaks:
+      "The host's own decisionVerbs are dropped, so the Options line disappears and the bot is free to invent labels the host never offered.",
+    find: `  const verbs = Array.isArray(raw.decisionVerbs)
+    ? (raw.decisionVerbs as Array<Record<string, unknown>>)
+        .map((v) => (typeof v.label === "string" ? v.label : ""))
+        .filter(Boolean)
+    : [];`,
+    replace: "  const verbs: string[] = [];",
+  },
+  {
+    id: "callback-double-answer",
+    file: "src/interaction-answers.ts",
+    breaks:
+      "A button press is submitted without re-checking the interaction is still pending, so a stale message answers something already resolved.",
+    find: '  if (!fresh || fresh.status !== "pending") {',
+    replace: "  if (false) {",
+  },
+];
+
+const args = process.argv.slice(2);
+const filter = args.find((a) => a.startsWith("--filter="))?.slice("--filter=".length);
+const selected = filter ? MUTATIONS.filter((m) => m.id.includes(filter)) : MUTATIONS;
+
+if (args.includes("--list")) {
+  for (const m of MUTATIONS) console.log(`${m.id.padEnd(24)} ${m.file}\n${" ".repeat(25)}${m.breaks}`);
+  process.exit(0);
+}
+
+if (selected.length === 0) {
+  console.error(`No mutation matches --filter=${filter}. Use --list to see the catalogue.`);
+  process.exit(1);
+}
+
+const abs = (f) => path.join(ROOT, f);
+
+/** Refuse to run against edits we could lose if this crashes mid-mutation. */
+function assertTargetsClean() {
+  const files = [...new Set(selected.map((m) => m.file))];
+  const res = spawnSync("git", ["status", "--porcelain", "--", ...files], {
+    cwd: ROOT,
+    encoding: "utf8",
+  });
+  if (res.status !== 0) {
+    console.error("Could not read git status; refusing to mutate files in place.");
+    process.exit(1);
+  }
+  if (res.stdout.trim()) {
+    console.error(
+      "Uncommitted changes in the files this script rewrites:\n" +
+        res.stdout +
+        "\nCommit or stash them first — a crash mid-run would restore over your edits.",
+    );
+    process.exit(1);
+  }
+}
+
+function runSuite() {
+  // --bail=1 because the only question is whether the suite goes red at all.
+  const res = spawnSync("npx", ["vitest", "run", "--reporter=dot", "--bail=1"], {
+    cwd: ROOT,
+    encoding: "utf8",
+  });
+  return res.status !== 0;
+}
+
+assertTargetsClean();
+
+/** Files rewritten right now, restored on any exit path including Ctrl-C. */
+const open = new Map();
+const restoreAll = () => {
+  for (const [file, original] of open) writeFileSync(file, original);
+  open.clear();
+};
+process.on("SIGINT", () => {
+  restoreAll();
+  process.exit(130);
+});
+process.on("SIGTERM", () => {
+  restoreAll();
+  process.exit(143);
+});
+
+const results = [];
+try {
+  for (const m of selected) {
+    const file = abs(m.file);
+    const original = readFileSync(file, "utf8");
+
+    if (!original.includes(m.find)) {
+      results.push({ id: m.id, status: "STALE", note: `anchor not found in ${m.file}` });
+      console.log(`STALE   ${m.id} — anchor not found in ${m.file}`);
+      continue;
+    }
+
+    open.set(file, original);
+    writeFileSync(file, original.replace(m.find, m.replace));
+    try {
+      const caught = runSuite();
+      results.push({ id: m.id, status: caught ? "CAUGHT" : "MISSED", note: m.breaks });
+      console.log(`${caught ? "CAUGHT " : "MISSED "} ${m.id}`);
+    } finally {
+      writeFileSync(file, original);
+      open.delete(file);
+    }
+  }
+} finally {
+  restoreAll();
+}
+
+const bad = results.filter((r) => r.status !== "CAUGHT");
+console.log("\n===== mutation check =====");
+for (const r of results) console.log(`${r.status.padEnd(7)} ${r.id}`);
+console.log(`\n${results.length - bad.length}/${results.length} mutations caught`);
+
+const missed = bad.filter((r) => r.status === "MISSED");
+const stale = bad.filter((r) => r.status === "STALE");
+
+if (missed.length) {
+  console.log("\nUnguarded behaviour — the code broke and the suite stayed green:");
+  for (const r of missed) console.log(`  ${r.id}: ${r.note}`);
+  console.log("\nAdd an assertion that fails for each mutation above.");
+}
+
+if (stale.length) {
+  console.log("\nNot checked at all — the mutation no longer applies to the source:");
+  for (const r of stale) console.log(`  ${r.id}: ${r.note}`);
+  console.log("\nRe-anchor these against the refactored code; a skipped mutation proves nothing.");
+}
+
+process.exit(bad.length ? 1 : 0);

--- a/scripts/mutation-check.mjs
+++ b/scripts/mutation-check.mjs
@@ -94,6 +94,47 @@ const MUTATIONS = [
     find: '  if (!fresh || fresh.status !== "pending") {',
     replace: "  if (false) {",
   },
+  {
+    id: "chat-id-as-company-id",
+    file: "src/acp-bridge.ts",
+    breaks:
+      "An unlinked chat resolves to its Telegram chat id used as a Paperclip company id — an address that cannot work, spent silently on every host call.",
+    find: "  return mapping?.companyId ?? mapping?.companyName ?? null;",
+    replace: "  return mapping?.companyId ?? mapping?.companyName ?? chatId;",
+  },
+  {
+    id: "loop-company-not-threaded",
+    file: "src/acp-bridge.ts",
+    breaks:
+      "The discussion loop stops using the host's own companyId from the event envelope and re-derives it from chat state, which is guesswork by comparison.",
+    find:
+      "  await checkConversationLoopContinuation(ctx, token, chatId, threadId, sessionId, text, done, companyId);",
+    replace:
+      "  await checkConversationLoopContinuation(ctx, token, chatId, threadId, sessionId, text, done);",
+  },
+  {
+    id: "loop-unresolved-company",
+    file: "src/acp-bridge.ts",
+    breaks:
+      "An agent-to-agent discussion continues with an unresolved company, re-spending the failure on every remaining turn instead of pausing once.",
+    find: `      const resolvedCompanyId = companyId ?? await resolveCompanyIdFromChat(ctx, chatId);
+      if (!resolvedCompanyId) {`,
+    replace: `      const resolvedCompanyId = (companyId ?? await resolveCompanyIdFromChat(ctx, chatId)) as string;
+      if (false) {`,
+  },
+  {
+    id: "route-message-unlinked",
+    file: "src/acp-bridge.ts",
+    breaks:
+      "A message addressed to a live agent session in an unlinked chat is routed to a fake company instead of telling the user to /connect.",
+    find: `  if (!resolvedCompanyId) {
+    // Handled: the message was addressed to a live session, so staying silent
+    // here would look like the agent simply ignored it.
+    await sendMessage(ctx, token, chatId, NOT_LINKED_MESSAGE, { messageThreadId: threadId });
+    return true;
+  }`,
+    replace: "",
+  },
 ];
 
 const args = process.argv.slice(2);

--- a/src/acp-bridge.ts
+++ b/src/acp-bridge.ts
@@ -72,10 +72,17 @@ type OutputQueueEntry = {
 
 export function setupAcpOutputListener(
   ctx: PluginContext,
-  token: string,
+  resolveToken: (event: { companyId: string }) => Promise<string | null>,
 ): void {
   ctx.events.on(ACP_OUTPUT_EVENT, async (event) => {
     const payload = event.payload as AcpOutputEvent;
+    const token = await resolveToken(event);
+    if (!token) {
+      ctx.logger.warn("Skipping ACP output because Telegram bot token could not be resolved", {
+        companyId: event.companyId,
+      });
+      return;
+    }
     await handleAcpOutput(ctx, token, payload);
   });
 }

--- a/src/acp-bridge.ts
+++ b/src/acp-bridge.ts
@@ -83,7 +83,10 @@ export function setupAcpOutputListener(
       });
       return;
     }
-    await handleAcpOutput(ctx, token, payload);
+    // The envelope's companyId is the host's own; it is already trusted enough
+    // to resolve the bot token. Passing it on keeps the discussion loop from
+    // re-deriving the company from chat state, which is guesswork by comparison.
+    await handleAcpOutput(ctx, token, payload, event.companyId);
   });
 }
 
@@ -284,6 +287,10 @@ async function handleAcpSpawn(
   const trimmedName = agentName.trim();
   const displayName = trimmedName.charAt(0).toUpperCase() + trimmedName.slice(1);
   const resolvedCompanyId = companyId ?? await resolveCompanyIdFromChat(ctx, chatId);
+  if (!resolvedCompanyId) {
+    await sendMessage(ctx, token, chatId, NOT_LINKED_MESSAGE, { messageThreadId });
+    return;
+  }
 
   // Try native session first: resolve agent by name, then create session
   let transport: "native" | "acp" = "acp";
@@ -444,6 +451,10 @@ async function handleAcpCancel(
   )[0]!;
 
   const resolvedCompanyId = companyId ?? await resolveCompanyIdFromChat(ctx, chatId);
+  if (!resolvedCompanyId) {
+    await sendMessage(ctx, token, chatId, NOT_LINKED_MESSAGE, { messageThreadId });
+    return;
+  }
 
   if (target.transport === "native") {
     try {
@@ -524,6 +535,10 @@ async function handleAcpClose(
   }
 
   const resolvedCompanyId = companyId ?? await resolveCompanyIdFromChat(ctx, chatId);
+  if (!resolvedCompanyId) {
+    await sendMessage(ctx, token, chatId, NOT_LINKED_MESSAGE, { messageThreadId });
+    return;
+  }
 
   // Close via the correct transport
   if (targetSession.transport === "native") {
@@ -625,6 +640,12 @@ export async function routeMessageToAgent(
   await saveSessions(ctx, chatId, threadId, sessions);
 
   const resolvedCompanyId = companyId ?? await resolveCompanyIdFromChat(ctx, chatId);
+  if (!resolvedCompanyId) {
+    // Handled: the message was addressed to a live session, so staying silent
+    // here would look like the agent simply ignored it.
+    await sendMessage(ctx, token, chatId, NOT_LINKED_MESSAGE, { messageThreadId: threadId });
+    return true;
+  }
   const projectId = await resolveMappedProjectIdForTopic(ctx, chatId, resolvedCompanyId, threadId);
 
   // Route via correct transport
@@ -672,6 +693,7 @@ export async function handleAcpOutput(
   ctx: PluginContext,
   token: string,
   event: AcpOutputEvent,
+  companyId?: string,
 ): Promise<void> {
   const { sessionId, chatId, threadId, text, done } = event;
 
@@ -703,7 +725,7 @@ export async function handleAcpOutput(
   }
 
   await sendLabeledOutput(ctx, token, chatId, threadId, sessionId, displayName, text, done);
-  await checkConversationLoopContinuation(ctx, token, chatId, threadId, sessionId, text, done);
+  await checkConversationLoopContinuation(ctx, token, chatId, threadId, sessionId, text, done, companyId);
 }
 
 // --- Output sequencing ---
@@ -1283,6 +1305,7 @@ async function checkConversationLoopContinuation(
   sessionId: string,
   text: string,
   done?: boolean,
+  companyId?: string,
 ): Promise<void> {
   const loop = await ctx.state.get({
     scopeKind: "instance",
@@ -1362,7 +1385,25 @@ async function checkConversationLoopContinuation(
     const nextSession = sessions.find((s) => s.sessionId === nextSessionId);
 
     if (nextSession) {
-      const resolvedCompanyId = await resolveCompanyIdFromChat(ctx, chatId);
+      const resolvedCompanyId = companyId ?? await resolveCompanyIdFromChat(ctx, chatId);
+      if (!resolvedCompanyId) {
+        // Pausing beats continuing: this runs once per turn, so an unresolved
+        // company would otherwise be re-spent on every remaining turn of the
+        // discussion, each failing the same way and none of it visible.
+        loop.status = "paused";
+        await ctx.state.set(
+          { scopeKind: "instance", stateKey: `loop_${chatId}_${threadId}` },
+          loop,
+        );
+        await sendMessage(
+          ctx,
+          token,
+          chatId,
+          `${escapeMarkdownV2("⚠️")} *Discussion Paused* \\- ${escapeMarkdownV2("this chat is not linked to a Paperclip company. Use /connect, then send a message to resume.")}`,
+          { parseMode: "MarkdownV2", messageThreadId: threadId },
+        );
+        return;
+      }
 
       if (nextSession.transport === "native") {
         await wakeAgentWithIssue(
@@ -1411,13 +1452,30 @@ async function saveSessions(
   );
 }
 
-async function resolveCompanyIdFromChat(ctx: PluginContext, chatId: string): Promise<string> {
+/**
+ * The company this chat is linked to, or null when it is linked to nothing.
+ *
+ * This used to fall back to the raw `chatId`, which is a Telegram identifier
+ * and never a Paperclip company id. Every caller then spent that fake id on a
+ * host call that could only fail, and because nothing here throws or logs, an
+ * unlinked chat looked exactly like a working one. The discussion loop made it
+ * worse: it re-resolved per turn, so one unlinked chat produced a fake id on
+ * every turn of an agent-to-agent conversation.
+ *
+ * Returning null forces each caller to say why it stopped. `companyName` stays
+ * as a fallback because worker.ts and commands.ts both accept it for chats
+ * linked by older versions; unlike chatId it is at least a company reference.
+ */
+async function resolveCompanyIdFromChat(ctx: PluginContext, chatId: string): Promise<string | null> {
   const mapping = await ctx.state.get({
     scopeKind: "instance",
     stateKey: `chat_${chatId}`,
   }) as { companyId?: string; companyName?: string } | null;
-  return mapping?.companyId ?? mapping?.companyName ?? chatId;
+  return mapping?.companyId ?? mapping?.companyName ?? null;
 }
+
+/** What every call site says when the chat turns out not to be linked. */
+const NOT_LINKED_MESSAGE = "This chat is not linked to a Paperclip company. Use /connect first.";
 
 function simpleHash(text: string): string {
   let hash = 0;

--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -448,6 +448,18 @@ async function executeStep(
       return "awaiting_approval";
     }
 
+    // NOTE: there is deliberately no "choice" step.
+    //
+    // A step that asks the user to pick and waits for the answer cannot work
+    // here: updates are processed strictly sequentially, so a workflow that
+    // blocks on a button press blocks the loop that would deliver it. The
+    // press can never arrive and the run stalls until it times out.
+    //
+    // `wait_approval` has the same defect today — its cmd_approve_* buttons are
+    // handled nowhere, so a workflow reaching it parks forever. Both need the
+    // workflow engine to persist its continuation and resume from a callback,
+    // which does not exist yet. /decisions shows the stateless pattern that
+    // does work: park the context, resolve it in the callback handler.
     case "set_state": {
       const key = interpolate(step.key);
       const value = interpolate(step.value);

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -340,6 +340,15 @@ async function handleConnect(
       return;
     }
 
+    const existing = await ctx.state.get({
+      scopeKind: "instance",
+      stateKey: `chat_${chatId}`,
+    }) as { companyId?: string } | null;
+    if (existing?.companyId === match.id) {
+      ctx.logger.info("Chat already linked to company", { chatId, companyId: match.id, companyName: match.name });
+      return;
+    }
+
     // Inbound: chat → company (for commands like /status)
     await ctx.state.set(
       { scopeKind: "instance", stateKey: `chat_${chatId}` },

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -19,19 +19,23 @@ type TopicMappingRecord = {
 type TopicMappingValue = string | TopicMappingRecord;
 type TopicMap = Record<string, TopicMappingValue>;
 
+// Order drives the / menu Telegram shows on every chat (see setMyCommands in
+// worker.ts), so it is the only discovery path a user has — daily-use
+// commands lead, and setup/forum-only commands (connect, connect_topic,
+// topics) trail since most users touch them once or never.
 export const BOT_COMMANDS: BotCommand[] = [
-  { command: "create", description: "Create a new task (assigned to CEO agent)" },
+  { command: "create", description: "Create a new task for the team" },
   { command: "decisions", description: "List decisions waiting on your input" },
-  { command: "status", description: "Company health: active agents, open issues" },
-  { command: "issues", description: "List open issues (optionally by project)" },
-  { command: "agents", description: "List agents with current status" },
-  { command: "approve", description: "Approve a pending request by ID" },
-  { command: "help", description: "Show available commands" },
+  { command: "status", description: "Show a quick snapshot: active agents and open issues" },
+  { command: "issues", description: "List open issues, optionally by project" },
+  { command: "agents", description: "List all agents and what they're doing" },
+  { command: "approve", description: "Approve a pending request by its ID" },
+  { command: "help", description: "Show this list of commands" },
+  { command: "acp", description: "Manage agent sessions: start, check, cancel, or close" },
+  { command: "commands", description: "Manage custom commands: list, import, run, or delete" },
   { command: "connect", description: "Link this chat to a Paperclip company" },
-  { command: "connect_topic", description: "Map a project to a forum topic" },
-  { command: "topics", description: "List or remove forum topic mappings" },
-  { command: "acp", description: "Manage agent sessions (spawn, status, cancel, close)" },
-  { command: "commands", description: "Manage custom workflow commands (list, import, run, delete)" },
+  { command: "connect_topic", description: "Map a project to this forum topic (forum groups only)" },
+  { command: "topics", description: "List or remove this chat's forum topic mappings" },
 ];
 
 export async function handleCommand(

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,7 +1,7 @@
 import type { PluginContext, PluginEvent, Agent, Issue, Project } from "@paperclipai/plugin-sdk";
 import { sendMessage, escapeMarkdownV2, sendChatAction } from "./telegram-api.js";
 import { METRIC_NAMES } from "./constants.js";
-import { fetchPendingInteractions, sendPendingList } from "./decisions.js";
+import { fetchAttention, sendAttentionList, describeDecisionsError } from "./decisions.js";
 import { handleAcpCommand } from "./acp-bridge.js";
 import { buildPaperclipAuthHeaders, fetchPaperclipApi } from "./paperclip-api.js";
 
@@ -120,21 +120,16 @@ async function handleDecisions(
 
   try {
     const companyId = resolvedCompanyId ?? (await resolveCompanyId(ctx, chatId));
-    const found = await fetchPendingInteractions(ctx, baseUrl, companyId, boardApiToken);
-    await sendPendingList(ctx, token, chatId, found, {
+    const found = await fetchAttention(ctx, baseUrl, companyId, boardApiToken);
+    await sendAttentionList(ctx, token, chatId, found, {
       messageThreadId,
       publicUrl: isExternalUrl(publicUrl) ? publicUrl : undefined,
     });
   } catch (err) {
-    // Board access is what makes the decision queue readable, so a 401/403
-    // here usually means it was never connected rather than a real outage.
-    await sendMessage(
-      ctx,
-      token,
-      chatId,
-      `Could not load decisions: ${err instanceof Error ? err.message : String(err)}`,
-      { messageThreadId },
-    );
+    // A raw "403 Board access required" names the symptom and hides the cause,
+    // so translate it into what actually went wrong before sending it on.
+    ctx.logger.error("Failed to load decisions", { error: String(err) });
+    await sendMessage(ctx, token, chatId, describeDecisionsError(err), { messageThreadId });
   }
 }
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -108,14 +108,23 @@ async function handleStatus(
   try {
     const companyId = resolvedCompanyId ?? await resolveCompanyId(ctx, chatId);
     const agents = await ctx.agents.list({ companyId });
-    const activeAgents = agents.filter((a: Agent) => a.status === "active");
+    // Agents report "running" or "idle" (and "paused"/"error" when unavailable).
+    // Counting `status === "active"` matched nothing, so this line always read
+    // "0/N" no matter how many agents were working.
+    const running = agents.filter((a: Agent) => a.status === "running" || a.status === "active");
+    const unavailable = agents.filter((a: Agent) => a.status === "paused" || a.status === "error");
     const issues = await ctx.issues.list({ companyId, limit: 10 });
     const doneIssues = issues.filter((i: Issue) => i.status === "done");
+
+    const agentLine =
+      `${escapeMarkdownV2("🤖")} Agents: *${running.length}* running, ` +
+      `*${escapeMarkdownV2(String(agents.length - unavailable.length))}* available` +
+      (unavailable.length > 0 ? escapeMarkdownV2(` (${unavailable.length} paused/error)`) : "");
 
     const lines = [
       escapeMarkdownV2("📊") + " *Paperclip Status*",
       "",
-      `${escapeMarkdownV2("🤖")} Active agents: *${activeAgents.length}*/${escapeMarkdownV2(String(agents.length))}`,
+      agentLine,
       `${escapeMarkdownV2("📋")} Recent issues: *${escapeMarkdownV2(String(issues.length))}* \\(${escapeMarkdownV2(String(doneIssues.length))} done\\)`,
     ];
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,6 +1,7 @@
 import type { PluginContext, PluginEvent, Agent, Issue, Project } from "@paperclipai/plugin-sdk";
 import { sendMessage, escapeMarkdownV2, sendChatAction } from "./telegram-api.js";
 import { METRIC_NAMES } from "./constants.js";
+import { fetchPendingInteractions, sendPendingList } from "./decisions.js";
 import { handleAcpCommand } from "./acp-bridge.js";
 import { buildPaperclipAuthHeaders, fetchPaperclipApi } from "./paperclip-api.js";
 
@@ -20,6 +21,7 @@ type TopicMap = Record<string, TopicMappingValue>;
 
 export const BOT_COMMANDS: BotCommand[] = [
   { command: "create", description: "Create a new task (assigned to CEO agent)" },
+  { command: "decisions", description: "List decisions waiting on your input" },
   { command: "status", description: "Company health: active agents, open issues" },
   { command: "issues", description: "List open issues (optionally by project)" },
   { command: "agents", description: "List agents with current status" },
@@ -51,6 +53,9 @@ export async function handleCommand(
     case "create":
       await handleCreate(ctx, token, chatId, args, messageThreadId, publicUrl || baseUrl, companyId);
       break;
+    case "decisions":
+      await handleDecisions(ctx, token, chatId, messageThreadId, baseUrl, publicUrl, companyId, boardApiToken);
+      break;
     case "status":
       await handleStatus(ctx, token, chatId, messageThreadId, publicUrl, companyId);
       break;
@@ -63,11 +68,10 @@ export async function handleCommand(
     case "approve":
       await handleApprove(ctx, token, chatId, args, messageThreadId, baseUrl, boardApiToken);
       break;
-    // /start is Telegram's own entry point — the client shows it as a button on
-    // every new chat, so it is the first thing most users ever send. Without a
-    // case here it falls through to "Unknown command: /start", which is a poor
-    // first impression of the bot. Deliberately not added to BOT_COMMANDS:
-    // Telegram treats /start as implicit and listing it clutters the menu.
+    // /start is Telegram's own entry point — the button the client shows on
+    // every new chat, so it is the first thing a user ever sends. With no case
+    // here it fell through to "Unknown command: /start", which is the worst
+    // possible first impression. Answer it with the command list.
     case "start":
     case "help":
       await handleHelp(ctx, token, chatId, messageThreadId);
@@ -93,6 +97,45 @@ export async function handleCommand(
 
 function isExternalUrl(url?: string): boolean {
   return !!url && url.startsWith("https://");
+}
+
+/**
+ * /decisions — what is actually waiting on a human, from the decision queue
+ * behind the /<company>/decisions page.
+ *
+ * Distinct from /approve: an approval is a yes/no on one request, whereas a
+ * decision carries its own option set and applies effects when chosen.
+ */
+async function handleDecisions(
+  ctx: PluginContext,
+  token: string,
+  chatId: string,
+  messageThreadId?: number,
+  baseUrl: string = "http://localhost:3100",
+  publicUrl?: string,
+  resolvedCompanyId?: string,
+  boardApiToken?: string,
+): Promise<void> {
+  await sendChatAction(ctx, token, chatId);
+
+  try {
+    const companyId = resolvedCompanyId ?? (await resolveCompanyId(ctx, chatId));
+    const found = await fetchPendingInteractions(ctx, baseUrl, companyId, boardApiToken);
+    await sendPendingList(ctx, token, chatId, found, {
+      messageThreadId,
+      publicUrl: isExternalUrl(publicUrl) ? publicUrl : undefined,
+    });
+  } catch (err) {
+    // Board access is what makes the decision queue readable, so a 401/403
+    // here usually means it was never connected rather than a real outage.
+    await sendMessage(
+      ctx,
+      token,
+      chatId,
+      `Could not load decisions: ${err instanceof Error ? err.message : String(err)}`,
+      { messageThreadId },
+    );
+  }
 }
 
 async function handleStatus(

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -63,6 +63,12 @@ export async function handleCommand(
     case "approve":
       await handleApprove(ctx, token, chatId, args, messageThreadId, baseUrl, boardApiToken);
       break;
+    // /start is Telegram's own entry point — the client shows it as a button on
+    // every new chat, so it is the first thing most users ever send. Without a
+    // case here it falls through to "Unknown command: /start", which is a poor
+    // first impression of the bot. Deliberately not added to BOT_COMMANDS:
+    // Telegram treats /start as implicit and listing it clutters the menu.
+    case "start":
     case "help":
       await handleHelp(ctx, token, chatId, messageThreadId);
       break;

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -124,6 +124,9 @@ async function handleDecisions(
     await sendAttentionList(ctx, token, chatId, found, {
       messageThreadId,
       publicUrl: isExternalUrl(publicUrl) ? publicUrl : undefined,
+      baseUrl,
+      companyId,
+      boardApiToken,
     });
   } catch (err) {
     // A raw "403 Board access required" names the symptom and hides the cause,

--- a/src/config-compat.ts
+++ b/src/config-compat.ts
@@ -1,0 +1,50 @@
+import type { PluginContext } from "@paperclipai/plugin-sdk";
+
+type Logger = PluginContext["logger"];
+
+function logConfigFallback(
+  logger: Logger,
+  message: string,
+  companyId: string | null | undefined,
+  err: unknown,
+): void {
+  logger.warn(message, {
+    companyId,
+    error: String(err),
+  });
+}
+
+export async function loadStartupConfig<T extends Record<string, unknown>>(
+  ctx: PluginContext,
+  fallback: T,
+): Promise<T> {
+  try {
+    const rawConfig = await ctx.config.get();
+    return { ...fallback, ...rawConfig } as T;
+  } catch (err) {
+    logConfigFallback(ctx.logger, "Failed to load Telegram plugin config; using defaults", null, err);
+    return fallback;
+  }
+}
+
+export async function resolveCompatibleConfig<T extends Record<string, unknown>>(
+  ctx: PluginContext,
+  fallback: T,
+  companyId?: string | null,
+): Promise<T> {
+  try {
+    const getConfig = ctx.config.get as unknown as (
+      params?: { companyId?: string | null },
+    ) => Promise<Record<string, unknown>>;
+    const scopedConfig = await getConfig(companyId ? { companyId } : undefined);
+    return { ...fallback, ...scopedConfig } as T;
+  } catch (err) {
+    logConfigFallback(
+      ctx.logger,
+      "Company-scoped Telegram plugin config unavailable; using global config",
+      companyId,
+      err,
+    );
+    return fallback;
+  }
+}

--- a/src/config-compat.ts
+++ b/src/config-compat.ts
@@ -14,14 +14,40 @@ function logConfigFallback(
   });
 }
 
+/**
+ * Load the unscoped, startup-time plugin config.
+ *
+ * On hosts that enforce per-invocation company scoping, `ctx.config.get()`
+ * with no companyId fails from setup() with "company context is required" —
+ * the same class of scoping failure `listCompaniesForStartup` works around
+ * for `companies.list()`. When that happens, retry once against the company
+ * id already known from board-access state (passed in as `fallbackCompanyId`)
+ * rather than silently running on defaults until some later event happens to
+ * carry a company scope.
+ */
 export async function loadStartupConfig<T extends Record<string, unknown>>(
   ctx: PluginContext,
   fallback: T,
+  fallbackCompanyId?: string | null,
 ): Promise<T> {
   try {
     const rawConfig = await ctx.config.get();
     return { ...fallback, ...rawConfig } as T;
   } catch (err) {
+    if (fallbackCompanyId) {
+      try {
+        const scopedConfig = await ctx.config.get(fallbackCompanyId);
+        return { ...fallback, ...scopedConfig } as T;
+      } catch (scopedErr) {
+        logConfigFallback(
+          ctx.logger,
+          "Failed to load Telegram plugin config; using defaults",
+          fallbackCompanyId,
+          scopedErr,
+        );
+        return fallback;
+      }
+    }
     logConfigFallback(ctx.logger, "Failed to load Telegram plugin config; using defaults", null, err);
     return fallback;
   }

--- a/src/config-compat.ts
+++ b/src/config-compat.ts
@@ -33,10 +33,7 @@ export async function resolveCompatibleConfig<T extends Record<string, unknown>>
   companyId?: string | null,
 ): Promise<T> {
   try {
-    const getConfig = ctx.config.get as unknown as (
-      params?: { companyId?: string | null },
-    ) => Promise<Record<string, unknown>>;
-    const scopedConfig = await getConfig(companyId ? { companyId } : undefined);
+    const scopedConfig = await ctx.config.get(companyId ?? undefined);
     return { ...fallback, ...scopedConfig } as T;
   } catch (err) {
     logConfigFallback(

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,5 @@
 export const PLUGIN_ID = "paperclip-plugin-telegram";
-export const PLUGIN_VERSION = "0.3.0";
+export const PLUGIN_VERSION = "0.6.1";
 export const MAX_AGENTS_PER_THREAD = 5;
 
 export const DEFAULT_CONFIG = {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -62,6 +62,7 @@ export const METRIC_NAMES = {
   mediaProcessed: "telegram_media_processed",
   commandsExecuted: "telegram_custom_commands_executed",
   suggestionsEmitted: "telegram_suggestions_emitted",
+  interactionAnswered: "telegram_interaction_answers_submitted",
 } as const;
 
 // Cross-plugin ACP event names

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,5 @@
 export const PLUGIN_ID = "paperclip-plugin-telegram";
-export const PLUGIN_VERSION = "0.6.1";
+export const PLUGIN_VERSION = "0.3.0";
 export const MAX_AGENTS_PER_THREAD = 5;
 
 export const DEFAULT_CONFIG = {

--- a/src/decisions.ts
+++ b/src/decisions.ts
@@ -1,6 +1,14 @@
 import type { PluginContext } from "@paperclipai/plugin-sdk";
 import { sendMessage, escapeMarkdownV2 } from "./telegram-api.js";
 import { buildPaperclipAuthHeaders, fetchPaperclipApi } from "./paperclip-api.js";
+import {
+  fetchInteraction,
+  sendAnswerableInteraction,
+  isAskUserQuestionsAnswerable,
+  type AnswerableInteraction,
+  type AskUserQuestionsPayload,
+  type RequestConfirmationPayload,
+} from "./interaction-answers.js";
 
 /**
  * What is actually waiting on a human, read from the same source the Decisions
@@ -36,6 +44,12 @@ export type AttentionItem = {
   excerpt?: string;
   verbs: string[];
   inlineResolvable: boolean;
+  // Only set for sourceKind === "issue_thread_interaction": the attention
+  // feed's excerpt has no question/option payload, so answering inline needs
+  // these to go fetch the full interaction from the issue it belongs to.
+  interactionId?: string;
+  issueId?: string;
+  interactionKind?: string;
 };
 
 export type AttentionResult = {
@@ -95,10 +109,13 @@ function toAttentionItem(raw: Record<string, unknown>): AttentionItem {
         .map((v) => (typeof v.label === "string" ? v.label : ""))
         .filter(Boolean)
     : [];
+  const sourceKind = typeof raw.sourceKind === "string" ? raw.sourceKind : "unknown";
+  const subjectMetadata = (subject.metadata ?? {}) as Record<string, unknown>;
+  const isInteraction = sourceKind === "issue_thread_interaction";
 
   return {
     id: typeof raw.id === "string" ? raw.id : "",
-    sourceKind: typeof raw.sourceKind === "string" ? raw.sourceKind : "unknown",
+    sourceKind,
     title: typeof subject.title === "string" ? subject.title : "(untitled)",
     issueIdentifier:
       typeof relatedIssue.identifier === "string" ? relatedIssue.identifier : undefined,
@@ -108,7 +125,39 @@ function toAttentionItem(raw: Record<string, unknown>): AttentionItem {
     excerpt: extractExcerpt(detail),
     verbs,
     inlineResolvable: raw.inlineResolvable === true,
+    interactionId: isInteraction && typeof subject.id === "string" ? subject.id : undefined,
+    issueId: isInteraction && typeof subjectMetadata.issueId === "string" ? subjectMetadata.issueId : undefined,
+    interactionKind: isInteraction && typeof subjectMetadata.kind === "string" ? subjectMetadata.kind : undefined,
   };
+}
+
+/**
+ * Fetch the full interaction and, if its shape is one Telegram can render as
+ * buttons, narrow it into an AnswerableInteraction. Returns null for anything
+ * that must fall back to the web-UI link: an unsupported kind, a fetch
+ * failure, an interaction that resolved since the feed was read, or (for
+ * ask_user_questions) a question with a designer-declared free-text option.
+ */
+async function tryBuildAnswerableInteraction(
+  ctx: PluginContext,
+  baseUrl: string,
+  item: AttentionItem,
+  boardApiToken?: string,
+): Promise<AnswerableInteraction | null> {
+  if (!item.issueId || !item.interactionId) return null;
+
+  const fresh = await fetchInteraction(ctx, baseUrl, item.issueId, item.interactionId, boardApiToken);
+  if (!fresh || fresh.status !== "pending") return null;
+
+  if (fresh.kind === "ask_user_questions") {
+    const payload = fresh.payload as AskUserQuestionsPayload;
+    if (!isAskUserQuestionsAnswerable(payload)) return null;
+    return { id: fresh.id, kind: "ask_user_questions", payload };
+  }
+  if (fresh.kind === "request_confirmation") {
+    return { id: fresh.id, kind: "request_confirmation", payload: fresh.payload as RequestConfirmationPayload };
+  }
+  return null;
 }
 
 /**
@@ -138,7 +187,11 @@ export async function fetchAttention(
   };
 }
 
-export function renderAttentionItem(item: AttentionItem, publicUrl?: string): string {
+export function renderAttentionItem(
+  item: AttentionItem,
+  publicUrl?: string,
+  opts: { includeOpenLink?: boolean } = {},
+): string {
   const heading = `${severityMarker(item.severity)} *${escapeMarkdownV2(item.title)}*`;
   const context = [describeSourceKind(item.sourceKind), item.issueIdentifier]
     .filter(Boolean)
@@ -161,7 +214,9 @@ export function renderAttentionItem(item: AttentionItem, publicUrl?: string): st
 
   // Deep-link to the item itself, not to the Decisions index — href already
   // carries the interaction anchor, so this lands on the thing being decided.
-  if (publicUrl && item.issueHref) {
+  // Suppressed when an inline answer prompt follows this message (BLA-154) —
+  // the link would just be a redundant way to do what the buttons already do.
+  if (opts.includeOpenLink !== false && publicUrl && item.issueHref) {
     lines.push("", escapeMarkdownV2(`Open: ${publicUrl}${item.issueHref}`));
   }
 
@@ -173,7 +228,14 @@ export async function sendAttentionList(
   token: string,
   chatId: string,
   found: AttentionResult,
-  opts: { messageThreadId?: number; publicUrl?: string; limit?: number } = {},
+  opts: {
+    messageThreadId?: number;
+    publicUrl?: string;
+    limit?: number;
+    baseUrl?: string;
+    companyId?: string;
+    boardApiToken?: string;
+  } = {},
 ): Promise<void> {
   const { items, totalCount } = found;
 
@@ -186,10 +248,26 @@ export async function sendAttentionList(
 
   const limit = opts.limit ?? DEFAULT_DISPLAY_LIMIT;
   for (const item of items.slice(0, limit)) {
-    await sendMessage(ctx, token, chatId, renderAttentionItem(item, opts.publicUrl), {
+    // Only issue_thread_interaction items are candidates — approvals,
+    // reviews, blockers etc. resolve through entirely different endpoints
+    // this plugin does not call (BLA-154's scope is ask_user_questions and
+    // request_confirmation specifically).
+    const answerable = item.sourceKind === "issue_thread_interaction" && item.inlineResolvable && opts.baseUrl
+      ? await tryBuildAnswerableInteraction(ctx, opts.baseUrl, item, opts.boardApiToken)
+      : null;
+
+    await sendMessage(ctx, token, chatId, renderAttentionItem(item, opts.publicUrl, { includeOpenLink: !answerable }), {
       parseMode: "MarkdownV2",
       messageThreadId: opts.messageThreadId,
     });
+
+    if (answerable && item.issueId) {
+      await sendAnswerableInteraction(ctx, token, chatId, answerable, {
+        issueId: item.issueId,
+        companyId: opts.companyId,
+        messageThreadId: opts.messageThreadId,
+      });
+    }
   }
 
   if (totalCount > limit) {

--- a/src/decisions.ts
+++ b/src/decisions.ts
@@ -100,7 +100,12 @@ function extractExcerpt(detail: Record<string, unknown> | undefined): string | u
   return undefined;
 }
 
-function toAttentionItem(raw: Record<string, unknown>): AttentionItem {
+/**
+ * Exported so tests can build fixtures through the real mapper. They used to
+ * keep a hand-copy of this function; it drifted into a second implementation
+ * that no longer failed when this one broke.
+ */
+export function toAttentionItem(raw: Record<string, unknown>): AttentionItem {
   const subject = (raw.subject ?? {}) as Record<string, unknown>;
   const relatedIssue = (raw.relatedIssue ?? {}) as Record<string, unknown>;
   const detail = raw.detail as Record<string, unknown> | undefined;

--- a/src/decisions.ts
+++ b/src/decisions.ts
@@ -1,0 +1,185 @@
+import type { PluginContext } from "@paperclipai/plugin-sdk";
+import { sendMessage, escapeMarkdownV2 } from "./telegram-api.js";
+import { buildPaperclipAuthHeaders, fetchPaperclipApi } from "./paperclip-api.js";
+
+/**
+ * What is actually waiting on a human, as the /<company>/decisions page shows it.
+ *
+ * The naming here is a trap worth documenting. There IS a `decisions` table and
+ * a /companies/:id/decisions endpoint — but that is a different, largely unused
+ * feature. The Decisions PAGE is built from **issue thread interactions**:
+ * `ask_user_questions` and `request_confirmation` records attached to issues,
+ * grouped into "decision queues" (Questions, Plans).
+ *
+ * Querying /decisions?status=open returns [] on an instance with a full page,
+ * which reads as "nothing pending" and is worse than an error.
+ *
+ * There is no company-wide endpoint that returns pending interactions WITH
+ * their content:
+ *   - /decision-queues/:key/items returns bare pointers (sourceKind+sourceId),
+ *     with no enrichment and no issue id, and it retains resolved items too.
+ *   - Interactions are only readable per issue, via /issues/:id/interactions.
+ *
+ * So this walks recent issues and collects their pending interactions. The
+ * bound is deliberate: unbounded, this would be one request per issue for the
+ * life of the company. Pending questions are by nature recent — an agent is
+ * blocked waiting on them — so recency is the right cut, and the cap is
+ * reported to the user rather than hidden.
+ */
+
+const CALLBACK_PREFIX = "dec_";
+const DEFAULT_ISSUE_SCAN = 30;
+
+export type PendingInteraction = {
+  id: string;
+  issueId: string;
+  issueIdentifier?: string;
+  kind: string;
+  title: string;
+  summary?: string | null;
+  status: string;
+};
+
+type RawInteraction = {
+  id?: string;
+  kind?: string;
+  status?: string;
+  title?: string;
+  summary?: string | null;
+};
+
+export function isDecisionCallback(data: string): boolean {
+  return data.startsWith(CALLBACK_PREFIX);
+}
+
+/** Human label for an interaction kind; unknown kinds fall back to the raw value. */
+export function describeKind(kind: string): string {
+  const labels: Record<string, string> = {
+    ask_user_questions: "Question",
+    request_confirmation: "Confirmation",
+  };
+  return labels[kind] ?? kind.replace(/_/g, " ");
+}
+
+async function fetchIssueInteractions(
+  ctx: PluginContext,
+  baseUrl: string,
+  issueId: string,
+  boardApiToken?: string,
+): Promise<RawInteraction[]> {
+  try {
+    const response = await fetchPaperclipApi(ctx, `${baseUrl}/api/issues/${issueId}/interactions`, {
+      method: "GET",
+      headers: { ...buildPaperclipAuthHeaders(boardApiToken) },
+    });
+    const parsed = (await (response as Response).json()) as unknown;
+    return Array.isArray(parsed) ? (parsed as RawInteraction[]) : [];
+  } catch {
+    // One unreadable issue must not sink the whole command.
+    return [];
+  }
+}
+
+/**
+ * Collect interactions still waiting on a person, newest issues first.
+ * Returns the scanned count so the caller can be honest about the bound.
+ */
+export async function fetchPendingInteractions(
+  ctx: PluginContext,
+  baseUrl: string,
+  companyId: string,
+  boardApiToken?: string,
+  scanLimit: number = DEFAULT_ISSUE_SCAN,
+): Promise<{ pending: PendingInteraction[]; scanned: number }> {
+  const issues = await ctx.issues.list({ companyId, limit: scanLimit });
+
+  // Concurrent, but in small batches: one request per issue against a local
+  // server is fine, a burst of 30 is not.
+  const pending: PendingInteraction[] = [];
+  const batchSize = 6;
+  for (let i = 0; i < issues.length; i += batchSize) {
+    const batch = issues.slice(i, i + batchSize);
+    const results = await Promise.all(
+      batch.map(async (issue) => ({
+        issue,
+        interactions: await fetchIssueInteractions(ctx, baseUrl, issue.id, boardApiToken),
+      })),
+    );
+    for (const { issue, interactions } of results) {
+      for (const interaction of interactions) {
+        if (interaction.status !== "pending") continue;
+        pending.push({
+          id: interaction.id ?? "",
+          issueId: issue.id,
+          issueIdentifier: issue.identifier ?? undefined,
+          kind: interaction.kind ?? "unknown",
+          title: interaction.title ?? "(untitled)",
+          summary: interaction.summary ?? null,
+          status: interaction.status,
+        });
+      }
+    }
+  }
+
+  return { pending, scanned: issues.length };
+}
+
+export function renderPendingInteraction(item: PendingInteraction, publicUrl?: string): string {
+  const lines = [
+    `${escapeMarkdownV2("🗳")} *${escapeMarkdownV2(item.title)}*`,
+    escapeMarkdownV2(`${describeKind(item.kind)} · ${item.issueIdentifier ?? item.issueId}`),
+  ];
+
+  const summary = (item.summary ?? "").trim();
+  if (summary) {
+    const excerpt = summary.length > 350 ? `${summary.slice(0, 350)}…` : summary;
+    lines.push("", escapeMarkdownV2(excerpt));
+  }
+
+  // Answering needs a form (free text, per-question picks), which Telegram
+  // buttons cannot render — so link out rather than pretend to collect it.
+  if (publicUrl && item.issueIdentifier) {
+    lines.push("", escapeMarkdownV2(`Answer: ${publicUrl}/decisions`));
+  }
+
+  return lines.join("\n");
+}
+
+export async function sendPendingList(
+  ctx: PluginContext,
+  token: string,
+  chatId: string,
+  found: { pending: PendingInteraction[]; scanned: number },
+  opts: { messageThreadId?: number; publicUrl?: string; limit?: number } = {},
+): Promise<void> {
+  const { pending, scanned } = found;
+
+  if (pending.length === 0) {
+    await sendMessage(
+      ctx,
+      token,
+      chatId,
+      `Nothing is waiting on your input (checked the ${scanned} most recent issues).`,
+      { messageThreadId: opts.messageThreadId },
+    );
+    return;
+  }
+
+  const limit = opts.limit ?? 5;
+  for (const item of pending.slice(0, limit)) {
+    await sendMessage(ctx, token, chatId, renderPendingInteraction(item, opts.publicUrl), {
+      parseMode: "MarkdownV2",
+      messageThreadId: opts.messageThreadId,
+    });
+  }
+
+  if (pending.length > limit) {
+    await sendMessage(
+      ctx,
+      token,
+      chatId,
+      `…and ${pending.length - limit} more waiting.`,
+      { messageThreadId: opts.messageThreadId },
+    );
+  }
+}

--- a/src/decisions.ts
+++ b/src/decisions.ts
@@ -3,183 +3,217 @@ import { sendMessage, escapeMarkdownV2 } from "./telegram-api.js";
 import { buildPaperclipAuthHeaders, fetchPaperclipApi } from "./paperclip-api.js";
 
 /**
- * What is actually waiting on a human, as the /<company>/decisions page shows it.
+ * What is actually waiting on a human, read from the same source the Decisions
+ * page renders: GET /api/companies/:companyId/attention.
  *
- * The naming here is a trap worth documenting. There IS a `decisions` table and
- * a /companies/:id/decisions endpoint — but that is a different, largely unused
- * feature. The Decisions PAGE is built from **issue thread interactions**:
- * `ask_user_questions` and `request_confirmation` records attached to issues,
- * grouped into "decision queues" (Questions, Plans).
+ * Two earlier attempts got this wrong, in ways worth recording because both
+ * returned a confident, plausible, incomplete answer rather than an error:
  *
- * Querying /decisions?status=open returns [] on an instance with a full page,
- * which reads as "nothing pending" and is worse than an error.
+ *   1. /companies/:id/decisions — a different, largely unused feature. Returns
+ *      [] on an instance whose Decisions page is full.
+ *   2. Walking recent issues for pending issue_thread_interactions. Correct as
+ *      far as it went, but the page is not only interactions: it also surfaces
+ *      blocker_attention, reviews, approvals, recovery actions and more. On a
+ *      live instance showing six items, that approach found one — and it could
+ *      not see the other four blockers at all, at any scan depth.
  *
- * There is no company-wide endpoint that returns pending interactions WITH
- * their content:
- *   - /decision-queues/:key/items returns bare pointers (sourceKind+sourceId),
- *     with no enrichment and no issue id, and it retains resolved items too.
- *   - Interactions are only readable per issue, via /issues/:id/interactions.
- *
- * So this walks recent issues and collects their pending interactions. The
- * bound is deliberate: unbounded, this would be one request per issue for the
- * life of the company. Pending questions are by nature recent — an agent is
- * blocked waiting on them — so recency is the right cut, and the cap is
- * reported to the user rather than hidden.
+ * The attention endpoint solves both: one request instead of one per issue, no
+ * scan bound to apologise for, server-side ranking, and every source kind the
+ * page knows about. It also returns `whyNow` and `decisionVerbs`, so the bot
+ * can say what the decision IS rather than just that one exists.
  */
 
-const CALLBACK_PREFIX = "dec_";
-const DEFAULT_ISSUE_SCAN = 30;
+const DEFAULT_DISPLAY_LIMIT = 5;
 
-export type PendingInteraction = {
+export type AttentionItem = {
   id: string;
-  issueId: string;
-  issueIdentifier?: string;
-  kind: string;
+  sourceKind: string;
   title: string;
-  summary?: string | null;
-  status: string;
+  issueIdentifier?: string;
+  issueHref?: string;
+  whyNow?: string;
+  severity?: string;
+  excerpt?: string;
+  verbs: string[];
+  inlineResolvable: boolean;
 };
 
-type RawInteraction = {
-  id?: string;
-  kind?: string;
-  status?: string;
-  title?: string;
-  summary?: string | null;
+export type AttentionResult = {
+  items: AttentionItem[];
+  totalCount: number;
 };
 
-export function isDecisionCallback(data: string): boolean {
-  return data.startsWith(CALLBACK_PREFIX);
-}
+type RawAttention = {
+  totalCount?: number;
+  items?: Array<Record<string, unknown>>;
+};
 
-/** Human label for an interaction kind; unknown kinds fall back to the raw value. */
-export function describeKind(kind: string): string {
+/** Human label for a source kind; unknown kinds degrade to the raw value. */
+export function describeSourceKind(kind: string): string {
   const labels: Record<string, string> = {
-    ask_user_questions: "Question",
-    request_confirmation: "Confirmation",
+    issue_thread_interaction: "Needs your answer",
+    blocker_attention: "Blocked",
+    approval: "Approval",
+    review: "Review",
+    recovery_action: "Recovery",
+    failed_run: "Failed run",
+    budget_alert: "Budget",
+    agent_error_alert: "Agent error",
+    join_request: "Join request",
+    decision: "Decision",
+    productivity_review: "Productivity review",
   };
   return labels[kind] ?? kind.replace(/_/g, " ");
 }
 
-async function fetchIssueInteractions(
-  ctx: PluginContext,
-  baseUrl: string,
-  issueId: string,
-  boardApiToken?: string,
-): Promise<RawInteraction[]> {
-  try {
-    const response = await fetchPaperclipApi(ctx, `${baseUrl}/api/issues/${issueId}/interactions`, {
-      method: "GET",
-      headers: { ...buildPaperclipAuthHeaders(boardApiToken) },
-    });
-    const parsed = (await (response as Response).json()) as unknown;
-    return Array.isArray(parsed) ? (parsed as RawInteraction[]) : [];
-  } catch {
-    // One unreadable issue must not sink the whole command.
-    return [];
-  }
+function severityMarker(severity?: string): string {
+  if (severity === "high" || severity === "critical") return "🔴";
+  if (severity === "low") return "⚪";
+  return "🟡";
 }
 
 /**
- * Collect interactions still waiting on a person, newest issues first.
- * Returns the scanned count so the caller can be honest about the bound.
+ * Pull the one line of substance out of whichever detail shape this item has.
+ * Each source kind carries a different field, and a missing one is normal
+ * rather than an error — blockers have no prose at all.
  */
-export async function fetchPendingInteractions(
+function extractExcerpt(detail: Record<string, unknown> | undefined): string | undefined {
+  if (!detail) return undefined;
+  const candidates = [detail.firstQuestionText, detail.promptExcerpt, detail.summary];
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && candidate.trim()) return candidate.trim();
+  }
+  return undefined;
+}
+
+function toAttentionItem(raw: Record<string, unknown>): AttentionItem {
+  const subject = (raw.subject ?? {}) as Record<string, unknown>;
+  const relatedIssue = (raw.relatedIssue ?? {}) as Record<string, unknown>;
+  const detail = raw.detail as Record<string, unknown> | undefined;
+  const verbs = Array.isArray(raw.decisionVerbs)
+    ? (raw.decisionVerbs as Array<Record<string, unknown>>)
+        .map((v) => (typeof v.label === "string" ? v.label : ""))
+        .filter(Boolean)
+    : [];
+
+  return {
+    id: typeof raw.id === "string" ? raw.id : "",
+    sourceKind: typeof raw.sourceKind === "string" ? raw.sourceKind : "unknown",
+    title: typeof subject.title === "string" ? subject.title : "(untitled)",
+    issueIdentifier:
+      typeof relatedIssue.identifier === "string" ? relatedIssue.identifier : undefined,
+    issueHref: typeof subject.href === "string" ? subject.href : undefined,
+    whyNow: typeof raw.whyNow === "string" ? raw.whyNow : undefined,
+    severity: typeof raw.severity === "string" ? raw.severity : undefined,
+    excerpt: extractExcerpt(detail),
+    verbs,
+    inlineResolvable: raw.inlineResolvable === true,
+  };
+}
+
+/**
+ * Fetch everything waiting on a human. Throws on failure rather than returning
+ * an empty list — "nothing is pending" must never be indistinguishable from
+ * "we could not ask", which is the mistake that made the previous version
+ * report an empty queue while four items sat on the page.
+ */
+export async function fetchAttention(
   ctx: PluginContext,
   baseUrl: string,
   companyId: string,
   boardApiToken?: string,
-  scanLimit: number = DEFAULT_ISSUE_SCAN,
-): Promise<{ pending: PendingInteraction[]; scanned: number }> {
-  const issues = await ctx.issues.list({ companyId, limit: scanLimit });
+): Promise<AttentionResult> {
+  const response = (await fetchPaperclipApi(
+    ctx,
+    `${baseUrl}/api/companies/${companyId}/attention`,
+    { method: "GET", headers: { ...buildPaperclipAuthHeaders(boardApiToken) } },
+  )) as Response;
 
-  // Concurrent, but in small batches: one request per issue against a local
-  // server is fine, a burst of 30 is not.
-  const pending: PendingInteraction[] = [];
-  const batchSize = 6;
-  for (let i = 0; i < issues.length; i += batchSize) {
-    const batch = issues.slice(i, i + batchSize);
-    const results = await Promise.all(
-      batch.map(async (issue) => ({
-        issue,
-        interactions: await fetchIssueInteractions(ctx, baseUrl, issue.id, boardApiToken),
-      })),
-    );
-    for (const { issue, interactions } of results) {
-      for (const interaction of interactions) {
-        if (interaction.status !== "pending") continue;
-        pending.push({
-          id: interaction.id ?? "",
-          issueId: issue.id,
-          issueIdentifier: issue.identifier ?? undefined,
-          kind: interaction.kind ?? "unknown",
-          title: interaction.title ?? "(untitled)",
-          summary: interaction.summary ?? null,
-          status: interaction.status,
-        });
-      }
-    }
-  }
+  const parsed = (await response.json()) as RawAttention;
+  const items = Array.isArray(parsed.items) ? parsed.items.map(toAttentionItem) : [];
 
-  return { pending, scanned: issues.length };
+  return {
+    items,
+    totalCount: typeof parsed.totalCount === "number" ? parsed.totalCount : items.length,
+  };
 }
 
-export function renderPendingInteraction(item: PendingInteraction, publicUrl?: string): string {
-  const lines = [
-    `${escapeMarkdownV2("🗳")} *${escapeMarkdownV2(item.title)}*`,
-    escapeMarkdownV2(`${describeKind(item.kind)} · ${item.issueIdentifier ?? item.issueId}`),
-  ];
+export function renderAttentionItem(item: AttentionItem, publicUrl?: string): string {
+  const heading = `${severityMarker(item.severity)} *${escapeMarkdownV2(item.title)}*`;
+  const context = [describeSourceKind(item.sourceKind), item.issueIdentifier]
+    .filter(Boolean)
+    .join(" · ");
+  const lines = [heading, escapeMarkdownV2(context)];
 
-  const summary = (item.summary ?? "").trim();
-  if (summary) {
-    const excerpt = summary.length > 350 ? `${summary.slice(0, 350)}…` : summary;
+  // whyNow is the host's own one-line explanation of urgency. Preferring it
+  // over anything invented here keeps the bot and the web UI telling the same
+  // story about the same item.
+  if (item.whyNow) lines.push("", escapeMarkdownV2(item.whyNow));
+
+  if (item.excerpt) {
+    const excerpt = item.excerpt.length > 300 ? `${item.excerpt.slice(0, 300)}…` : item.excerpt;
     lines.push("", escapeMarkdownV2(excerpt));
   }
 
-  // Answering needs a form (free text, per-question picks), which Telegram
-  // buttons cannot render — so link out rather than pretend to collect it.
-  if (publicUrl && item.issueIdentifier) {
-    lines.push("", escapeMarkdownV2(`Answer: ${publicUrl}/decisions`));
+  if (item.verbs.length > 0) {
+    lines.push("", escapeMarkdownV2(`Options: ${item.verbs.join(" / ")}`));
+  }
+
+  // Deep-link to the item itself, not to the Decisions index — href already
+  // carries the interaction anchor, so this lands on the thing being decided.
+  if (publicUrl && item.issueHref) {
+    lines.push("", escapeMarkdownV2(`Open: ${publicUrl}${item.issueHref}`));
   }
 
   return lines.join("\n");
 }
 
-export async function sendPendingList(
+export async function sendAttentionList(
   ctx: PluginContext,
   token: string,
   chatId: string,
-  found: { pending: PendingInteraction[]; scanned: number },
+  found: AttentionResult,
   opts: { messageThreadId?: number; publicUrl?: string; limit?: number } = {},
 ): Promise<void> {
-  const { pending, scanned } = found;
+  const { items, totalCount } = found;
 
-  if (pending.length === 0) {
-    await sendMessage(
-      ctx,
-      token,
-      chatId,
-      `Nothing is waiting on your input (checked the ${scanned} most recent issues).`,
-      { messageThreadId: opts.messageThreadId },
-    );
+  if (items.length === 0) {
+    await sendMessage(ctx, token, chatId, "Nothing is waiting on your input.", {
+      messageThreadId: opts.messageThreadId,
+    });
     return;
   }
 
-  const limit = opts.limit ?? 5;
-  for (const item of pending.slice(0, limit)) {
-    await sendMessage(ctx, token, chatId, renderPendingInteraction(item, opts.publicUrl), {
+  const limit = opts.limit ?? DEFAULT_DISPLAY_LIMIT;
+  for (const item of items.slice(0, limit)) {
+    await sendMessage(ctx, token, chatId, renderAttentionItem(item, opts.publicUrl), {
       parseMode: "MarkdownV2",
       messageThreadId: opts.messageThreadId,
     });
   }
 
-  if (pending.length > limit) {
-    await sendMessage(
-      ctx,
-      token,
-      chatId,
-      `…and ${pending.length - limit} more waiting.`,
-      { messageThreadId: opts.messageThreadId },
-    );
+  if (totalCount > limit) {
+    await sendMessage(ctx, token, chatId, `…and ${totalCount - limit} more waiting.`, {
+      messageThreadId: opts.messageThreadId,
+    });
   }
+}
+
+/**
+ * Turn a failure into something the reader can act on. A raw
+ * `403: {"error":"Board access required"}` names the symptom and hides the
+ * cause: the board token was not resolved for this update.
+ */
+export function describeDecisionsError(err: unknown): string {
+  const message = err instanceof Error ? err.message : String(err);
+
+  if (/\b(401|403)\b/.test(message) || /board access/i.test(message)) {
+    return [
+      "Can't read decisions — the bot has no board access right now.",
+      "",
+      "This is the plugin's board API token failing to resolve, not a permissions change on your account. It usually means the plugin config was loaded without a company scope, which happens on worker restart.",
+    ].join("\n");
+  }
+
+  return `Could not load decisions: ${message}`;
 }

--- a/src/escalation.ts
+++ b/src/escalation.ts
@@ -344,7 +344,7 @@ export class EscalationManager {
     });
   }
 
-  async checkTimeouts(ctx: PluginContext, token: string): Promise<void> {
+  async checkTimeouts(ctx: PluginContext, token: string, companyId?: string): Promise<void> {
     const pendingIds = (await ctx.state.get({
       scopeKind: "instance",
       stateKey: "escalation_pending_ids",
@@ -364,6 +364,7 @@ export class EscalationManager {
         await this.removePending(ctx, escalationId);
         continue;
       }
+      if (companyId && stored.companyId !== companyId) continue;
 
       const timeoutAt = new Date(stored.timeoutAt).getTime();
       if (now < timeoutAt) continue;

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -56,6 +56,15 @@ function runButton(agentId: string, runId: string | null, publicUrl?: string): {
   return null;
 }
 
+function runIdLine(runId: string): string {
+  return `${esc("run_id")}: ${code(runId)}`;
+}
+
+function issueRunLabel(payload: Payload): string | null {
+  const identifier = payload.issueIdentifier ?? payload.identifier;
+  return identifier ? String(identifier) : null;
+}
+
 function classifyAgentError(errorMessage: string): string {
   if (/timed?\s*out|timeout/i.test(errorMessage)) return "Agent Timeout";
   if (/limit|rate.?limit|quota/i.test(errorMessage)) return "Agent Rate Limit";
@@ -257,7 +266,8 @@ export function formatAgentRunStarted(event: PluginEvent, opts?: IssueLinksOpts)
   const p = event.payload as Payload;
   const agentId = String(p.agentId ?? event.entityId);
   const agentName = String(p.agentName ?? agentId);
-  const runId = p.runId ? String(p.runId) : null;
+  const runId = String(p.runId ?? event.entityId);
+  const issueLabel = issueRunLabel(p);
 
   const buttons: Array<{ text: string; url: string }> = [];
   if (opts?.baseUrl && isExternalUrl(opts.baseUrl)) {
@@ -268,7 +278,10 @@ export function formatAgentRunStarted(event: PluginEvent, opts?: IssueLinksOpts)
   }
 
   return {
-    text: `${esc("▶️")} ${bold(agentName)} ${esc("started a new run")}`,
+    text: [
+      `${esc("▶️")} ${bold(agentName)} ${esc("started a new run")}${issueLabel ? ` ${bold(issueLabel)}` : ""}`,
+      runIdLine(runId),
+    ].join("\n"),
     options: {
       parseMode: "MarkdownV2",
       disableNotification: true,
@@ -281,7 +294,8 @@ export function formatAgentRunFinished(event: PluginEvent, opts?: IssueLinksOpts
   const p = event.payload as Payload;
   const agentId = String(p.agentId ?? event.entityId);
   const agentName = String(p.agentName ?? agentId);
-  const runId = p.runId ? String(p.runId) : null;
+  const runId = String(p.runId ?? event.entityId);
+  const issueLabel = issueRunLabel(p);
 
   const buttons: Array<{ text: string; url: string }> = [];
   if (opts?.baseUrl && isExternalUrl(opts.baseUrl)) {
@@ -292,7 +306,10 @@ export function formatAgentRunFinished(event: PluginEvent, opts?: IssueLinksOpts
   }
 
   return {
-    text: `${esc("⏹️")} ${bold(agentName)} ${esc("completed successfully")}`,
+    text: [
+      `${esc("⏹️")} ${bold(agentName)} ${esc("completed successfully")}${issueLabel ? ` ${bold(issueLabel)}` : ""}`,
+      runIdLine(runId),
+    ].join("\n"),
     options: {
       parseMode: "MarkdownV2",
       disableNotification: true,

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -56,15 +56,6 @@ function runButton(agentId: string, runId: string | null, publicUrl?: string): {
   return null;
 }
 
-function runIdLine(runId: string): string {
-  return `${esc("run_id")}: ${code(runId)}`;
-}
-
-function issueRunLabel(payload: Payload): string | null {
-  const identifier = payload.issueIdentifier ?? payload.identifier;
-  return identifier ? String(identifier) : null;
-}
-
 function classifyAgentError(errorMessage: string): string {
   if (/timed?\s*out|timeout/i.test(errorMessage)) return "Agent Timeout";
   if (/limit|rate.?limit|quota/i.test(errorMessage)) return "Agent Rate Limit";
@@ -266,8 +257,7 @@ export function formatAgentRunStarted(event: PluginEvent, opts?: IssueLinksOpts)
   const p = event.payload as Payload;
   const agentId = String(p.agentId ?? event.entityId);
   const agentName = String(p.agentName ?? agentId);
-  const runId = String(p.runId ?? event.entityId);
-  const issueLabel = issueRunLabel(p);
+  const runId = p.runId ? String(p.runId) : null;
 
   const buttons: Array<{ text: string; url: string }> = [];
   if (opts?.baseUrl && isExternalUrl(opts.baseUrl)) {
@@ -278,10 +268,7 @@ export function formatAgentRunStarted(event: PluginEvent, opts?: IssueLinksOpts)
   }
 
   return {
-    text: [
-      `${esc("▶️")} ${bold(agentName)} ${esc("started a new run")}${issueLabel ? ` ${bold(issueLabel)}` : ""}`,
-      runIdLine(runId),
-    ].join("\n"),
+    text: `${esc("▶️")} ${bold(agentName)} ${esc("started a new run")}`,
     options: {
       parseMode: "MarkdownV2",
       disableNotification: true,
@@ -294,8 +281,7 @@ export function formatAgentRunFinished(event: PluginEvent, opts?: IssueLinksOpts
   const p = event.payload as Payload;
   const agentId = String(p.agentId ?? event.entityId);
   const agentName = String(p.agentName ?? agentId);
-  const runId = String(p.runId ?? event.entityId);
-  const issueLabel = issueRunLabel(p);
+  const runId = p.runId ? String(p.runId) : null;
 
   const buttons: Array<{ text: string; url: string }> = [];
   if (opts?.baseUrl && isExternalUrl(opts.baseUrl)) {
@@ -306,10 +292,7 @@ export function formatAgentRunFinished(event: PluginEvent, opts?: IssueLinksOpts
   }
 
   return {
-    text: [
-      `${esc("⏹️")} ${bold(agentName)} ${esc("completed successfully")}${issueLabel ? ` ${bold(issueLabel)}` : ""}`,
-      runIdLine(runId),
-    ].join("\n"),
+    text: `${esc("⏹️")} ${bold(agentName)} ${esc("completed successfully")}`,
     options: {
       parseMode: "MarkdownV2",
       disableNotification: true,

--- a/src/interaction-answers.ts
+++ b/src/interaction-answers.ts
@@ -1,0 +1,635 @@
+import type { PluginContext } from "@paperclipai/plugin-sdk";
+import { sendMessage, editMessage, answerCallbackQuery, escapeMarkdownV2, truncateAtWord } from "./telegram-api.js";
+import { buildPaperclipAuthHeaders, fetchPaperclipApi } from "./paperclip-api.js";
+import { METRIC_NAMES } from "./constants.js";
+
+/**
+ * Answer `ask_user_questions` and `request_confirmation` interactions from
+ * Telegram instead of only linking to the web UI (BLA-154).
+ *
+ * Two constraints shape this file:
+ *
+ * 1. Updates are processed strictly sequentially — `for (const update of
+ *    updates) { await handleUpdate(update) }` — so nothing here may await a
+ *    button press. Every flow sends a message and returns; the next step runs
+ *    from `resolveInteractionAnswerCallback` (button taps) or the reply-text
+ *    handler in worker.ts (typed rejection reasons), both driven by a LATER
+ *    update. This is the same defect that shipped and got reverted in
+ *    BLA-150/BLA-153.
+ * 2. Telegram caps `callback_data` at 64 bytes. A button needs to carry both
+ *    an issue id and an interaction id (two UUIDs, 72+ bytes) to call the
+ *    resolve endpoint, which does not fit alongside a prefix and an action.
+ *    So callback_data carries a short, plugin-generated key; the key maps to
+ *    the actual ids in `ctx.state`, not in the button itself.
+ *
+ * Scope, deliberately: only shapes that can be answered without losing
+ * information. `ask_user_questions` is answerable only when every option on
+ * every question is a plain pick — a question with a designer-declared
+ * free-text option (`option.freeText`) still links to the web UI, because a
+ * button cannot collect that text. `request_confirmation` is always
+ * answerable: accepting is a button, and rejecting — with or without a
+ * required reason — is "reply to this message", which the reply already
+ * carries as the reason text.
+ *
+ * decisions.ts is the caller: the attention feed it reads (BLA-159's
+ * GET /companies/:id/attention) marks `issue_thread_interaction` items
+ * `inlineResolvable` and hands back a `decisionVerbs` label, but not the
+ * question/option payload needed to render buttons — that still requires
+ * fetching the full interaction (`fetchInteraction`, below) for the issue it
+ * belongs to.
+ */
+
+const CALLBACK_PREFIX = "int_";
+const STATE_NAMESPACE = "interaction-answers";
+
+export type AskUserQuestionsOption = {
+  id: string;
+  label: string;
+  description?: string | null;
+  freeText?: boolean;
+};
+
+export type AskUserQuestionsQuestion = {
+  id: string;
+  prompt: string;
+  helpText?: string | null;
+  selectionMode: "single" | "multi";
+  required?: boolean;
+  options: AskUserQuestionsOption[];
+};
+
+export type AskUserQuestionsPayload = {
+  version: 1;
+  title?: string | null;
+  questions: AskUserQuestionsQuestion[];
+};
+
+export type AskUserQuestionsAnswer = {
+  questionId: string;
+  optionIds: string[];
+};
+
+export type RequestConfirmationPayload = {
+  version: 1;
+  prompt: string;
+  acceptLabel?: string | null;
+  rejectLabel?: string | null;
+  rejectRequiresReason?: boolean;
+  detailsMarkdown?: string | null;
+  toolAction?: {
+    risk: "write" | "destructive";
+    toolDisplayName: string;
+    previewMarkdown: string;
+  };
+};
+
+export type AnswerableInteraction =
+  | { id: string; kind: "ask_user_questions"; payload: AskUserQuestionsPayload }
+  | { id: string; kind: "request_confirmation"; payload: RequestConfirmationPayload };
+
+type ParkedAskUserQuestions = {
+  kind: "ask_user_questions";
+  chatId: string;
+  messageThreadId?: number;
+  issueId: string;
+  interactionId: string;
+  questions: AskUserQuestionsQuestion[];
+  questionIndex: number;
+  answers: AskUserQuestionsAnswer[];
+  selectedOptionIds: string[];
+};
+
+type ParkedConfirmation = {
+  kind: "request_confirmation";
+  chatId: string;
+  messageThreadId?: number;
+  issueId: string;
+  interactionId: string;
+};
+
+type ParkedAnswer = ParkedAskUserQuestions | ParkedConfirmation;
+
+type ReplyMapping = {
+  entityId: string;
+  entityType: "interaction_reject_reason";
+  companyId: string;
+  issueId: string;
+};
+
+let counter = 0;
+/** Short, unique, underscore-free — safe to split out of callback_data. */
+function nextKey(): string {
+  counter = (counter + 1) % 100000;
+  return `${Date.now().toString(36)}${counter.toString(36)}`;
+}
+
+function stateKeyFor(key: string) {
+  return { scopeKind: "instance" as const, namespace: STATE_NAMESPACE, stateKey: key };
+}
+
+async function loadParked(ctx: PluginContext, key: string): Promise<ParkedAnswer | null> {
+  return (await ctx.state.get(stateKeyFor(key))) as ParkedAnswer | null;
+}
+
+async function saveParked(ctx: PluginContext, key: string, value: ParkedAnswer): Promise<void> {
+  await ctx.state.set(stateKeyFor(key), value);
+}
+
+async function clearParked(ctx: PluginContext, key: string): Promise<void> {
+  await ctx.state.delete(stateKeyFor(key));
+}
+
+export function isInteractionAnswerCallback(data: string): boolean {
+  return data.startsWith(CALLBACK_PREFIX);
+}
+
+/**
+ * A question is answerable via buttons only if every option on it is a plain
+ * pick. A designer-declared free-text option (`option.freeText`) means the
+ * question can only be answered faithfully with typed text, which buttons
+ * cannot supply — so the whole interaction falls back to the web-UI link
+ * rather than collecting an answer that silently drops that option.
+ */
+export function isAskUserQuestionsAnswerable(payload: AskUserQuestionsPayload): boolean {
+  return (
+    payload.questions.length > 0 &&
+    payload.questions.every((q) => q.options.length > 0 && q.options.every((o) => o.freeText !== true))
+  );
+}
+
+function optionLabel(option: AskUserQuestionsOption, selected: boolean, multi: boolean): string {
+  const mark = multi ? (selected ? "☑ " : "☐ ") : "";
+  return `${mark}${option.label}`.slice(0, 64);
+}
+
+function questionButtons(key: string, question: AskUserQuestionsQuestion, selectedOptionIds: string[]) {
+  const multi = question.selectionMode === "multi";
+  const rows = question.options.map((option, index) => [
+    {
+      text: optionLabel(option, selectedOptionIds.includes(option.id), multi),
+      callback_data: `${CALLBACK_PREFIX}${key}_o${index}`,
+    },
+  ]);
+  if (multi) {
+    rows.push([{ text: "Continue ▶", callback_data: `${CALLBACK_PREFIX}${key}_done` }]);
+  }
+  if (!question.required) {
+    rows.push([{ text: "Skip", callback_data: `${CALLBACK_PREFIX}${key}_skip` }]);
+  }
+  return rows;
+}
+
+function renderQuestionText(question: AskUserQuestionsQuestion, index: number, total: number): string {
+  const lines = [
+    escapeMarkdownV2(`Question ${index + 1} of ${total}`),
+    `*${escapeMarkdownV2(question.prompt)}*`,
+  ];
+  if (question.helpText) lines.push(escapeMarkdownV2(question.helpText));
+  if (question.selectionMode === "multi") {
+    lines.push(escapeMarkdownV2("Pick any that apply, then Continue."));
+  }
+  return lines.join("\n");
+}
+
+async function sendAskUserQuestionsPrompt(
+  ctx: PluginContext,
+  token: string,
+  chatId: string,
+  opts: { issueId: string; interactionId: string; payload: AskUserQuestionsPayload; messageThreadId?: number },
+): Promise<boolean> {
+  if (!isAskUserQuestionsAnswerable(opts.payload)) return false;
+
+  const key = nextKey();
+  await saveParked(ctx, key, {
+    kind: "ask_user_questions",
+    chatId,
+    messageThreadId: opts.messageThreadId,
+    issueId: opts.issueId,
+    interactionId: opts.interactionId,
+    questions: opts.payload.questions,
+    questionIndex: 0,
+    answers: [],
+    selectedOptionIds: [],
+  });
+
+  const question = opts.payload.questions[0]!;
+  await sendMessage(ctx, token, chatId, renderQuestionText(question, 0, opts.payload.questions.length), {
+    parseMode: "MarkdownV2",
+    messageThreadId: opts.messageThreadId,
+    inlineKeyboard: questionButtons(key, question, []),
+  });
+  return true;
+}
+
+function renderConfirmationText(payload: RequestConfirmationPayload): string {
+  const lines = [`*${escapeMarkdownV2("Confirmation needed")}*`, "", escapeMarkdownV2(payload.prompt)];
+  if (payload.toolAction) {
+    lines.push(
+      "",
+      escapeMarkdownV2(`⚠️ ${payload.toolAction.risk} action: ${payload.toolAction.toolDisplayName}`),
+      escapeMarkdownV2(truncateAtWord(payload.toolAction.previewMarkdown, 350)),
+    );
+  } else if (payload.detailsMarkdown) {
+    lines.push("", escapeMarkdownV2(truncateAtWord(payload.detailsMarkdown, 350)));
+  }
+  lines.push(
+    "",
+    escapeMarkdownV2(
+      payload.rejectRequiresReason
+        ? "Reply to this message with your reason to reject."
+        : "Tap Reject, or reply to this message with a reason to reject with one.",
+    ),
+  );
+  return lines.join("\n");
+}
+
+async function sendRequestConfirmationPrompt(
+  ctx: PluginContext,
+  token: string,
+  chatId: string,
+  opts: {
+    companyId?: string;
+    issueId: string;
+    interactionId: string;
+    payload: RequestConfirmationPayload;
+    messageThreadId?: number;
+  },
+): Promise<boolean> {
+  const key = nextKey();
+  await saveParked(ctx, key, {
+    kind: "request_confirmation",
+    chatId,
+    messageThreadId: opts.messageThreadId,
+    issueId: opts.issueId,
+    interactionId: opts.interactionId,
+  });
+
+  const buttons = [[{ text: opts.payload.acceptLabel ?? "✅ Accept", callback_data: `${CALLBACK_PREFIX}${key}_accept` }]];
+  if (!opts.payload.rejectRequiresReason) {
+    buttons[0]!.push({ text: opts.payload.rejectLabel ?? "❌ Reject", callback_data: `${CALLBACK_PREFIX}${key}_reject` });
+  }
+
+  const messageId = await sendMessage(ctx, token, chatId, renderConfirmationText(opts.payload), {
+    parseMode: "MarkdownV2",
+    messageThreadId: opts.messageThreadId,
+    inlineKeyboard: buttons,
+  });
+
+  // Replying to this message is always a valid way to reject with a reason,
+  // required or not — register it the same way the issue/escalation reply
+  // routing already does, so worker.ts's existing dispatcher picks it up.
+  if (messageId && opts.companyId) {
+    const mapping: ReplyMapping = {
+      entityId: opts.interactionId,
+      entityType: "interaction_reject_reason",
+      companyId: opts.companyId,
+      issueId: opts.issueId,
+    };
+    await ctx.state.set(
+      { scopeKind: "company", scopeId: opts.companyId, stateKey: `msg_${chatId}_${messageId}` },
+      mapping,
+    );
+  }
+
+  return true;
+}
+
+/**
+ * Send an interactive prompt for an interaction, if its shape supports one.
+ * Returns false when the caller should fall back to the existing web-UI link
+ * — the interaction is not answerable via Telegram buttons.
+ */
+export async function sendAnswerableInteraction(
+  ctx: PluginContext,
+  token: string,
+  chatId: string,
+  interaction: AnswerableInteraction,
+  opts: { issueId: string; companyId?: string; messageThreadId?: number },
+): Promise<boolean> {
+  if (interaction.kind === "ask_user_questions") {
+    return sendAskUserQuestionsPrompt(ctx, token, chatId, {
+      issueId: opts.issueId,
+      interactionId: interaction.id,
+      payload: interaction.payload,
+      messageThreadId: opts.messageThreadId,
+    });
+  }
+  if (interaction.kind === "request_confirmation") {
+    return sendRequestConfirmationPrompt(ctx, token, chatId, {
+      companyId: opts.companyId,
+      issueId: opts.issueId,
+      interactionId: interaction.id,
+      payload: interaction.payload,
+      messageThreadId: opts.messageThreadId,
+    });
+  }
+  return false;
+}
+
+// --- Fetching & resolving ---
+
+export type FreshInteraction = { id: string; status: string; kind: string; payload: unknown };
+
+/**
+ * Fetch one interaction with its full payload — the attention feed's
+ * `issue_thread_interaction` items carry only an excerpt, not the
+ * question/option data buttons need. Also used, ignoring `payload`, as the
+ * pre-resolve freshness check.
+ */
+export async function fetchInteraction(
+  ctx: PluginContext,
+  baseUrl: string,
+  issueId: string,
+  interactionId: string,
+  boardApiToken?: string,
+): Promise<FreshInteraction | null> {
+  try {
+    const response = await fetchPaperclipApi(ctx, `${baseUrl}/api/issues/${issueId}/interactions`, {
+      method: "GET",
+      headers: { ...buildPaperclipAuthHeaders(boardApiToken) },
+    });
+    const parsed = (await response.json()) as unknown;
+    const list = Array.isArray(parsed) ? (parsed as FreshInteraction[]) : [];
+    return list.find((item) => item.id === interactionId) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function postInteractionAction(
+  ctx: PluginContext,
+  baseUrl: string,
+  issueId: string,
+  interactionId: string,
+  action: "accept" | "reject" | "respond",
+  body: unknown,
+  boardApiToken?: string,
+): Promise<{ status: string }> {
+  const response = await fetchPaperclipApi(ctx, `${baseUrl}/api/issues/${issueId}/interactions/${interactionId}/${action}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...buildPaperclipAuthHeaders(boardApiToken) },
+    body: JSON.stringify(body),
+  });
+  return (await response.json()) as { status: string };
+}
+
+async function finishAskUserQuestions(
+  ctx: PluginContext,
+  token: string,
+  baseUrl: string,
+  boardApiToken: string | undefined,
+  parked: ParkedAskUserQuestions,
+  messageId?: number,
+): Promise<void> {
+  try {
+    const result = await postInteractionAction(
+      ctx,
+      baseUrl,
+      parked.issueId,
+      parked.interactionId,
+      "respond",
+      { answers: parked.answers },
+      boardApiToken,
+    );
+    await ctx.metrics.write(METRIC_NAMES.interactionAnswered, 1);
+    const text = result.status === "answered"
+      ? "✅ Answer recorded."
+      : `Recorded, but the interaction is now "${result.status}". Check /decisions or the web UI.`;
+    if (messageId) await editMessage(ctx, token, parked.chatId, messageId, text);
+    else await sendMessage(ctx, token, parked.chatId, text, { messageThreadId: parked.messageThreadId });
+  } catch (err) {
+    const text = `Could not submit your answer: ${err instanceof Error ? err.message : String(err)}`;
+    if (messageId) await editMessage(ctx, token, parked.chatId, messageId, text);
+    else await sendMessage(ctx, token, parked.chatId, text, { messageThreadId: parked.messageThreadId });
+  }
+}
+
+async function advanceAskUserQuestions(
+  ctx: PluginContext,
+  token: string,
+  baseUrl: string,
+  boardApiToken: string | undefined,
+  key: string,
+  parked: ParkedAskUserQuestions,
+  answer: AskUserQuestionsAnswer,
+  messageId?: number,
+): Promise<void> {
+  const answers = [...parked.answers, answer];
+  const nextIndex = parked.questionIndex + 1;
+
+  if (nextIndex >= parked.questions.length) {
+    await clearParked(ctx, key);
+    await finishAskUserQuestions(ctx, token, baseUrl, boardApiToken, { ...parked, answers }, messageId);
+    return;
+  }
+
+  const next: ParkedAskUserQuestions = { ...parked, answers, questionIndex: nextIndex, selectedOptionIds: [] };
+  await saveParked(ctx, key, next);
+  const question = parked.questions[nextIndex]!;
+  await sendMessage(ctx, token, parked.chatId, renderQuestionText(question, nextIndex, parked.questions.length), {
+    parseMode: "MarkdownV2",
+    messageThreadId: parked.messageThreadId,
+    inlineKeyboard: questionButtons(key, question, []),
+  });
+}
+
+async function handleAskUserQuestionsAction(
+  ctx: PluginContext,
+  token: string,
+  baseUrl: string,
+  boardApiToken: string | undefined,
+  key: string,
+  parked: ParkedAskUserQuestions,
+  action: string,
+  callbackQueryId: string,
+  messageId?: number,
+): Promise<void> {
+  const question = parked.questions[parked.questionIndex];
+  if (!question) {
+    await clearParked(ctx, key);
+    await answerCallbackQuery(ctx, token, callbackQueryId, "This question flow is out of sync. Use /decisions to retry.");
+    return;
+  }
+
+  if (action === "skip") {
+    // The button is never offered for a required question, but the action is
+    // still validated here rather than trusted from callback_data alone.
+    if (question.required) {
+      await answerCallbackQuery(ctx, token, callbackQueryId, "This question requires an answer.");
+      return;
+    }
+    await answerCallbackQuery(ctx, token, callbackQueryId, "Skipped");
+    await advanceAskUserQuestions(ctx, token, baseUrl, boardApiToken, key, parked, { questionId: question.id, optionIds: [] }, messageId);
+    return;
+  }
+
+  if (action === "done") {
+    if (question.required && parked.selectedOptionIds.length === 0) {
+      await answerCallbackQuery(ctx, token, callbackQueryId, "Pick at least one option first.");
+      return;
+    }
+    await answerCallbackQuery(ctx, token, callbackQueryId, "Recorded");
+    await advanceAskUserQuestions(
+      ctx, token, baseUrl, boardApiToken, key, parked,
+      { questionId: question.id, optionIds: parked.selectedOptionIds }, messageId,
+    );
+    return;
+  }
+
+  const optionMatch = /^o(\d+)$/.exec(action);
+  if (!optionMatch) {
+    await answerCallbackQuery(ctx, token, callbackQueryId, "Unknown action");
+    return;
+  }
+  const optionIndex = Number(optionMatch[1]);
+  const option = question.options[optionIndex];
+  if (!option) {
+    await answerCallbackQuery(ctx, token, callbackQueryId, "Unknown option");
+    return;
+  }
+
+  if (question.selectionMode === "single") {
+    await answerCallbackQuery(ctx, token, callbackQueryId, `Picked: ${option.label}`);
+    await advanceAskUserQuestions(ctx, token, baseUrl, boardApiToken, key, parked, { questionId: question.id, optionIds: [option.id] }, messageId);
+    return;
+  }
+
+  // Multi-select: toggle and re-render this same question with updated marks.
+  const selectedOptionIds = parked.selectedOptionIds.includes(option.id)
+    ? parked.selectedOptionIds.filter((id) => id !== option.id)
+    : [...parked.selectedOptionIds, option.id];
+  await saveParked(ctx, key, { ...parked, selectedOptionIds });
+  await answerCallbackQuery(ctx, token, callbackQueryId, selectedOptionIds.includes(option.id) ? `Added: ${option.label}` : `Removed: ${option.label}`);
+  if (messageId) {
+    await editMessage(ctx, token, parked.chatId, messageId, renderQuestionText(question, parked.questionIndex, parked.questions.length), {
+      parseMode: "MarkdownV2",
+      inlineKeyboard: questionButtons(key, question, selectedOptionIds),
+    });
+  }
+}
+
+async function handleConfirmationAction(
+  ctx: PluginContext,
+  token: string,
+  baseUrl: string,
+  boardApiToken: string | undefined,
+  key: string,
+  parked: ParkedConfirmation,
+  action: "accept" | "reject",
+  callbackQueryId: string,
+  messageId?: number,
+): Promise<void> {
+  await clearParked(ctx, key);
+  try {
+    const result = await postInteractionAction(ctx, baseUrl, parked.issueId, parked.interactionId, action, {}, boardApiToken);
+    await ctx.metrics.write(METRIC_NAMES.interactionAnswered, 1);
+    const expected = action === "accept" ? "accepted" : "rejected";
+    const text = result.status === expected
+      ? (action === "accept" ? "✅ Accepted." : "❌ Rejected.")
+      : `Recorded, but the interaction is now "${result.status}". Check /decisions or the web UI.`;
+    await answerCallbackQuery(ctx, token, callbackQueryId, text.replace(/[✅❌]\s*/u, ""));
+    if (messageId) await editMessage(ctx, token, parked.chatId, messageId, text);
+  } catch (err) {
+    const text = `Could not ${action} this: ${err instanceof Error ? err.message : String(err)}`;
+    await answerCallbackQuery(ctx, token, callbackQueryId, text);
+    if (messageId) await editMessage(ctx, token, parked.chatId, messageId, text);
+  }
+}
+
+/**
+ * Resolve an `int_`-prefixed callback_query. Everything needed to act (issue
+ * id, interaction id, in-progress answers) lives in the parked state under
+ * `key` — the callback only carried the key and the tapped action.
+ */
+export async function resolveInteractionAnswerCallback(
+  ctx: PluginContext,
+  token: string,
+  data: string,
+  callbackQueryId: string,
+  baseUrl: string,
+  boardApiToken: string | undefined,
+  messageId?: number,
+): Promise<boolean> {
+  if (!isInteractionAnswerCallback(data)) return false;
+  const body = data.slice(CALLBACK_PREFIX.length);
+  const separator = body.lastIndexOf("_");
+  if (separator <= 0) {
+    await answerCallbackQuery(ctx, token, callbackQueryId, "Unknown action");
+    return true;
+  }
+  const key = body.slice(0, separator);
+  const action = body.slice(separator + 1);
+
+  const parked = await loadParked(ctx, key);
+  if (!parked) {
+    await answerCallbackQuery(ctx, token, callbackQueryId, "This has expired or was already answered. Use /decisions to check again.");
+    return true;
+  }
+
+  // Resolved against the interaction as it stands NOW, not as it was when the
+  // message was sent — it may have been withdrawn, expired, or answered
+  // elsewhere (web UI, another chat) since.
+  const fresh = await fetchInteraction(ctx, baseUrl, parked.issueId, parked.interactionId, boardApiToken);
+  if (!fresh || fresh.status !== "pending") {
+    await clearParked(ctx, key);
+    const status = fresh?.status ?? "gone";
+    await answerCallbackQuery(ctx, token, callbackQueryId, `This is no longer pending (${status}). Use /decisions to check again.`);
+    if (messageId) {
+      await editMessage(ctx, token, parked.chatId, messageId, `This is no longer pending (${status}).`);
+    }
+    return true;
+  }
+
+  if (parked.kind === "ask_user_questions") {
+    await handleAskUserQuestionsAction(ctx, token, baseUrl, boardApiToken, key, parked, action, callbackQueryId, messageId);
+    return true;
+  }
+
+  if (action !== "accept" && action !== "reject") {
+    await answerCallbackQuery(ctx, token, callbackQueryId, "Unknown action");
+    return true;
+  }
+  await handleConfirmationAction(ctx, token, baseUrl, boardApiToken, key, parked, action, callbackQueryId, messageId);
+  return true;
+}
+
+/**
+ * The typed-text half of the reply-to-reject flow: a message that replies to
+ * a confirmation prompt becomes that confirmation's rejection reason. Called
+ * from worker.ts's existing reply-routing dispatch, which already resolves
+ * the `msg_${chatId}_${messageId}` mapping this module wrote at send time.
+ */
+export async function finalizeReplyRejection(
+  ctx: PluginContext,
+  token: string,
+  baseUrl: string,
+  boardApiToken: string | undefined,
+  mapping: ReplyMapping,
+  reasonText: string,
+  chatId: string,
+): Promise<void> {
+  try {
+    const fresh = await fetchInteraction(ctx, baseUrl, mapping.issueId, mapping.entityId, boardApiToken);
+    if (!fresh || fresh.status !== "pending") {
+      const status = fresh?.status ?? "gone";
+      await sendMessage(ctx, token, chatId, `This is no longer pending (${status}).`);
+      return;
+    }
+    const result = await postInteractionAction(ctx, baseUrl, mapping.issueId, mapping.entityId, "reject", { reason: reasonText }, boardApiToken);
+    await ctx.metrics.write(METRIC_NAMES.interactionAnswered, 1);
+    const text = result.status === "rejected"
+      ? "❌ Rejected with your reason."
+      : `Recorded, but the interaction is now "${result.status}". Check /decisions or the web UI.`;
+    await sendMessage(ctx, token, chatId, text);
+  } catch (err) {
+    await sendMessage(ctx, token, chatId, `Could not reject this: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+export function isInteractionReplyMapping(value: unknown): value is ReplyMapping {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    (value as Record<string, unknown>).entityType === "interaction_reject_reason"
+  );
+}

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -53,6 +53,10 @@ const manifest: PaperclipPluginManifestV1 = {
         type: "string",
         format: "secret-ref",
       },
+      transcriptionApiKeyRef: {
+        type: "string",
+        format: "secret-ref",
+      },
     },
   },
   ui: {

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -41,6 +41,20 @@ const manifest: PaperclipPluginManifestV1 = {
     worker: "./dist/worker.js",
     ui: "./dist/ui",
   },
+  instanceConfigSchema: {
+    type: "object",
+    additionalProperties: true,
+    properties: {
+      telegramBotTokenRef: {
+        type: "string",
+        format: "secret-ref",
+      },
+      paperclipBoardApiTokenRef: {
+        type: "string",
+        format: "secret-ref",
+      },
+    },
+  },
   ui: {
     slots: [
       {
@@ -55,8 +69,8 @@ const manifest: PaperclipPluginManifestV1 = {
     {
       jobKey: "telegram-daily-digest",
       displayName: "Telegram Digest",
-      description: "Send a summary of agent activity to Telegram (daily or bidaily).",
-      schedule: "0 * * * *",
+      description: "Send a summary of agent activity to Telegram (daily, bidaily, or tridaily).",
+      schedule: "* * * * *",
     },
     {
       jobKey: "check-escalation-timeouts",

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -73,8 +73,8 @@ const manifest: PaperclipPluginManifestV1 = {
     {
       jobKey: "telegram-daily-digest",
       displayName: "Telegram Digest",
-      description: "Send a summary of agent activity to Telegram (daily, bidaily, or tridaily).",
-      schedule: "* * * * *",
+      description: "Send a summary of agent activity to Telegram (daily or bidaily).",
+      schedule: "0 * * * *",
     },
     {
       jobKey: "check-escalation-timeouts",

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -45,16 +45,25 @@ const manifest: PaperclipPluginManifestV1 = {
     type: "object",
     additionalProperties: true,
     properties: {
+      // Secret refs accept BOTH shapes on purpose.
+      //
+      // Older hosts store a bare secret UUID string. Current hosts validate
+      // config against this schema AND separately enforce their own secret-ref
+      // rule requiring an object: { type: "secret_ref", secretId, version? }.
+      // With `type: "string"` alone the two are mutually unsatisfiable — the
+      // object fails this schema ("must be string") and the string fails the
+      // host ('must use { type: "secret_ref", ... }') — so the plugin cannot be
+      // configured at all on such a host.
       telegramBotTokenRef: {
-        type: "string",
+        type: ["string", "object"],
         format: "secret-ref",
       },
       paperclipBoardApiTokenRef: {
-        type: "string",
+        type: ["string", "object"],
         format: "secret-ref",
       },
       transcriptionApiKeyRef: {
-        type: "string",
+        type: ["string", "object"],
         format: "secret-ref",
       },
     },

--- a/src/media-pipeline.ts
+++ b/src/media-pipeline.ts
@@ -59,7 +59,7 @@ export async function handleMediaMessage(
   // Transcribe audio/voice if applicable
   if (isAudio && config.transcriptionApiKeyRef) {
     try {
-      const transcription = await transcribeAudio(ctx, token, fileId, config.transcriptionApiKeyRef);
+      const transcription = await transcribeAudio(ctx, token, fileId, config.transcriptionApiKeyRef, companyId);
       if (transcription) {
         textContent = transcription;
 
@@ -175,6 +175,7 @@ async function transcribeAudio(
   botToken: string,
   fileId: string,
   transcriptionApiKeyRef: string,
+  companyId: string,
 ): Promise<string | null> {
   // 1. Get file path from Telegram (JSON response — ctx.http.fetch works fine for this)
   const fileRes = await ctx.http.fetch(
@@ -193,7 +194,8 @@ async function transcribeAudio(
   const audioBuffer = Buffer.from(await audioRes.arrayBuffer());
 
   // 3. Resolve the OpenAI API key from Paperclip secrets
-  const apiKey = await ctx.secrets.resolve(transcriptionApiKeyRef);
+  const resolveSecret = ctx.secrets.resolve as (secretRef: string, companyId?: string | null) => Promise<string>;
+  const apiKey = await resolveSecret(transcriptionApiKeyRef, companyId);
 
   // 4. Build multipart form data manually (native FormData + Blob works in Node 18+)
   const formData = new FormData();

--- a/src/media-pipeline.ts
+++ b/src/media-pipeline.ts
@@ -194,8 +194,10 @@ async function transcribeAudio(
   const audioBuffer = Buffer.from(await audioRes.arrayBuffer());
 
   // 3. Resolve the OpenAI API key from Paperclip secrets
-  const resolveSecret = ctx.secrets.resolve as (secretRef: string, companyId?: string | null) => Promise<string>;
-  const apiKey = await resolveSecret(transcriptionApiKeyRef, companyId);
+  const apiKey = await ctx.secrets.resolve(transcriptionApiKeyRef, {
+    companyId,
+    configPath: "transcriptionApiKeyRef",
+  });
 
   // 4. Build multipart form data manually (native FormData + Blob works in Node 18+)
   const formData = new FormData();

--- a/src/polling-dispatch.ts
+++ b/src/polling-dispatch.ts
@@ -1,0 +1,68 @@
+export type TelegramDispatchConfig = {
+  defaultChatId?: unknown;
+  approvalsChatId?: unknown;
+  errorsChatId?: unknown;
+  digestChatId?: unknown;
+  escalationChatId?: unknown;
+  allowedTelegramChatIds?: unknown;
+  briefAgentChatIds?: unknown;
+};
+
+export type TelegramDispatchRuntime = {
+  companyId: string;
+  config: TelegramDispatchConfig;
+};
+
+export type TelegramDispatchUpdate = {
+  message?: {
+    chat: { id: number };
+  };
+  callback_query?: {
+    message?: {
+      chat: { id: number };
+    };
+  };
+};
+
+function addStringValue(values: Set<string>, value: unknown): void {
+  if (typeof value !== "string" && typeof value !== "number") return;
+  const normalized = String(value).trim();
+  if (normalized) values.add(normalized);
+}
+
+function addStringArray(values: Set<string>, source: unknown): void {
+  if (!Array.isArray(source)) return;
+  for (const value of source) addStringValue(values, value);
+}
+
+export function getTelegramUpdateChatId(update: TelegramDispatchUpdate): string | null {
+  const chatId = update.message?.chat.id ?? update.callback_query?.message?.chat.id;
+  return typeof chatId === "number" ? String(chatId) : null;
+}
+
+export function telegramRuntimeChatIds(config: TelegramDispatchConfig): Set<string> {
+  const values = new Set<string>();
+  addStringValue(values, config.defaultChatId);
+  addStringValue(values, config.approvalsChatId);
+  addStringValue(values, config.errorsChatId);
+  addStringValue(values, config.digestChatId);
+  addStringValue(values, config.escalationChatId);
+  addStringArray(values, config.allowedTelegramChatIds);
+  addStringArray(values, config.briefAgentChatIds);
+  return values;
+}
+
+export function selectTelegramRuntimeForUpdate<TRuntime extends TelegramDispatchRuntime>(
+  runtimes: TRuntime[],
+  update: TelegramDispatchUpdate,
+): TRuntime | null {
+  if (runtimes.length === 0) return null;
+
+  const chatId = getTelegramUpdateChatId(update);
+  if (!chatId) return runtimes.length === 1 ? runtimes[0] : null;
+
+  const matches = runtimes.filter((runtime) => telegramRuntimeChatIds(runtime.config).has(chatId));
+  if (matches.length === 1) return matches[0];
+
+  return runtimes.length === 1 ? runtimes[0] : null;
+}

--- a/src/secret-ref-validation.ts
+++ b/src/secret-ref-validation.ts
@@ -12,12 +12,31 @@ const FIELDS = [
   { key: "transcriptionApiKeyRef", required: false },
 ] as const;
 
-export function isValidSecretRef(value: unknown): value is string {
-  return typeof value === "string" && UUID_RE.test(value.trim());
+/**
+ * A secret reference, in either shape a Paperclip host may use.
+ *
+ * Older hosts take a bare secret UUID string. Current hosts require an object
+ * `{ type: "secret_ref", secretId, version? }` and reject the bare string, so
+ * both must be accepted or the plugin is unconfigurable on one of them.
+ */
+export type SecretRef = string | { type: "secret_ref"; secretId: string; version?: number };
+
+export function isValidSecretRef(value: unknown): value is SecretRef {
+  if (typeof value === "string") return UUID_RE.test(value.trim());
+  if (typeof value === "object" && value !== null) {
+    const record = value as { type?: unknown; secretId?: unknown };
+    return (
+      record.type === "secret_ref" &&
+      typeof record.secretId === "string" &&
+      UUID_RE.test(record.secretId.trim())
+    );
+  }
+  return false;
 }
 
 function describeBadValue(value: unknown): string {
   if (value === undefined || value === null) return "<empty>";
+  if (typeof value === "object") return "<object>";
   if (typeof value !== "string") return `<${typeof value}>`;
   const trimmed = value.trim();
   if (trimmed.length === 0) return "<empty string>";

--- a/src/secret-ref-validation.ts
+++ b/src/secret-ref-validation.ts
@@ -34,6 +34,29 @@ export function isValidSecretRef(value: unknown): value is SecretRef {
   return false;
 }
 
+/**
+ * Coerce a secret ref into the shape THIS host accepts before calling
+ * ctx.secrets.resolve().
+ *
+ * Refs reach us in both shapes: config validated by a current host holds
+ * `{ type: "secret_ref", secretId }`, while refs persisted earlier — notably
+ * the board-access state written by the Board Access panel — hold a bare UUID
+ * string. Hosts that require the object form reject the bare string with
+ * "Invalid secret reference for plugin: <uuid>. Use { type: "secret_ref" ... }",
+ * which surfaces to the user as an unexplained 403 from whatever the token was
+ * needed for.
+ *
+ * Passing the object through unchanged keeps older hosts working, since they
+ * accept it as an opaque ref.
+ */
+export function normalizeSecretRef(value: unknown): SecretRef | null {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return UUID_RE.test(trimmed) ? { type: "secret_ref", secretId: trimmed } : null;
+  }
+  return isValidSecretRef(value) ? value : null;
+}
+
 function describeBadValue(value: unknown): string {
   if (value === undefined || value === null) return "<empty>";
   if (typeof value === "object") return "<object>";

--- a/src/telegram-api.ts
+++ b/src/telegram-api.ts
@@ -11,6 +11,14 @@ type InlineButton = {
 
 type InlineKeyboard = InlineButton[][];
 
+async function writeMetric(ctx: PluginContext, name: string, value: number): Promise<void> {
+  try {
+    await ctx.metrics.write(name, value);
+  } catch (err) {
+    ctx.logger.warn("Telegram metric write failed", { error: String(err), metric: name });
+  }
+}
+
 export type SendMessageOptions = {
   parseMode?: "MarkdownV2" | "HTML";
   replyToMessageId?: number;
@@ -44,7 +52,7 @@ export async function sendMessage(
 
   for (let attempt = 0; attempt < 3; attempt++) {
     try {
-      const res = await ctx.http.fetch(`${TELEGRAM_API}/bot${token}/sendMessage`, {
+      const res = await fetch(`${TELEGRAM_API}/bot${token}/sendMessage`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
@@ -75,15 +83,15 @@ export async function sendMessage(
           });
         }
         ctx.logger.error("Telegram sendMessage failed", { error: data.description });
-        await ctx.metrics.write(METRIC_NAMES.failed, 1);
+        await writeMetric(ctx, METRIC_NAMES.failed, 1);
         return null;
       }
 
-      await ctx.metrics.write(METRIC_NAMES.sent, 1);
+      await writeMetric(ctx, METRIC_NAMES.sent, 1);
       return data.result?.message_id ?? null;
     } catch (err) {
       ctx.logger.error("Telegram API error", { error: String(err) });
-      await ctx.metrics.write(METRIC_NAMES.failed, 1);
+      await writeMetric(ctx, METRIC_NAMES.failed, 1);
       return null;
     }
   }

--- a/src/telegram-api.ts
+++ b/src/telegram-api.ts
@@ -11,14 +11,6 @@ type InlineButton = {
 
 type InlineKeyboard = InlineButton[][];
 
-async function writeMetric(ctx: PluginContext, name: string, value: number): Promise<void> {
-  try {
-    await ctx.metrics.write(name, value);
-  } catch (err) {
-    ctx.logger.warn("Telegram metric write failed", { error: String(err), metric: name });
-  }
-}
-
 export type SendMessageOptions = {
   parseMode?: "MarkdownV2" | "HTML";
   replyToMessageId?: number;
@@ -52,7 +44,7 @@ export async function sendMessage(
 
   for (let attempt = 0; attempt < 3; attempt++) {
     try {
-      const res = await fetch(`${TELEGRAM_API}/bot${token}/sendMessage`, {
+      const res = await ctx.http.fetch(`${TELEGRAM_API}/bot${token}/sendMessage`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
@@ -83,15 +75,15 @@ export async function sendMessage(
           });
         }
         ctx.logger.error("Telegram sendMessage failed", { error: data.description });
-        await writeMetric(ctx, METRIC_NAMES.failed, 1);
+        await ctx.metrics.write(METRIC_NAMES.failed, 1);
         return null;
       }
 
-      await writeMetric(ctx, METRIC_NAMES.sent, 1);
+      await ctx.metrics.write(METRIC_NAMES.sent, 1);
       return data.result?.message_id ?? null;
     } catch (err) {
       ctx.logger.error("Telegram API error", { error: String(err) });
-      await writeMetric(ctx, METRIC_NAMES.failed, 1);
+      await ctx.metrics.write(METRIC_NAMES.failed, 1);
       return null;
     }
   }

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -48,6 +48,14 @@ type Notice = {
   text?: string;
 };
 
+type CompanySecretSummary = {
+  id: string;
+  name: string;
+  key?: string | null;
+  status?: string | null;
+  latestVersion?: number | null;
+};
+
 type TelegramRoutingConfig = {
   defaultChatId: string;
   topicRouting: boolean;
@@ -565,6 +573,12 @@ async function fetchPluginConfig(companyId?: string | null): Promise<Record<stri
     pluginConfigPath(companyId),
   );
   return record?.configJson && typeof record.configJson === "object" ? record.configJson : {};
+}
+
+async function fetchCompanySecrets(companyId: string): Promise<CompanySecretSummary[]> {
+  return fetchHostJson<CompanySecretSummary[]>(
+    `/api/companies/${encodeURIComponent(companyId)}/secrets`,
+  );
 }
 
 async function savePluginConfig(configJson: Record<string, unknown>, companyId?: string | null): Promise<void> {
@@ -1224,20 +1238,21 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
         <div style={{ display: "grid", gap: 4 }}>
           <h2 style={{ fontSize: 18, fontWeight: 700, lineHeight: "28px", margin: 0 }}>Connection & URLs</h2>
           <p style={{ color: "#6b7280", margin: 0 }}>
-            Core connection values used by the Telegram worker. Save the bot token as a Paperclip secret and paste its secret UUID here.
+            Core connection values used by the Telegram worker. Select company secrets for sensitive values; secret values are never shown here.
           </p>
         </div>
 
         <div style={{ display: "grid", gap: 12 }}>
-          <TextField
+          <SecretRefField
+            companyId={companyId}
             disabled={connectionLoading || connectionSaving}
             label="Telegram bot token secret ref"
             onChange={(value) => updateConnectionField("telegramBotTokenRef", value)}
-            placeholder="Secret UUID from Paperclip settings"
+            placeholder="Secret UUID fallback"
             value={connectionConfig.telegramBotTokenRef}
           >
-            Secret UUID for your Telegram bot token from @BotFather. The plugin resolves this secret before polling Telegram.
-          </TextField>
+            Select the company secret that stores your Telegram bot token from @BotFather. The plugin resolves this secret before polling Telegram.
+          </SecretRefField>
           <TextField
             disabled={connectionLoading || connectionSaving}
             label="Paperclip API URL"
@@ -1383,15 +1398,16 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
         </div>
 
         <div style={{ borderTop: "1px solid #e5e7eb", display: "grid", gap: 12, paddingTop: 14 }}>
-          <TextField
+          <SecretRefField
+            companyId={companyId}
             disabled={boardConfigLoading || boardConfigSaving}
             label="Board API token secret ref fallback"
             onChange={(value) => updateBoardField("paperclipBoardApiTokenRef", value)}
-            placeholder="Optional Paperclip secret UUID"
+            placeholder="Optional secret UUID fallback"
             value={boardConfig.paperclipBoardApiTokenRef}
           >
             Optional manual fallback for approval buttons and /approve. The Board Access Connection above is preferred because it creates and tracks the company-scoped secret for you.
-          </TextField>
+          </SecretRefField>
 
           {boardConfigMessage ? <NoticeBlock notice={boardConfigMessage} /> : null}
 
@@ -1971,15 +1987,16 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
         </div>
 
         <div style={{ display: "grid", gap: 12 }}>
-          <TextField
+          <SecretRefField
+            companyId={companyId}
             disabled={mediaLoading || mediaSaving}
-            label="Transcription API key secret ref"
+            label="OpenAI transcription secret"
             onChange={(value) => updateMediaField("transcriptionApiKeyRef", value)}
-            placeholder="OpenAI API key secret UUID"
+            placeholder="OpenAI API key secret UUID fallback"
             value={mediaConfig.transcriptionApiKeyRef}
           >
-            Secret UUID for the OpenAI API key used to transcribe voice and audio before routing media to the Brief Agent or an active topic agent session.
-          </TextField>
+            Select the company secret used for audio transcription. Secret values are never shown to the plugin UI.
+          </SecretRefField>
           <TextField
             disabled={mediaLoading || mediaSaving}
             label="Brief Agent ID"
@@ -2289,6 +2306,103 @@ function NoticeBlock({ notice }: { notice: Notice }): React.JSX.Element {
       <strong>{notice.title}</strong>
       {notice.text ? <p style={{ margin: "6px 0 0" }}>{notice.text}</p> : null}
     </div>
+  );
+}
+
+function SecretRefField({
+  label,
+  value,
+  placeholder,
+  disabled,
+  companyId,
+  children,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  placeholder: string;
+  disabled: boolean;
+  companyId: string;
+  children: React.ReactNode;
+  onChange(value: string): void;
+}): React.JSX.Element {
+  const [secrets, setSecrets] = useState<CompanySecretSummary[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadSecrets(): Promise<void> {
+      if (!companyId) {
+        setSecrets([]);
+        return;
+      }
+      setLoading(true);
+      setError(null);
+      try {
+        const nextSecrets = await fetchCompanySecrets(companyId);
+        if (!cancelled) {
+          setSecrets(nextSecrets.filter((secret) => secret.status !== "deleted"));
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(getErrorMessage(err));
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void loadSecrets();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [companyId]);
+
+  const selectedValue = secrets.some((secret) => secret.id === value) ? value : "";
+  const fieldDisabled = disabled || loading || !companyId;
+
+  return (
+    <label style={{ display: "grid", gap: 5 }}>
+      <span style={{ color: "#4b5563", fontSize: 12, fontWeight: 700 }}>{label}</span>
+      <select
+        disabled={fieldDisabled}
+        onChange={(event) => onChange(event.currentTarget.value)}
+        style={standardInputStyle}
+        value={selectedValue}
+      >
+        <option value="">
+          {!companyId
+            ? "Open inside a company to select a secret"
+            : loading
+              ? "Loading company secrets..."
+              : value && !selectedValue
+                ? "Manual UUID selected"
+                : "Select a company secret"}
+        </option>
+        {secrets.map((secret) => (
+          <option key={secret.id} value={secret.id}>
+            {secret.name || secret.key || secret.id}
+            {secret.key && secret.key !== secret.name ? ` (${secret.key})` : ""}
+            {secret.latestVersion ? ` · v${secret.latestVersion}` : ""}
+          </option>
+        ))}
+      </select>
+      <input
+        disabled={disabled}
+        onChange={(event) => onChange(event.currentTarget.value)}
+        placeholder={placeholder}
+        style={standardInputStyle}
+        type="text"
+        value={value}
+      />
+      <span style={{ color: "#6b7280", fontSize: 12 }}>{children}</span>
+      {error ? <span style={{ color: "#b91c1c", fontSize: 12 }}>Could not load company secrets: {error}</span> : null}
+    </label>
   );
 }
 

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -835,7 +835,7 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
       setConnectionLoading(true);
       setConnectionMessage(null);
       try {
-        const config = await fetchPluginConfig();
+        const config = await fetchPluginConfig(companyId);
         if (cancelled) return;
         const nextConnectionConfig = extractConnectionConfig(config);
         setConnectionConfig(nextConnectionConfig);
@@ -860,7 +860,7 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [companyId]);
 
   useEffect(() => {
     let cancelled = false;
@@ -1028,9 +1028,9 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
     setConnectionSaving(true);
     setConnectionMessage(null);
     try {
-      const currentConfig = await fetchPluginConfig();
+      const currentConfig = await fetchPluginConfig(companyId);
       const nextConfig = { ...currentConfig, ...connectionConfig };
-      await savePluginConfig(nextConfig);
+      await savePluginConfig(nextConfig, companyId);
       setConnectionSnapshot(connectionConfig);
       setConnectionMessage({
         tone: "success",

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -554,17 +554,24 @@ async function fetchBoardAccessIdentity(boardApiToken: string): Promise<string |
   return getIdentityLabel(identity);
 }
 
-async function fetchPluginConfig(): Promise<Record<string, unknown>> {
+function pluginConfigPath(companyId?: string | null): string {
+  const base = `/api/plugins/${encodeURIComponent(TELEGRAM_PLUGIN_ID)}/config`;
+  const scopedCompanyId = companyId?.trim();
+  return scopedCompanyId ? `${base}?companyId=${encodeURIComponent(scopedCompanyId)}` : base;
+}
+
+async function fetchPluginConfig(companyId?: string | null): Promise<Record<string, unknown>> {
   const record = await fetchHostJson<PluginConfigResponse>(
-    `/api/plugins/${encodeURIComponent(TELEGRAM_PLUGIN_ID)}/config`,
+    pluginConfigPath(companyId),
   );
   return record?.configJson && typeof record.configJson === "object" ? record.configJson : {};
 }
 
-async function savePluginConfig(configJson: Record<string, unknown>): Promise<void> {
-  await fetchHostJson(`/api/plugins/${encodeURIComponent(TELEGRAM_PLUGIN_ID)}/config`, {
+async function savePluginConfig(configJson: Record<string, unknown>, companyId?: string | null): Promise<void> {
+  const scopedCompanyId = companyId?.trim();
+  await fetchHostJson(pluginConfigPath(), {
     method: "POST",
-    body: JSON.stringify({ configJson }),
+    body: JSON.stringify(scopedCompanyId ? { configJson, companyId: scopedCompanyId } : { configJson }),
   });
 }
 
@@ -658,7 +665,7 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
       setRoutingLoading(true);
       setRoutingMessage(null);
       try {
-        const config = await fetchPluginConfig();
+        const config = await fetchPluginConfig(companyId);
         if (cancelled) return;
         const nextRoutingConfig = extractRoutingConfig(config);
         setRoutingConfig(nextRoutingConfig);
@@ -683,7 +690,7 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [companyId]);
 
   useEffect(() => {
     let cancelled = false;
@@ -692,7 +699,7 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
       setProactiveLoading(true);
       setProactiveMessage(null);
       try {
-        const config = await fetchPluginConfig();
+        const config = await fetchPluginConfig(companyId);
         if (cancelled) return;
         const nextProactiveConfig = extractProactiveConfig(config);
         setProactiveConfig(nextProactiveConfig);
@@ -717,7 +724,7 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [companyId]);
 
   useEffect(() => {
     let cancelled = false;
@@ -726,7 +733,7 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
       setEscalationLoading(true);
       setEscalationMessage(null);
       try {
-        const config = await fetchPluginConfig();
+        const config = await fetchPluginConfig(companyId);
         if (cancelled) return;
         const nextEscalationConfig = extractEscalationConfig(config);
         setEscalationConfig(nextEscalationConfig);
@@ -751,7 +758,7 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [companyId]);
 
   useEffect(() => {
     let cancelled = false;
@@ -760,7 +767,7 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
       setMediaLoading(true);
       setMediaMessage(null);
       try {
-        const config = await fetchPluginConfig();
+        const config = await fetchPluginConfig(companyId);
         if (cancelled) return;
         const nextMediaConfig = extractMediaConfig(config);
         setMediaConfig(nextMediaConfig);
@@ -785,7 +792,7 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [companyId]);
 
   useEffect(() => {
     let cancelled = false;
@@ -794,7 +801,7 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
       setAccessLoading(true);
       setAccessMessage(null);
       try {
-        const config = await fetchPluginConfig();
+        const config = await fetchPluginConfig(companyId);
         if (cancelled) return;
         const nextAccessConfig = extractAccessConfig(config);
         setAccessConfig(nextAccessConfig);
@@ -819,7 +826,7 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [companyId]);
 
   useEffect(() => {
     let cancelled = false;
@@ -862,7 +869,7 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
       setBoardConfigLoading(true);
       setBoardConfigMessage(null);
       try {
-        const config = await fetchPluginConfig();
+        const config = await fetchPluginConfig(companyId);
         if (cancelled) return;
         const nextBoardConfig = extractBoardConfig(config);
         setBoardConfig(nextBoardConfig);
@@ -887,7 +894,7 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [companyId]);
 
   function updateRoutingField<K extends keyof TelegramRoutingConfig>(
     key: K,
@@ -949,9 +956,9 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
     setBoardConfigSaving(true);
     setBoardConfigMessage(null);
     try {
-      const currentConfig = await fetchPluginConfig();
+      const currentConfig = await fetchPluginConfig(companyId);
       const nextConfig = { ...currentConfig, ...boardConfig };
-      await savePluginConfig(nextConfig);
+      await savePluginConfig(nextConfig, companyId);
       setBoardSnapshot(boardConfig);
       setBoardConfigMessage({
         tone: "success",
@@ -973,9 +980,9 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
     setAccessSaving(true);
     setAccessMessage(null);
     try {
-      const currentConfig = await fetchPluginConfig();
+      const currentConfig = await fetchPluginConfig(companyId);
       const nextConfig = { ...currentConfig, ...accessConfig };
-      await savePluginConfig(nextConfig);
+      await savePluginConfig(nextConfig, companyId);
       setAccessSnapshot(accessConfig);
       setAccessMessage({
         tone: "success",
@@ -997,9 +1004,9 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
     setRoutingSaving(true);
     setRoutingMessage(null);
     try {
-      const currentConfig = await fetchPluginConfig();
+      const currentConfig = await fetchPluginConfig(companyId);
       const nextConfig = { ...currentConfig, ...routingConfig };
-      await savePluginConfig(nextConfig);
+      await savePluginConfig(nextConfig, companyId);
       setRoutingSnapshot(routingConfig);
       setRoutingMessage({
         tone: "success",
@@ -1045,9 +1052,9 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
     setMediaSaving(true);
     setMediaMessage(null);
     try {
-      const currentConfig = await fetchPluginConfig();
+      const currentConfig = await fetchPluginConfig(companyId);
       const nextConfig = { ...currentConfig, ...mediaConfig };
-      await savePluginConfig(nextConfig);
+      await savePluginConfig(nextConfig, companyId);
       setMediaSnapshot(mediaConfig);
       setMediaMessage({
         tone: "success",
@@ -1069,9 +1076,9 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
     setEscalationSaving(true);
     setEscalationMessage(null);
     try {
-      const currentConfig = await fetchPluginConfig();
+      const currentConfig = await fetchPluginConfig(companyId);
       const nextConfig = { ...currentConfig, ...escalationConfig };
-      await savePluginConfig(nextConfig);
+      await savePluginConfig(nextConfig, companyId);
       setEscalationSnapshot(escalationConfig);
       setEscalationMessage({
         tone: "success",
@@ -1093,9 +1100,9 @@ export function TelegramSettingsPage({ context }: PluginSettingsPageProps): Reac
     setProactiveSaving(true);
     setProactiveMessage(null);
     try {
-      const currentConfig = await fetchPluginConfig();
+      const currentConfig = await fetchPluginConfig(companyId);
       const nextConfig = { ...currentConfig, ...proactiveConfig };
-      await savePluginConfig(nextConfig);
+      await savePluginConfig(nextConfig, companyId);
       setProactiveSnapshot(proactiveConfig);
       setProactiveMessage({
         tone: "success",

--- a/src/watch-registry.ts
+++ b/src/watch-registry.ts
@@ -125,15 +125,17 @@ export async function checkWatches(
   ctx: PluginContext,
   token: string,
   config: { maxSuggestionsPerHourPerCompany: number; watchDeduplicationWindowMs: number },
+  companyId?: string,
 ): Promise<void> {
-  // Get all companies that have watches
-  const companies = await ctx.companies.list();
+  const companyIds = companyId
+    ? [companyId]
+    : (await ctx.companies.list()).map((company) => company.id);
 
-  for (const company of companies) {
+  for (const currentCompanyId of companyIds) {
     try {
-      await checkWatchesForCompany(ctx, token, company.id, config);
+      await checkWatchesForCompany(ctx, token, currentCompanyId, config);
     } catch (err) {
-      ctx.logger.error("Watch check failed for company", { companyId: company.id, error: String(err) });
+      ctx.logger.error("Watch check failed for company", { companyId: currentCompanyId, error: String(err) });
     }
   }
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -51,7 +51,11 @@ import { isTelegramUpdateAllowed, validateTelegramAllowlists } from "./allowlist
 import { validateSecretRefFields } from "./secret-ref-validation.js";
 import { shouldNotifyApproval } from "./approval-routing.js";
 import { buildPaperclipAuthHeaders, fetchPaperclipApi } from "./paperclip-api.js";
-import { resolveStartupTelegramBotToken, type TelegramRuntimeHealth } from "./runtime-token.js";
+import {
+  SECRET_RESOLUTION_DISABLED_MESSAGE,
+  SECRET_RESOLUTION_ISSUE_URL,
+  type TelegramRuntimeHealth,
+} from "./runtime-token.js";
 import { loadStartupConfig, resolveCompatibleConfig } from "./config-compat.js";
 
 type TelegramConfig = {
@@ -167,18 +171,6 @@ async function resolveConfig(
   return resolveCompatibleConfig(ctx, fallback as unknown as Record<string, unknown>, companyId) as Promise<TelegramConfig>;
 }
 
-async function resolveTelegramBotToken(
-  ctx: PluginContext,
-  config: TelegramConfig,
-  companyId?: string | null,
-): Promise<string | undefined> {
-  const effectiveConfig = companyId ? await resolveConfig(ctx, config, companyId) : config;
-  if (!effectiveConfig.telegramBotTokenRef) return undefined;
-  return resolveStartupTelegramBotToken(ctx, effectiveConfig.telegramBotTokenRef, (health) => {
-    runtimeHealth = health;
-  });
-}
-
 function normalizeBoardAccessState(value: unknown): TelegramBoardAccessState {
   const record = isRecord(value) ? value : {};
   return {
@@ -284,6 +276,14 @@ async function resolveTelegramBotTokenRef(
     const resolveSecret = ctx.secrets.resolve as (secretRef: string, companyId?: string | null) => Promise<string>;
     return await resolveSecret(tokenRef, companyId);
   } catch (err) {
+    runtimeHealth = {
+      status: "degraded",
+      message: SECRET_RESOLUTION_DISABLED_MESSAGE,
+      details: {
+        issue: "paperclip-plugin-secret-resolution-disabled",
+        reference: SECRET_RESOLUTION_ISSUE_URL,
+      },
+    };
     ctx.logger.warn("Failed to resolve Telegram bot token secret", {
       companyId,
       error: String(err),

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -41,6 +41,7 @@ import {
   persistTelegramUpdateOffset,
   processTelegramUpdateBatch,
 } from "./polling-offset.js";
+import { getTelegramUpdateChatId, selectTelegramRuntimeForUpdate } from "./polling-dispatch.js";
 import { handleCommandsCommand, tryCustomCommand } from "./command-registry.js";
 import { handleRegisterWatch, checkWatches } from "./watch-registry.js";
 import { AGENT_ERROR_DEDUPLICATION_WINDOW_MS, METRIC_NAMES } from "./constants.js";
@@ -297,6 +298,12 @@ type TelegramCompanyRuntime = {
   token: string;
   baseUrl: string;
   publicUrl: string;
+};
+
+type TelegramPollingRuntimeGroup = {
+  tokenRef: string;
+  token: string;
+  runtimes: TelegramCompanyRuntime[];
 };
 
 async function resolveCompanyRuntimes(
@@ -591,11 +598,11 @@ const plugin = definePlugin({
     let pollingActive = true;
     let lastUpdateId = await getPersistedTelegramUpdateOffset(ctx);
 
-    async function pollUpdates(runtime: TelegramCompanyRuntime): Promise<void> {
+    async function pollUpdates(group: TelegramPollingRuntimeGroup): Promise<void> {
       while (pollingActive) {
         try {
           const res = await ctx.http.fetch(
-            `${TELEGRAM_API}/bot${runtime.token}/getUpdates?offset=${lastUpdateId + 1}&timeout=10&allowed_updates=["message","callback_query"]`,
+            `${TELEGRAM_API}/bot${group.token}/getUpdates?offset=${lastUpdateId + 1}&timeout=10&allowed_updates=["message","callback_query"]`,
             { method: "GET" },
           );
           const data = (await res.json()) as {
@@ -607,31 +614,65 @@ const plugin = definePlugin({
             lastUpdateId = await processTelegramUpdateBatch({
               updates: data.result,
               lastUpdateId,
-              handleUpdate: (update) => handleUpdate(
-                ctx,
-                runtime.token,
-                runtime.config,
-                update,
-                runtime.baseUrl,
-                runtime.publicUrl,
-              ),
+              handleUpdate: async (update) => {
+                const runtime = selectTelegramRuntimeForUpdate(group.runtimes, update);
+                if (!runtime) {
+                  ctx.logger.warn("No company-scoped Telegram runtime matched update", {
+                    updateId: update.update_id,
+                    chatId: getTelegramUpdateChatId(update),
+                    tokenRef: group.tokenRef,
+                  });
+                  return;
+                }
+
+                await handleUpdate(
+                  ctx,
+                  group.token,
+                  runtime.config,
+                  update,
+                  runtime.baseUrl,
+                  runtime.publicUrl,
+                  undefined,
+                  runtime.companyId,
+                );
+              },
               persistOffset: (updateId) => persistTelegramUpdateOffset(ctx, updateId),
               logger: ctx.logger,
             });
           }
         } catch (err) {
-          ctx.logger.error("Telegram polling error", { companyId: runtime.companyId, error: String(err) });
+          ctx.logger.error("Telegram polling error", {
+            tokenRef: group.tokenRef,
+            companyIds: group.runtimes.map((runtime) => runtime.companyId),
+            error: String(err),
+          });
           await new Promise((r) => setTimeout(r, 5000));
         }
       }
     }
 
-    const pollingRefs = new Set<string>();
+    const pollingGroups = new Map<string, TelegramPollingRuntimeGroup>();
     for (const runtime of pollingRuntimes) {
-      if (pollingRefs.has(runtime.config.telegramBotTokenRef)) continue;
-      pollingRefs.add(runtime.config.telegramBotTokenRef);
-      pollUpdates(runtime).catch((err) =>
-        ctx.logger.error("Polling loop crashed", { companyId: runtime.companyId, error: String(err) }),
+      const tokenRef = runtime.config.telegramBotTokenRef;
+      const existing = pollingGroups.get(tokenRef);
+      if (existing) {
+        existing.runtimes.push(runtime);
+      } else {
+        pollingGroups.set(tokenRef, {
+          tokenRef,
+          token: runtime.token,
+          runtimes: [runtime],
+        });
+      }
+    }
+
+    for (const group of pollingGroups.values()) {
+      pollUpdates(group).catch((err) =>
+        ctx.logger.error("Polling loop crashed", {
+          tokenRef: group.tokenRef,
+          companyIds: group.runtimes.map((runtime) => runtime.companyId),
+          error: String(err),
+        }),
       );
     }
 
@@ -1357,6 +1398,7 @@ export async function handleUpdate(
   baseUrl: string,
   publicUrl?: string,
   boardApiToken?: string,
+  runtimeCompanyId?: string,
 ): Promise<void> {
   if (!isTelegramUpdateAllowed(config, update)) {
     const fromId = update.message?.from?.id ?? update.callback_query?.from.id;
@@ -1387,7 +1429,7 @@ export async function handleUpdate(
   // Phase 3: Handle media messages
   const hasMedia = !!(msg.voice || msg.audio || msg.video_note || msg.document || msg.photo);
   if (hasMedia) {
-    const companyId = await resolveCompanyIdOrNull(ctx, chatId);
+    const companyId = runtimeCompanyId ?? await resolveCompanyIdOrNull(ctx, chatId);
     if (companyId) {
       const effectiveConfig = await resolveConfig(ctx, config, companyId);
       const effectivePublicUrl = effectiveConfig.paperclipPublicUrl || effectiveConfig.paperclipBaseUrl || publicUrl;
@@ -1411,7 +1453,7 @@ export async function handleUpdate(
   if (threadId) {
     const isCommand = text.startsWith("/");
     if (!isCommand) {
-      const companyId = await resolveCompanyIdOrNull(ctx, chatId);
+      const companyId = runtimeCompanyId ?? await resolveCompanyIdOrNull(ctx, chatId);
       if (companyId) {
         const replyToId = msg.reply_to_message?.message_id;
         const routed = await routeMessageToAgent(ctx, token, chatId, threadId, text, replyToId, companyId);
@@ -1429,7 +1471,7 @@ export async function handleUpdate(
     const args = text.slice(botCommand.offset + botCommand.length).trim();
     // undefined on unlinked chats: /connect and /help still work, and the
     // company-scoped handlers answer with their "not linked" guidance.
-    const companyId = (await resolveCompanyIdOrNull(ctx, chatId)) ?? undefined;
+    const companyId = runtimeCompanyId ?? (await resolveCompanyIdOrNull(ctx, chatId)) ?? undefined;
     const effectiveConfig = companyId ? await resolveConfig(ctx, config, companyId) : config;
     const effectiveBaseUrl = effectiveConfig.paperclipBaseUrl || baseUrl;
     const effectivePublicUrl = effectiveConfig.paperclipPublicUrl || effectiveBaseUrl;
@@ -1450,7 +1492,7 @@ export async function handleUpdate(
   }
 
   if (config.enableInbound && msg.reply_to_message?.from?.is_bot) {
-    const companyId = await resolveCompanyId(ctx, chatId);
+    const companyId = runtimeCompanyId ?? await resolveCompanyId(ctx, chatId);
     const replyToId = msg.reply_to_message.message_id;
     const mapping = await ctx.state.get({
       scopeKind: "company",

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -51,6 +51,7 @@ import { validateSecretRefFields } from "./secret-ref-validation.js";
 import { shouldNotifyApproval } from "./approval-routing.js";
 import { buildPaperclipAuthHeaders, fetchPaperclipApi } from "./paperclip-api.js";
 import { resolveStartupTelegramBotToken, type TelegramRuntimeHealth } from "./runtime-token.js";
+import { loadStartupConfig, resolveCompatibleConfig } from "./config-compat.js";
 
 type TelegramConfig = {
   telegramBotTokenRef: string;
@@ -162,19 +163,19 @@ async function resolveConfig(
   fallback: TelegramConfig,
   companyId?: string | null,
 ): Promise<TelegramConfig> {
-  try {
-    const getConfig = ctx.config.get as unknown as (
-      params?: { companyId?: string | null },
-    ) => Promise<Record<string, unknown>>;
-    const scopedConfig = await getConfig(companyId ? { companyId } : undefined);
-    return { ...fallback, ...scopedConfig } as unknown as TelegramConfig;
-  } catch (err) {
-    ctx.logger.warn("Failed to load scoped Telegram plugin config; using startup config", {
-      companyId,
-      error: String(err),
-    });
-    return fallback;
-  }
+  return resolveCompatibleConfig(ctx, fallback as unknown as Record<string, unknown>, companyId) as Promise<TelegramConfig>;
+}
+
+async function resolveTelegramBotToken(
+  ctx: PluginContext,
+  config: TelegramConfig,
+  companyId?: string | null,
+): Promise<string | undefined> {
+  const effectiveConfig = companyId ? await resolveConfig(ctx, config, companyId) : config;
+  if (!effectiveConfig.telegramBotTokenRef) return undefined;
+  return resolveStartupTelegramBotToken(ctx, effectiveConfig.telegramBotTokenRef, (health) => {
+    runtimeHealth = health;
+  });
 }
 
 function normalizeBoardAccessState(value: unknown): TelegramBoardAccessState {
@@ -253,6 +254,26 @@ async function resolveBoardApiToken(
   }
 
   return undefined;
+}
+
+async function resolveTelegramBotToken(
+  ctx: PluginContext,
+  config: TelegramConfig,
+  companyId?: string | null,
+): Promise<string | null> {
+  const effectiveConfig = companyId ? await resolveConfig(ctx, config, companyId) : config;
+  const tokenRef = effectiveConfig.telegramBotTokenRef;
+  if (!tokenRef) return null;
+
+  try {
+    return await ctx.secrets.resolve(tokenRef);
+  } catch (err) {
+    ctx.logger.warn("Failed to resolve Telegram bot token secret", {
+      companyId,
+      error: String(err),
+    });
+    return null;
+  }
 }
 
 async function resolveCallbackCompanyId(
@@ -373,7 +394,7 @@ async function resolveCompanyIdOrNull(ctx: PluginContext, chatId: string): Promi
 
 const plugin = definePlugin({
   async setup(ctx) {
-    const rawConfig = await ctx.config.get();
+    const rawConfig = await loadStartupConfig(ctx, {} as Record<string, unknown>);
     ctx.logger.info("Telegram plugin config loaded");
     const config = rawConfig as unknown as TelegramConfig;
     const baseUrl = config.paperclipBaseUrl || "http://localhost:3100";
@@ -396,22 +417,13 @@ const plugin = definePlugin({
       });
     });
 
-    if (!config.telegramBotTokenRef) {
-      ctx.logger.warn("No telegramBotTokenRef configured, plugin disabled");
-      return;
+    const startupToken = await resolveTelegramBotToken(ctx, config);
+    if (!startupToken) {
+      ctx.logger.warn("Telegram bot token is not resolvable during startup; setup will continue without global polling");
     }
-
-    const token = await resolveStartupTelegramBotToken(ctx, config.telegramBotTokenRef, (health) => {
-      runtimeHealth = health;
-    });
-    if (!token) {
-      ctx.logger.warn("Telegram plugin runtime disabled because bot token could not be resolved");
-      return;
-    }
-    const telegramToken = token;
 
     // --- Register bot commands with Telegram ---
-    if (config.enableCommands) {
+    if (config.enableCommands && startupToken) {
       const allCommands = [
         ...BOT_COMMANDS,
         { command: "commands", description: "Manage custom workflow commands" },
@@ -420,7 +432,7 @@ const plugin = definePlugin({
       // The host's worker-init RPC timeout is 15s; if api.telegram.org is
       // slow/unreachable, awaiting this call causes the worker to be SIGKILLed
       // before setup() completes. Fire-and-forget matches pollUpdates() below.
-      setMyCommands(ctx, token, allCommands)
+      setMyCommands(ctx, startupToken, allCommands)
         .then((registered) => {
           if (registered) {
             ctx.logger.info("Bot commands registered with Telegram");
@@ -441,7 +453,7 @@ const plugin = definePlugin({
       while (pollingActive) {
         try {
           const res = await ctx.http.fetch(
-            `${TELEGRAM_API}/bot${token}/getUpdates?offset=${lastUpdateId + 1}&timeout=10&allowed_updates=["message","callback_query"]`,
+            `${TELEGRAM_API}/bot${startupToken}/getUpdates?offset=${lastUpdateId + 1}&timeout=10&allowed_updates=["message","callback_query"]`,
             { method: "GET" },
           );
           const data = (await res.json()) as {
@@ -453,7 +465,7 @@ const plugin = definePlugin({
             lastUpdateId = await processTelegramUpdateBatch({
               updates: data.result,
               lastUpdateId,
-              handleUpdate: (update) => handleUpdate(ctx, telegramToken, config, update, baseUrl, publicUrl),
+              handleUpdate: (update) => handleUpdate(ctx, startupToken!, config, update, baseUrl, publicUrl),
               persistOffset: (updateId) => persistTelegramUpdateOffset(ctx, updateId),
               logger: ctx.logger,
             });
@@ -465,7 +477,7 @@ const plugin = definePlugin({
       }
     }
 
-    if (config.enableCommands || config.enableInbound) {
+    if (startupToken && (config.enableCommands || config.enableInbound)) {
       pollUpdates().catch((err) =>
         ctx.logger.error("Polling loop crashed", { error: String(err) }),
       );
@@ -476,7 +488,7 @@ const plugin = definePlugin({
     });
 
     // --- Phase 2: ACP output listener (cross-plugin events) ---
-    setupAcpOutputListener(ctx, token);
+    setupAcpOutputListener(ctx, (event) => resolveTelegramBotToken(ctx, config, event.companyId));
 
     // --- Event subscriptions ---
 
@@ -499,6 +511,8 @@ const plugin = definePlugin({
       overrideTopicId?: string,
     ) => {
       const effectiveConfig = await resolveConfig(ctx, config, event.companyId);
+      const token = await resolveTelegramBotToken(ctx, effectiveConfig, event.companyId);
+      if (!token) return;
       const chatId = await resolveChat(
         ctx,
         event.companyId,
@@ -827,6 +841,8 @@ const plugin = definePlugin({
         const companies = await ctx.companies.list();
         for (const company of companies) {
           const effectiveConfig = await resolveConfig(ctx, config, company.id);
+          const token = await resolveTelegramBotToken(ctx, effectiveConfig, company.id);
+          if (!token) continue;
           const effectivePublicUrl = effectiveConfig.paperclipPublicUrl || effectiveConfig.paperclipBaseUrl || publicUrl;
           const chatId = await resolveChat(ctx, company.id, effectiveConfig.digestChatId || effectiveConfig.defaultChatId);
           if (!chatId) continue;
@@ -962,6 +978,10 @@ const plugin = definePlugin({
     }, async (params: unknown, runCtx) => {
       const p = params as Record<string, unknown>;
       const effectiveConfig = await resolveConfig(ctx, config, runCtx.companyId);
+      const token = await resolveTelegramBotToken(ctx, effectiveConfig, runCtx.companyId);
+      if (!token) {
+        return { error: "Telegram bot token is not configured or could not be resolved for this company." };
+      }
       const escalationId = crypto.randomUUID();
       const timeoutMs = effectiveConfig.escalationTimeoutMs || 900000;
       const defaultAction = effectiveConfig.escalationDefaultAction || "defer";
@@ -1031,6 +1051,10 @@ const plugin = definePlugin({
         required: ["targetAgent", "reason", "contextSummary"],
       },
     }, async (params: unknown, runCtx) => {
+      const token = await resolveTelegramBotToken(ctx, config, runCtx.companyId);
+      if (!token) {
+        return { error: "Telegram bot token is not configured or could not be resolved for this company." };
+      }
       return handleHandoffToolCall(ctx, token, params as Record<string, unknown>, runCtx.companyId, runCtx.agentId);
     });
 
@@ -1052,6 +1076,10 @@ const plugin = definePlugin({
         required: ["targetAgent", "topic", "initialMessage"],
       },
     }, async (params: unknown, runCtx) => {
+      const token = await resolveTelegramBotToken(ctx, config, runCtx.companyId);
+      if (!token) {
+        return { error: "Telegram bot token is not configured or could not be resolved for this company." };
+      }
       return handleDiscussToolCall(ctx, token, params as Record<string, unknown>, runCtx.companyId, runCtx.agentId);
     });
 
@@ -1092,6 +1120,8 @@ const plugin = definePlugin({
     // --- Phase 1: Escalation timeout checker job ---
     ctx.jobs.register("check-escalation-timeouts", async () => {
       try {
+        const token = await resolveTelegramBotToken(ctx, config);
+        if (!token) return;
         await escalationManager.checkTimeouts(ctx, token);
       } catch (err) {
         ctx.logger.error("Escalation timeout check failed", { error: String(err) });
@@ -1101,6 +1131,8 @@ const plugin = definePlugin({
     // --- Phase 5: Watch checker job ---
     ctx.jobs.register("check-watches", async () => {
       try {
+        const token = await resolveTelegramBotToken(ctx, config);
+        if (!token) return;
         await checkWatches(ctx, token, {
           maxSuggestionsPerHourPerCompany: config.maxSuggestionsPerHourPerCompany ?? 10,
           watchDeduplicationWindowMs: config.watchDeduplicationWindowMs ?? 86400000,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -243,7 +243,8 @@ async function resolveBoardApiToken(
     if (seen.has(candidate.ref)) continue;
     seen.add(candidate.ref);
     try {
-      return await ctx.secrets.resolve(candidate.ref);
+      const resolveSecret = ctx.secrets.resolve as (secretRef: string, companyId?: string | null) => Promise<string>;
+      return await resolveSecret(candidate.ref, companyId);
     } catch (err) {
       ctx.logger.warn("Failed to resolve board API token secret", {
         source: candidate.source,
@@ -265,8 +266,22 @@ async function resolveTelegramBotToken(
   const tokenRef = effectiveConfig.telegramBotTokenRef;
   if (!tokenRef) return null;
 
+  return resolveTelegramBotTokenRef(ctx, tokenRef, companyId);
+}
+
+async function resolveTelegramBotTokenRef(
+  ctx: PluginContext,
+  tokenRef: string,
+  companyId?: string | null,
+): Promise<string | null> {
+  if (!companyId) {
+    ctx.logger.warn("Telegram bot token secret requires company context");
+    return null;
+  }
+
   try {
-    return await ctx.secrets.resolve(tokenRef);
+    const resolveSecret = ctx.secrets.resolve as (secretRef: string, companyId?: string | null) => Promise<string>;
+    return await resolveSecret(tokenRef, companyId);
   } catch (err) {
     ctx.logger.warn("Failed to resolve Telegram bot token secret", {
       companyId,
@@ -274,6 +289,78 @@ async function resolveTelegramBotToken(
     });
     return null;
   }
+}
+
+type TelegramCompanyRuntime = {
+  companyId: string;
+  config: TelegramConfig;
+  token: string;
+  baseUrl: string;
+  publicUrl: string;
+};
+
+async function resolveCompanyRuntimes(
+  ctx: PluginContext,
+  startupConfig: TelegramConfig,
+  predicate: (config: TelegramConfig) => boolean,
+): Promise<TelegramCompanyRuntime[]> {
+  const companies = await ctx.companies.list();
+  const runtimes: TelegramCompanyRuntime[] = [];
+
+  for (const company of companies) {
+    let scopedConfig: Record<string, unknown>;
+    try {
+      const getConfig = ctx.config.get as unknown as (
+        params?: { companyId?: string | null },
+      ) => Promise<Record<string, unknown>>;
+      scopedConfig = await getConfig({ companyId: company.id });
+    } catch (err) {
+      ctx.logger.warn("Company-scoped Telegram plugin config unavailable; skipping company runtime", {
+        companyId: company.id,
+        error: String(err),
+      });
+      continue;
+    }
+    if (!("telegramBotTokenRef" in scopedConfig)) continue;
+
+    const effectiveConfig = { ...startupConfig, ...scopedConfig } as unknown as TelegramConfig;
+    const hasCompanyTelegramRoute = [
+      "telegramBotTokenRef",
+      "defaultChatId",
+      "approvalsChatId",
+      "approvalsTopicId",
+      "errorsChatId",
+      "errorsTopicId",
+      "digestChatId",
+      "digestTopicId",
+      "escalationChatId",
+    ].some((key) => {
+      const value = effectiveConfig[key as keyof TelegramConfig];
+      const startupValue = startupConfig[key as keyof TelegramConfig];
+      return typeof value === "string" && value.trim() && value !== startupValue;
+    });
+    if (!hasCompanyTelegramRoute) continue;
+
+    if (!predicate(effectiveConfig)) continue;
+
+    const tokenRef = effectiveConfig.telegramBotTokenRef;
+    if (!tokenRef) continue;
+
+    const token = await resolveTelegramBotTokenRef(ctx, tokenRef, company.id);
+    if (!token) continue;
+
+    const baseUrl = effectiveConfig.paperclipBaseUrl || startupConfig.paperclipBaseUrl || "http://localhost:3100";
+    const publicUrl = effectiveConfig.paperclipPublicUrl || baseUrl;
+    runtimes.push({
+      companyId: company.id,
+      config: effectiveConfig,
+      token,
+      baseUrl,
+      publicUrl,
+    });
+  }
+
+  return runtimes;
 }
 
 async function resolveCallbackCompanyId(
@@ -289,7 +376,10 @@ async function resolveCallbackCompanyId(
     stateKey: `msg_${chatId}_${messageId}`,
   }) as { companyId?: string } | null;
 
-  return mapping?.companyId ?? null;
+  if (mapping?.companyId) return mapping.companyId;
+
+  const boardAccessState = await loadBoardAccessState(ctx);
+  return boardAccessState.companyId ?? null;
 }
 
 /**
@@ -367,6 +457,53 @@ async function resolveDigestThreadId(
   return await isForum(ctx, token, chatId) ? GENERAL_TOPIC_THREAD_ID : undefined;
 }
 
+function resolveDigestMode(config: TelegramConfig): TelegramConfig["digestMode"] {
+  return (config as Record<string, unknown>).dailyDigestEnabled === true && config.digestMode === "off"
+    ? "daily"
+    : config.digestMode ?? "off";
+}
+
+function parseDigestTime(value: string | undefined): { hour: number; minute: number } | null {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  const match = /^(\d{1,2})(?::(\d{2}))?$/.exec(trimmed);
+  if (!match) return null;
+  const hour = Number(match[1]);
+  const minute = match[2] === undefined ? 0 : Number(match[2]);
+  if (!Number.isInteger(hour) || !Number.isInteger(minute)) return null;
+  if (hour < 0 || hour > 23 || minute < 0 || minute > 59) return null;
+  return { hour, minute };
+}
+
+function digestTimesForConfig(config: TelegramConfig): Array<{ hour: number; minute: number }> {
+  const mode = resolveDigestMode(config);
+  if (mode === "off") return [];
+  if (mode === "daily") {
+    return [parseDigestTime(config.dailyDigestTime)].filter((time): time is { hour: number; minute: number } => Boolean(time));
+  }
+  if (mode === "bidaily") {
+    return [parseDigestTime(config.dailyDigestTime), parseDigestTime(config.bidailySecondTime)]
+      .filter((time): time is { hour: number; minute: number } => Boolean(time));
+  }
+  return (config.tridailyTimes || "07:00,13:00,19:00")
+    .split(",")
+    .map((time) => parseDigestTime(time))
+    .filter((time): time is { hour: number; minute: number } => Boolean(time));
+}
+
+function resolveDigestSlot(
+  config: TelegramConfig,
+  date: Date,
+): { dateKey: string; timeKey: string } | null {
+  const hour = date.getUTCHours();
+  const minute = date.getUTCMinutes();
+  const match = digestTimesForConfig(config).find((time) => time.hour === hour && time.minute === minute);
+  if (!match) return null;
+  const dateKey = date.toISOString().slice(0, 10);
+  const timeKey = `${String(match.hour).padStart(2, "0")}:${String(match.minute).padStart(2, "0")}`;
+  return { dateKey, timeKey };
+}
+
 async function resolveCompanyId(ctx: PluginContext, chatId: string): Promise<string> {
   const mapping = await ctx.state.get({
     scopeKind: "instance",
@@ -417,29 +554,34 @@ const plugin = definePlugin({
       });
     });
 
-    const startupToken = await resolveTelegramBotToken(ctx, config);
-    if (!startupToken) {
-      ctx.logger.warn("Telegram bot token is not resolvable during startup; setup will continue without global polling");
+    const pollingRuntimes = await resolveCompanyRuntimes(
+      ctx,
+      config,
+      (effectiveConfig) => Boolean(effectiveConfig.enableCommands || effectiveConfig.enableInbound),
+    );
+    if (pollingRuntimes.length === 0) {
+      ctx.logger.warn("No company-scoped Telegram bot token is resolvable during startup; setup will continue without polling");
     }
 
-    // --- Register bot commands with Telegram ---
-    if (config.enableCommands && startupToken) {
+    const commandRegistrationRefs = new Set<string>();
+    for (const runtime of pollingRuntimes) {
+      if (!runtime.config.enableCommands) continue;
+      if (commandRegistrationRefs.has(runtime.config.telegramBotTokenRef)) continue;
+      commandRegistrationRefs.add(runtime.config.telegramBotTokenRef);
+
       const allCommands = [
         ...BOT_COMMANDS,
         { command: "commands", description: "Manage custom workflow commands" },
       ];
-      // Non-blocking init: don't hold up worker initialize on external API.
-      // The host's worker-init RPC timeout is 15s; if api.telegram.org is
-      // slow/unreachable, awaiting this call causes the worker to be SIGKILLed
-      // before setup() completes. Fire-and-forget matches pollUpdates() below.
-      setMyCommands(ctx, startupToken, allCommands)
+      setMyCommands(ctx, runtime.token, allCommands)
         .then((registered) => {
           if (registered) {
-            ctx.logger.info("Bot commands registered with Telegram");
+            ctx.logger.info("Bot commands registered with Telegram", { companyId: runtime.companyId });
           }
         })
         .catch((err) => {
           ctx.logger.error("Failed to register bot commands", {
+            companyId: runtime.companyId,
             error: String(err),
           });
         });
@@ -449,11 +591,11 @@ const plugin = definePlugin({
     let pollingActive = true;
     let lastUpdateId = await getPersistedTelegramUpdateOffset(ctx);
 
-    async function pollUpdates(): Promise<void> {
+    async function pollUpdates(runtime: TelegramCompanyRuntime): Promise<void> {
       while (pollingActive) {
         try {
           const res = await ctx.http.fetch(
-            `${TELEGRAM_API}/bot${startupToken}/getUpdates?offset=${lastUpdateId + 1}&timeout=10&allowed_updates=["message","callback_query"]`,
+            `${TELEGRAM_API}/bot${runtime.token}/getUpdates?offset=${lastUpdateId + 1}&timeout=10&allowed_updates=["message","callback_query"]`,
             { method: "GET" },
           );
           const data = (await res.json()) as {
@@ -465,21 +607,31 @@ const plugin = definePlugin({
             lastUpdateId = await processTelegramUpdateBatch({
               updates: data.result,
               lastUpdateId,
-              handleUpdate: (update) => handleUpdate(ctx, startupToken!, config, update, baseUrl, publicUrl),
+              handleUpdate: (update) => handleUpdate(
+                ctx,
+                runtime.token,
+                runtime.config,
+                update,
+                runtime.baseUrl,
+                runtime.publicUrl,
+              ),
               persistOffset: (updateId) => persistTelegramUpdateOffset(ctx, updateId),
               logger: ctx.logger,
             });
           }
         } catch (err) {
-          ctx.logger.error("Telegram polling error", { error: String(err) });
+          ctx.logger.error("Telegram polling error", { companyId: runtime.companyId, error: String(err) });
           await new Promise((r) => setTimeout(r, 5000));
         }
       }
     }
 
-    if (startupToken && (config.enableCommands || config.enableInbound)) {
-      pollUpdates().catch((err) =>
-        ctx.logger.error("Polling loop crashed", { error: String(err) }),
+    const pollingRefs = new Set<string>();
+    for (const runtime of pollingRuntimes) {
+      if (pollingRefs.has(runtime.config.telegramBotTokenRef)) continue;
+      pollingRefs.add(runtime.config.telegramBotTokenRef);
+      pollUpdates(runtime).catch((err) =>
+        ctx.logger.error("Polling loop crashed", { companyId: runtime.companyId, error: String(err) }),
       );
     }
 
@@ -539,7 +691,8 @@ const plugin = definePlugin({
         : null;
       if (anchorKey) {
         const anchor = (await ctx.state.get({
-          scopeKind: "instance",
+          scopeKind: "company",
+          scopeId: event.companyId,
           stateKey: anchorKey,
         })) as { messageId: number; messageThreadId?: number } | null;
         // Only thread when targeting the same topic — Telegram rejects cross-topic replies.
@@ -551,17 +704,27 @@ const plugin = definePlugin({
       const messageId = await sendMessage(ctx, token, chatId, msg.text, msg.options);
 
       if (messageId) {
+        const messageMapping = {
+          entityId: event.entityId,
+          entityType: event.entityType,
+          companyId: event.companyId,
+          eventType: event.eventType,
+        };
+
+        await ctx.state.set(
+          {
+            scopeKind: "company",
+            scopeId: event.companyId,
+            stateKey: `msg_${chatId}_${messageId}`,
+          },
+          messageMapping,
+        );
         await ctx.state.set(
           {
             scopeKind: "instance",
             stateKey: `msg_${chatId}_${messageId}`,
           },
-          {
-            entityId: event.entityId,
-            entityType: event.entityType,
-            companyId: event.companyId,
-            eventType: event.eventType,
-          },
+          messageMapping,
         );
 
         await ctx.activity.log({
@@ -575,12 +738,13 @@ const plugin = definePlugin({
         // same entity reply to this one. Never overwritten — the first message stays root.
         if (anchorKey) {
           const existing = (await ctx.state.get({
-            scopeKind: "instance",
+            scopeKind: "company",
+            scopeId: event.companyId,
             stateKey: anchorKey,
           })) as { messageId: number; messageThreadId?: number } | null;
           if (!existing) {
             await ctx.state.set(
-              { scopeKind: "instance", stateKey: anchorKey },
+              { scopeKind: "company", scopeId: event.companyId, stateKey: anchorKey },
               { messageId, messageThreadId },
             );
           }
@@ -588,7 +752,7 @@ const plugin = definePlugin({
       }
     };
 
-    if (config.notifyOnIssueCreated) {
+    {
       ctx.events.on("issue.created", async (event: PluginEvent) => {
         const effectiveConfig = await resolveConfig(ctx, config, event.companyId);
         if (!effectiveConfig.notifyOnIssueCreated) return;
@@ -596,7 +760,7 @@ const plugin = definePlugin({
       });
     }
 
-    if (config.notifyOnIssueDone) {
+    {
       const doneDedupe = makeUpdateDedupe();
       ctx.events.on("issue.updated", async (event: PluginEvent) => {
         const effectiveConfig = await resolveConfig(ctx, config, event.companyId);
@@ -627,7 +791,7 @@ const plugin = definePlugin({
       });
     }
 
-    if (config.notifyOnIssueAssigned) {
+    {
       const assignmentDedupe = makeUpdateDedupe();
 
       ctx.events.on("issue.updated", async (event: PluginEvent) => {
@@ -671,7 +835,7 @@ const plugin = definePlugin({
       });
     }
 
-    if (config.notifyOnApprovalCreated) {
+    {
       ctx.events.on("approval.created", async (event: PluginEvent) => {
         const effectiveConfig = await resolveConfig(ctx, config, event.companyId);
         if (!effectiveConfig.notifyOnApprovalCreated) return;
@@ -719,7 +883,7 @@ const plugin = definePlugin({
       });
     }
 
-    if (config.notifyOnAgentError) {
+    {
       const agentErrorDedupe = makeUpdateDedupe(AGENT_ERROR_DEDUPLICATION_WINDOW_MS, 1000);
       ctx.events.on("agent.run.failed", async (event: PluginEvent) => {
         const effectiveConfig = await resolveConfig(ctx, config, event.companyId);
@@ -764,19 +928,35 @@ const plugin = definePlugin({
       }
     };
 
-    if (config.notifyOnAgentRunStarted) {
+    const enrichRunIssue = async (event: PluginEvent) => {
+      const payload = event.payload as Record<string, unknown>;
+      if (payload.issueId && !payload.issueIdentifier) {
+        try {
+          const issue = await ctx.issues.get(String(payload.issueId), event.companyId);
+          if (issue?.identifier) payload.issueIdentifier = issue.identifier;
+        } catch { /* best effort */ }
+      }
+    };
+
+    {
       ctx.events.on("agent.run.started", async (event: PluginEvent) => {
         const effectiveConfig = await resolveConfig(ctx, config, event.companyId);
-        if (!effectiveConfig.notifyOnAgentRunStarted) return;
+        if (!effectiveConfig.notifyOnAgentRunStarted) {
+          return;
+        }
         await enrichAgentName(event);
+        await enrichRunIssue(event);
         await notify(event, formatAgentRunStarted);
       });
     }
-    if (config.notifyOnAgentRunFinished) {
+    {
       ctx.events.on("agent.run.finished", async (event: PluginEvent) => {
         const effectiveConfig = await resolveConfig(ctx, config, event.companyId);
-        if (!effectiveConfig.notifyOnAgentRunFinished) return;
+        if (!effectiveConfig.notifyOnAgentRunFinished) {
+          return;
+        }
         await enrichAgentName(event);
+        await enrichRunIssue(event);
         await notify(event, formatAgentRunFinished);
       });
     }
@@ -805,133 +985,126 @@ const plugin = definePlugin({
     });
 
     // --- Daily digest job ---
+    ctx.jobs.register("telegram-daily-digest", async (job) => {
+      const scheduledAt = job.scheduledAt ? new Date(job.scheduledAt) : new Date();
+      const manualRun = job.trigger === "manual";
+      const companies = await ctx.companies.list();
+      for (const company of companies) {
+        const effectiveConfig = await resolveConfig(ctx, config, company.id);
+        const effectiveDigestMode = resolveDigestMode(effectiveConfig);
+        if (effectiveDigestMode === "off") continue;
 
-    // Support legacy dailyDigestEnabled boolean
-    const effectiveDigestMode = (config as Record<string, unknown>).dailyDigestEnabled === true && config.digestMode === "off"
-      ? "daily"
-      : config.digestMode ?? "off";
+        const digestSlot = resolveDigestSlot(effectiveConfig, scheduledAt);
+        if (!manualRun && !digestSlot) continue;
 
-    if (effectiveDigestMode !== "off") {
-      ctx.jobs.register("telegram-daily-digest", async () => {
-        // Check if current UTC hour matches a configured digest time
-        const nowHour = new Date().getUTCHours();
-        const nowMin = new Date().getUTCMinutes();
-        if (nowMin >= 5) return; // only fire within first 5 min of the hour
-
-        const parseHour = (t: string) => {
-          const [h] = (t || "").split(":");
-          return parseInt(h ?? "", 10);
-        };
-        const firstHour = parseHour(config.dailyDigestTime);
-        const secondHour = parseHour(config.bidailySecondTime);
-        const tridailyHours = (config.tridailyTimes || "07:00,13:00,19:00")
-          .split(",")
-          .map((t) => parseHour(t.trim()));
-
-        let shouldSend = false;
-        if (effectiveDigestMode === "daily") {
-          shouldSend = nowHour === firstHour;
-        } else if (effectiveDigestMode === "bidaily") {
-          shouldSend = nowHour === firstHour || nowHour === secondHour;
-        } else if (effectiveDigestMode === "tridaily") {
-          shouldSend = tridailyHours.includes(nowHour);
+        let sentKey: string | null = null;
+        if (!manualRun && digestSlot) {
+          sentKey = `digest_sent_${digestSlot.dateKey}_${digestSlot.timeKey}`;
+          const alreadySent = await ctx.state.get({
+            scopeKind: "company",
+            scopeId: company.id,
+            stateKey: sentKey,
+          });
+          if (alreadySent) continue;
         }
-        if (!shouldSend) return;
 
-        const companies = await ctx.companies.list();
-        for (const company of companies) {
-          const effectiveConfig = await resolveConfig(ctx, config, company.id);
-          const token = await resolveTelegramBotToken(ctx, effectiveConfig, company.id);
-          if (!token) continue;
-          const effectivePublicUrl = effectiveConfig.paperclipPublicUrl || effectiveConfig.paperclipBaseUrl || publicUrl;
-          const chatId = await resolveChat(ctx, company.id, effectiveConfig.digestChatId || effectiveConfig.defaultChatId);
-          if (!chatId) continue;
+        const token = await resolveTelegramBotToken(ctx, effectiveConfig, company.id);
+        if (!token) continue;
+        const effectivePublicUrl = effectiveConfig.paperclipPublicUrl || effectiveConfig.paperclipBaseUrl || publicUrl;
+        const chatId = await resolveChat(ctx, company.id, effectiveConfig.digestChatId || effectiveConfig.defaultChatId);
+        if (!chatId) continue;
 
-          try {
-            const agents = await ctx.agents.list({ companyId: company.id });
-            const activeAgents = agents.filter((a: Agent) => a.status === "active");
-            const issues = await ctx.issues.list({ companyId: company.id, limit: 50 });
+        try {
+          const agents = await ctx.agents.list({ companyId: company.id });
+          const activeAgents = agents.filter((a: Agent) => a.status === "active");
+          const issues = await ctx.issues.list({ companyId: company.id, limit: 50 });
 
-            const now = Date.now();
-            const oneDayMs = 24 * 60 * 60 * 1000;
-            const completedToday = issues.filter((i: Issue) =>
-              i.status === "done" && i.completedAt && (now - new Date(i.completedAt).getTime()) < oneDayMs
-            );
-            const createdToday = issues.filter((i: Issue) =>
-              (now - new Date(i.createdAt).getTime()) < oneDayMs
-            );
+          const now = Date.now();
+          const oneDayMs = 24 * 60 * 60 * 1000;
+          const completedToday = issues.filter((i: Issue) =>
+            i.status === "done" && i.completedAt && (now - new Date(i.completedAt).getTime()) < oneDayMs
+          );
+          const createdToday = issues.filter((i: Issue) =>
+            (now - new Date(i.createdAt).getTime()) < oneDayMs
+          );
 
-            const issuePrefix = company.issuePrefix;
-            const inProgress = issues.filter((i: Issue) => i.status === "in_progress");
-            const inReview = issues.filter((i: Issue) => i.status === "in_review");
-            const blocked = issues.filter((i: Issue) => i.status === "blocked");
+          const issuePrefix = company.issuePrefix;
+          const inProgress = issues.filter((i: Issue) => i.status === "in_progress");
+          const inReview = issues.filter((i: Issue) => i.status === "in_review");
+          const blocked = issues.filter((i: Issue) => i.status === "blocked");
 
-            const dateStr = new Date().toISOString().split("T")[0];
-            const companyLabel = company.name ? ` \\- ${escapeMarkdownV2(company.name)}` : "";
-            const digestLabel = effectiveDigestMode === "bidaily" ? "Digest" : "Daily Digest";
-            const lines = [
-              escapeMarkdownV2("\ud83d\udcca") + ` *${escapeMarkdownV2(digestLabel)}${companyLabel} \\- ${escapeMarkdownV2(dateStr!)}*`,
-              "",
-              `${escapeMarkdownV2("\u2705")} Tasks completed: *${completedToday.length}*`,
-              `${escapeMarkdownV2("\ud83d\udccb")} Tasks created: *${createdToday.length}*`,
-              `${escapeMarkdownV2("\ud83e\udd16")} Active agents: *${activeAgents.length}*/${escapeMarkdownV2(String(agents.length))}`,
-            ];
+          const dateStr = scheduledAt.toISOString().split("T")[0];
+          const companyLabel = company.name ? ` \\- ${escapeMarkdownV2(company.name)}` : "";
+          const digestLabel = effectiveDigestMode === "bidaily" ? "Digest" : "Daily Digest";
+          const lines = [
+            escapeMarkdownV2("\ud83d\udcca") + ` *${escapeMarkdownV2(digestLabel)}${companyLabel} \\- ${escapeMarkdownV2(dateStr!)}*`,
+            "",
+            `${escapeMarkdownV2("\u2705")} Tasks completed: *${completedToday.length}*`,
+            `${escapeMarkdownV2("\ud83d\udccb")} Tasks created: *${createdToday.length}*`,
+            `${escapeMarkdownV2("\ud83e\udd16")} Active agents: *${activeAgents.length}*/${escapeMarkdownV2(String(agents.length))}`,
+          ];
 
-            if (activeAgents.length > 0) {
-              const topAgent = activeAgents[0]!.name;
-              lines.push(`${escapeMarkdownV2("\u2b50")} Top performer: *${escapeMarkdownV2(topAgent)}*`);
-            }
-
-            const formatIssueItem = (i: Issue) => {
-              const id = i.identifier ?? i.id;
-              const idText = issuePrefix
-                ? `[${escapeMarkdownV2(id)}](${effectivePublicUrl}/${issuePrefix}/issues/${id})`
-                : escapeMarkdownV2(id);
-              return `  ${idText} \\- ${escapeMarkdownV2(i.title)}`;
-            };
-
-            if (inProgress.length > 0) {
-              lines.push("", `${escapeMarkdownV2("\ud83d\udd04")} *In Progress \\(${inProgress.length}\\)*`);
-              for (const i of inProgress.slice(0, 10)) lines.push(formatIssueItem(i));
-            }
-            if (inReview.length > 0) {
-              lines.push("", `${escapeMarkdownV2("\ud83d\udd0d")} *In Review \\(${inReview.length}\\)*`);
-              for (const i of inReview.slice(0, 10)) lines.push(formatIssueItem(i));
-            }
-            if (blocked.length > 0) {
-              lines.push("", `${escapeMarkdownV2("\ud83d\udeab")} *Blocked \\(${blocked.length}\\)*`);
-              for (const i of blocked.slice(0, 10)) lines.push(formatIssueItem(i));
-            }
-
-            const digestThreadId = await resolveDigestThreadId(ctx, token, chatId, effectiveConfig.digestTopicId);
-
-            await sendMessage(ctx, token, chatId, lines.join("\n"), {
-              parseMode: "MarkdownV2",
-              messageThreadId: digestThreadId,
-            });
-          } catch (err) {
-            ctx.logger.error("Daily digest failed for company", { companyId: company.id, error: String(err) });
-            const text = [
-              escapeMarkdownV2("\ud83d\udcca") + " *Daily Digest*",
-              "",
-              escapeMarkdownV2("Could not generate digest. Check plugin logs for details."),
-            ].join("\n");
-
-            const errorThreadId = await resolveDigestThreadId(
-              ctx,
-              token,
-              chatId,
-              effectiveConfig.errorsTopicId || effectiveConfig.digestTopicId,
-            );
-
-            await sendMessage(ctx, token, chatId, text, {
-              parseMode: "MarkdownV2",
-              messageThreadId: errorThreadId,
-            });
+          if (activeAgents.length > 0) {
+            const topAgent = activeAgents[0]!.name;
+            lines.push(`${escapeMarkdownV2("\u2b50")} Top performer: *${escapeMarkdownV2(topAgent)}*`);
           }
+
+          const formatIssueItem = (i: Issue) => {
+            const id = i.identifier ?? i.id;
+            const idText = issuePrefix
+              ? `[${escapeMarkdownV2(id)}](${effectivePublicUrl}/${issuePrefix}/issues/${id})`
+              : escapeMarkdownV2(id);
+            return `  ${idText} \\- ${escapeMarkdownV2(i.title)}`;
+          };
+
+          if (inProgress.length > 0) {
+            lines.push("", `${escapeMarkdownV2("\ud83d\udd04")} *In Progress \\(${inProgress.length}\\)*`);
+            for (const i of inProgress.slice(0, 10)) lines.push(formatIssueItem(i));
+          }
+          if (inReview.length > 0) {
+            lines.push("", `${escapeMarkdownV2("\ud83d\udd0d")} *In Review \\(${inReview.length}\\)*`);
+            for (const i of inReview.slice(0, 10)) lines.push(formatIssueItem(i));
+          }
+          if (blocked.length > 0) {
+            lines.push("", `${escapeMarkdownV2("\ud83d\udeab")} *Blocked \\(${blocked.length}\\)*`);
+            for (const i of blocked.slice(0, 10)) lines.push(formatIssueItem(i));
+          }
+
+          const digestThreadId = await resolveDigestThreadId(ctx, token, chatId, effectiveConfig.digestTopicId);
+
+          await sendMessage(ctx, token, chatId, lines.join("\n"), {
+            parseMode: "MarkdownV2",
+            messageThreadId: digestThreadId,
+          });
+
+          if (sentKey) {
+            await ctx.state.set(
+              { scopeKind: "company", scopeId: company.id, stateKey: sentKey },
+              { sentAt: new Date().toISOString(), jobRunId: job.runId },
+            );
+          }
+        } catch (err) {
+          ctx.logger.error("Daily digest failed for company", { companyId: company.id, error: String(err) });
+          const text = [
+            escapeMarkdownV2("\ud83d\udcca") + " *Daily Digest*",
+            "",
+            escapeMarkdownV2("Could not generate digest. Check plugin logs for details."),
+          ].join("\n");
+
+          const errorThreadId = await resolveDigestThreadId(
+            ctx,
+            token,
+            chatId,
+            effectiveConfig.errorsTopicId || effectiveConfig.digestTopicId,
+          );
+
+          await sendMessage(ctx, token, chatId, text, {
+            parseMode: "MarkdownV2",
+            messageThreadId: errorThreadId,
+          });
         }
-      });
-    }
+      }
+    });
 
     // --- Phase 1: Escalation support ---
     const escalationManager = new EscalationManager();
@@ -1120,9 +1293,14 @@ const plugin = definePlugin({
     // --- Phase 1: Escalation timeout checker job ---
     ctx.jobs.register("check-escalation-timeouts", async () => {
       try {
-        const token = await resolveTelegramBotToken(ctx, config);
-        if (!token) return;
-        await escalationManager.checkTimeouts(ctx, token);
+        const runtimes = await resolveCompanyRuntimes(
+          ctx,
+          config,
+          (effectiveConfig) => Boolean(effectiveConfig.enableInbound || effectiveConfig.escalationChatId),
+        );
+        for (const runtime of runtimes) {
+          await escalationManager.checkTimeouts(ctx, runtime.token, runtime.companyId);
+        }
       } catch (err) {
         ctx.logger.error("Escalation timeout check failed", { error: String(err) });
       }
@@ -1131,12 +1309,17 @@ const plugin = definePlugin({
     // --- Phase 5: Watch checker job ---
     ctx.jobs.register("check-watches", async () => {
       try {
-        const token = await resolveTelegramBotToken(ctx, config);
-        if (!token) return;
-        await checkWatches(ctx, token, {
-          maxSuggestionsPerHourPerCompany: config.maxSuggestionsPerHourPerCompany ?? 10,
-          watchDeduplicationWindowMs: config.watchDeduplicationWindowMs ?? 86400000,
-        });
+        const runtimes = await resolveCompanyRuntimes(
+          ctx,
+          config,
+          (effectiveConfig) => (effectiveConfig.maxSuggestionsPerHourPerCompany ?? 10) > 0,
+        );
+        for (const runtime of runtimes) {
+          await checkWatches(ctx, runtime.token, {
+            maxSuggestionsPerHourPerCompany: runtime.config.maxSuggestionsPerHourPerCompany ?? 10,
+            watchDeduplicationWindowMs: runtime.config.watchDeduplicationWindowMs ?? 86400000,
+          }, runtime.companyId);
+        }
       } catch (err) {
         ctx.logger.error("Watch check failed", { error: String(err) });
       }
@@ -1267,9 +1450,11 @@ export async function handleUpdate(
   }
 
   if (config.enableInbound && msg.reply_to_message?.from?.is_bot) {
+    const companyId = await resolveCompanyId(ctx, chatId);
     const replyToId = msg.reply_to_message.message_id;
     const mapping = await ctx.state.get({
-      scopeKind: "instance",
+      scopeKind: "company",
+      scopeId: companyId,
       stateKey: `msg_${chatId}_${replyToId}`,
     }) as { entityId: string; entityType: string; companyId: string } | null;
 
@@ -1321,6 +1506,7 @@ async function handleCallbackQuery(
   const actor = query.from.username ?? query.from.first_name ?? String(query.from.id);
   const chatId = query.message?.chat.id ? String(query.message.chat.id) : null;
   const messageId = query.message?.message_id;
+  const originalMessageText = query.message?.text?.trim() ?? "";
 
   if (data.startsWith("approve_")) {
     const approvalId = data.replace("approve_", "");
@@ -1348,8 +1534,7 @@ async function handleCallbackQuery(
           token,
           chatId,
           messageId,
-          `${escapeMarkdownV2("\u2705")} *Approved* by ${escapeMarkdownV2(actor)}`,
-          { parseMode: "MarkdownV2" },
+          formatApprovalDecisionMessage("approved", actor, originalMessageText, approvalId),
         );
       }
     } catch (err) {
@@ -1403,8 +1588,7 @@ async function handleCallbackQuery(
           token,
           chatId,
           messageId,
-          `${escapeMarkdownV2("\u274c")} *Rejected* by ${escapeMarkdownV2(actor)}`,
-          { parseMode: "MarkdownV2" },
+          formatApprovalDecisionMessage("rejected", actor, originalMessageText, approvalId),
         );
       }
     } catch (err) {
@@ -1428,6 +1612,22 @@ async function handleCallbackQuery(
   }
 
   await answerCallbackQuery(ctx, token, query.id, "Unknown action");
+}
+
+function formatApprovalDecisionMessage(
+  decision: "approved" | "rejected",
+  actor: string,
+  originalMessageText: string,
+  approvalId: string,
+): string {
+  const status = decision === "approved" ? "✅ Approved" : "❌ Rejected";
+  const body = stripApprovalDecisionPrefix(originalMessageText).trim();
+  const fallbackBody = `Approval ID: ${approvalId}`;
+  return `${status} by ${actor}\n${body || fallbackBody}`;
+}
+
+function stripApprovalDecisionPrefix(text: string): string {
+  return text.replace(/^(?:✅ Approved|❌ Rejected) by [^\n]*\n*/u, "");
 }
 
 runWorker(plugin, import.meta.url);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -157,6 +157,26 @@ function asNonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 
+async function resolveConfig(
+  ctx: PluginContext,
+  fallback: TelegramConfig,
+  companyId?: string | null,
+): Promise<TelegramConfig> {
+  try {
+    const getConfig = ctx.config.get as unknown as (
+      params?: { companyId?: string | null },
+    ) => Promise<Record<string, unknown>>;
+    const scopedConfig = await getConfig(companyId ? { companyId } : undefined);
+    return { ...fallback, ...scopedConfig } as unknown as TelegramConfig;
+  } catch (err) {
+    ctx.logger.warn("Failed to load scoped Telegram plugin config; using startup config", {
+      companyId,
+      error: String(err),
+    });
+    return fallback;
+  }
+}
+
 function normalizeBoardAccessState(value: unknown): TelegramBoardAccessState {
   const record = isRecord(value) ? value : {};
   return {
@@ -478,10 +498,11 @@ const plugin = definePlugin({
       overrideChatId?: string,
       overrideTopicId?: string,
     ) => {
+      const effectiveConfig = await resolveConfig(ctx, config, event.companyId);
       const chatId = await resolveChat(
         ctx,
         event.companyId,
-        overrideChatId || config.defaultChatId,
+        overrideChatId || effectiveConfig.defaultChatId,
       );
       if (!chatId) return;
       const linksOpts = await resolveIssueLinksOpts(event.companyId);
@@ -489,7 +510,7 @@ const plugin = definePlugin({
 
       let messageThreadId = parseTopicId(overrideTopicId);
       if (!messageThreadId) {
-        messageThreadId = await resolveNotificationThreadId(ctx, chatId, event, config.topicRouting);
+        messageThreadId = await resolveNotificationThreadId(ctx, chatId, event, effectiveConfig.topicRouting);
       }
 
       if (messageThreadId) {
@@ -554,14 +575,18 @@ const plugin = definePlugin({
     };
 
     if (config.notifyOnIssueCreated) {
-      ctx.events.on("issue.created", (event: PluginEvent) =>
-        notify(event, formatIssueCreated),
-      );
+      ctx.events.on("issue.created", async (event: PluginEvent) => {
+        const effectiveConfig = await resolveConfig(ctx, config, event.companyId);
+        if (!effectiveConfig.notifyOnIssueCreated) return;
+        await notify(event, formatIssueCreated);
+      });
     }
 
     if (config.notifyOnIssueDone) {
       const doneDedupe = makeUpdateDedupe();
       ctx.events.on("issue.updated", async (event: PluginEvent) => {
+        const effectiveConfig = await resolveConfig(ctx, config, event.companyId);
+        if (!effectiveConfig.notifyOnIssueDone) return;
         const payload = event.payload as Record<string, unknown>;
         if (payload.status !== "done") return;
         if (!doneDedupe(`done|${event.entityId}`)) return;
@@ -592,6 +617,8 @@ const plugin = definePlugin({
       const assignmentDedupe = makeUpdateDedupe();
 
       ctx.events.on("issue.updated", async (event: PluginEvent) => {
+        const effectiveConfig = await resolveConfig(ctx, config, event.companyId);
+        if (!effectiveConfig.notifyOnIssueAssigned) return;
         const payload = event.payload as Record<string, unknown>;
         const prev = (payload._previous as Record<string, unknown> | undefined) ?? {};
 
@@ -601,7 +628,7 @@ const plugin = definePlugin({
           "assigneeAgentId" in payload && payload.assigneeAgentId !== prev.assigneeAgentId;
         if (!userChanged && !agentChanged) return;
 
-        if (config.onlyNotifyIfAssignedTo && payload.assigneeUserId !== config.onlyNotifyIfAssignedTo) {
+        if (effectiveConfig.onlyNotifyIfAssignedTo && payload.assigneeUserId !== effectiveConfig.onlyNotifyIfAssignedTo) {
           return;
         }
 
@@ -632,7 +659,9 @@ const plugin = definePlugin({
 
     if (config.notifyOnApprovalCreated) {
       ctx.events.on("approval.created", async (event: PluginEvent) => {
-        if (!shouldNotifyApproval(event, config.onlyNotifyBoardApprovals)) return;
+        const effectiveConfig = await resolveConfig(ctx, config, event.companyId);
+        if (!effectiveConfig.notifyOnApprovalCreated) return;
+        if (!shouldNotifyApproval(event, effectiveConfig.onlyNotifyBoardApprovals)) return;
         const payload = event.payload as Record<string, unknown>;
         // Enrich with linked issue details (event only has issueIds)
         const issueIds = Array.isArray(payload.issueIds) ? payload.issueIds as string[] : [];
@@ -672,13 +701,15 @@ const plugin = definePlugin({
             ? `${approvalType} — ${agentLabel}`
             : approvalType;
         }
-        await notify(event, formatApprovalCreated, config.approvalsChatId, config.approvalsTopicId);
+        await notify(event, formatApprovalCreated, effectiveConfig.approvalsChatId, effectiveConfig.approvalsTopicId);
       });
     }
 
     if (config.notifyOnAgentError) {
       const agentErrorDedupe = makeUpdateDedupe(AGENT_ERROR_DEDUPLICATION_WINDOW_MS, 1000);
       ctx.events.on("agent.run.failed", async (event: PluginEvent) => {
+        const effectiveConfig = await resolveConfig(ctx, config, event.companyId);
+        if (!effectiveConfig.notifyOnAgentError) return;
         const payload = event.payload as Record<string, unknown>;
         const agentId = String(payload.agentId ?? event.entityId);
         if (payload.agentId && !payload.agentName) {
@@ -705,7 +736,7 @@ const plugin = definePlugin({
         const errorMessage = normalizeAgentErrorMessage(payload.error ?? payload.message);
         const dedupeKey = ["agent.run.failed", event.companyId, agentId, errorMessage].join(":");
         if (!agentErrorDedupe(dedupeKey)) return;
-        await notify(event, formatAgentError, config.errorsChatId, config.errorsTopicId);
+        await notify(event, formatAgentError, effectiveConfig.errorsChatId, effectiveConfig.errorsTopicId);
       });
     }
 
@@ -721,12 +752,16 @@ const plugin = definePlugin({
 
     if (config.notifyOnAgentRunStarted) {
       ctx.events.on("agent.run.started", async (event: PluginEvent) => {
+        const effectiveConfig = await resolveConfig(ctx, config, event.companyId);
+        if (!effectiveConfig.notifyOnAgentRunStarted) return;
         await enrichAgentName(event);
         await notify(event, formatAgentRunStarted);
       });
     }
     if (config.notifyOnAgentRunFinished) {
       ctx.events.on("agent.run.finished", async (event: PluginEvent) => {
+        const effectiveConfig = await resolveConfig(ctx, config, event.companyId);
+        if (!effectiveConfig.notifyOnAgentRunFinished) return;
         await enrichAgentName(event);
         await notify(event, formatAgentRunFinished);
       });
@@ -791,7 +826,9 @@ const plugin = definePlugin({
 
         const companies = await ctx.companies.list();
         for (const company of companies) {
-          const chatId = await resolveChat(ctx, company.id, config.digestChatId || config.defaultChatId);
+          const effectiveConfig = await resolveConfig(ctx, config, company.id);
+          const effectivePublicUrl = effectiveConfig.paperclipPublicUrl || effectiveConfig.paperclipBaseUrl || publicUrl;
+          const chatId = await resolveChat(ctx, company.id, effectiveConfig.digestChatId || effectiveConfig.defaultChatId);
           if (!chatId) continue;
 
           try {
@@ -832,7 +869,7 @@ const plugin = definePlugin({
             const formatIssueItem = (i: Issue) => {
               const id = i.identifier ?? i.id;
               const idText = issuePrefix
-                ? `[${escapeMarkdownV2(id)}](${publicUrl}/${issuePrefix}/issues/${id})`
+                ? `[${escapeMarkdownV2(id)}](${effectivePublicUrl}/${issuePrefix}/issues/${id})`
                 : escapeMarkdownV2(id);
               return `  ${idText} \\- ${escapeMarkdownV2(i.title)}`;
             };
@@ -850,7 +887,7 @@ const plugin = definePlugin({
               for (const i of blocked.slice(0, 10)) lines.push(formatIssueItem(i));
             }
 
-            const digestThreadId = await resolveDigestThreadId(ctx, token, chatId, config.digestTopicId);
+            const digestThreadId = await resolveDigestThreadId(ctx, token, chatId, effectiveConfig.digestTopicId);
 
             await sendMessage(ctx, token, chatId, lines.join("\n"), {
               parseMode: "MarkdownV2",
@@ -868,7 +905,7 @@ const plugin = definePlugin({
               ctx,
               token,
               chatId,
-              config.errorsTopicId || config.digestTopicId,
+              effectiveConfig.errorsTopicId || effectiveConfig.digestTopicId,
             );
 
             await sendMessage(ctx, token, chatId, text, {
@@ -924,14 +961,15 @@ const plugin = definePlugin({
       },
     }, async (params: unknown, runCtx) => {
       const p = params as Record<string, unknown>;
+      const effectiveConfig = await resolveConfig(ctx, config, runCtx.companyId);
       const escalationId = crypto.randomUUID();
-      const timeoutMs = config.escalationTimeoutMs || 900000;
-      const defaultAction = config.escalationDefaultAction || "defer";
+      const timeoutMs = effectiveConfig.escalationTimeoutMs || 900000;
+      const defaultAction = effectiveConfig.escalationDefaultAction || "defer";
 
       const resolvedEscalationChatId = await resolveChat(
         ctx,
         runCtx.companyId,
-        config.escalationChatId,
+        effectiveConfig.escalationChatId,
       );
       if (!resolvedEscalationChatId) {
         ctx.logger.warn("Escalation received but no escalationChatId configured");
@@ -964,8 +1002,8 @@ const plugin = definePlugin({
       await escalationManager.create(ctx, token, escalationEvent, resolvedEscalationChatId);
 
       // Send hold message to the originating chat if configured
-      if (config.escalationHoldMessage && escalationEvent.originChatId) {
-        const holdText = escapeMarkdownV2(config.escalationHoldMessage);
+      if (effectiveConfig.escalationHoldMessage && escalationEvent.originChatId) {
+        const holdText = escapeMarkdownV2(effectiveConfig.escalationHoldMessage);
         await sendMessage(ctx, token, escalationEvent.originChatId, holdText, {
           parseMode: "MarkdownV2",
           messageThreadId: escalationEvent.originThreadId ? Number(escalationEvent.originThreadId) : undefined,
@@ -1118,8 +1156,10 @@ export async function handleUpdate(
 
   if (update.callback_query) {
     const companyId = await resolveCallbackCompanyId(ctx, update.callback_query);
-    const boardApiToken = await resolveBoardApiToken(ctx, config, companyId);
-    await handleCallbackQuery(ctx, token, update.callback_query, baseUrl, boardApiToken);
+    const effectiveConfig = await resolveConfig(ctx, config, companyId);
+    const effectiveBaseUrl = effectiveConfig.paperclipBaseUrl || baseUrl;
+    const boardApiToken = await resolveBoardApiToken(ctx, effectiveConfig, companyId);
+    await handleCallbackQuery(ctx, token, update.callback_query, effectiveBaseUrl, boardApiToken);
     return;
   }
 
@@ -1134,11 +1174,13 @@ export async function handleUpdate(
   if (hasMedia) {
     const companyId = await resolveCompanyIdOrNull(ctx, chatId);
     if (companyId) {
+      const effectiveConfig = await resolveConfig(ctx, config, companyId);
+      const effectivePublicUrl = effectiveConfig.paperclipPublicUrl || effectiveConfig.paperclipBaseUrl || publicUrl;
       const handled = await handleMediaMessage(ctx, token, msg as Parameters<typeof handleMediaMessage>[2], {
-        briefAgentId: config.briefAgentId ?? "",
-        briefAgentChatIds: config.briefAgentChatIds ?? [],
-        transcriptionApiKeyRef: config.transcriptionApiKeyRef ?? "",
-        publicUrl,
+        briefAgentId: effectiveConfig.briefAgentId ?? "",
+        briefAgentChatIds: effectiveConfig.briefAgentChatIds ?? [],
+        transcriptionApiKeyRef: effectiveConfig.transcriptionApiKeyRef ?? "",
+        publicUrl: effectivePublicUrl,
       }, companyId);
       if (handled) return;
     } else {
@@ -1173,6 +1215,9 @@ export async function handleUpdate(
     // undefined on unlinked chats: /connect and /help still work, and the
     // company-scoped handlers answer with their "not linked" guidance.
     const companyId = (await resolveCompanyIdOrNull(ctx, chatId)) ?? undefined;
+    const effectiveConfig = companyId ? await resolveConfig(ctx, config, companyId) : config;
+    const effectiveBaseUrl = effectiveConfig.paperclipBaseUrl || baseUrl;
+    const effectivePublicUrl = effectiveConfig.paperclipPublicUrl || effectiveBaseUrl;
 
     // Phase 4: Check custom commands first
     if (command === "commands") {
@@ -1184,8 +1229,8 @@ export async function handleUpdate(
     if (handledCustom) return;
 
     // Built-in commands
-    const boardApiToken = command === "approve" ? await resolveBoardApiToken(ctx, config, companyId) : undefined;
-    await handleCommand(ctx, token, chatId, command, args, threadId, baseUrl, publicUrl, companyId, boardApiToken, config.maxAgentsPerThread);
+    const boardApiToken = command === "approve" ? await resolveBoardApiToken(ctx, effectiveConfig, companyId) : undefined;
+    await handleCommand(ctx, token, chatId, command, args, threadId, effectiveBaseUrl, effectivePublicUrl, companyId, boardApiToken, effectiveConfig.maxAgentsPerThread);
     return;
   }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -216,9 +216,9 @@ function getBoardAccessRegistration(
  * /help would be wasteful — the cost of that optimisation is this coupling, so
  * it is asserted in tests.
  */
-const BOARD_TOKEN_COMMANDS = new Set(["approve", "decisions"]);
+export const BOARD_TOKEN_COMMANDS = new Set(["approve", "decisions"]);
 
-async function resolveBoardApiToken(
+export async function resolveBoardApiToken(
   ctx: PluginContext,
   config: TelegramConfig,
   companyId?: string | null,
@@ -337,7 +337,7 @@ type TelegramPollingRuntimeGroup = {
  * not callable from setup(). Falls back to the company id recorded in the
  * board-access state, which is written when board access is connected.
  */
-async function listCompaniesForStartup(ctx: PluginContext): Promise<Array<{ id: string }>> {
+export async function listCompaniesForStartup(ctx: PluginContext): Promise<Array<{ id: string }>> {
   let listed: Array<{ id: string }> = [];
   let listError: unknown = null;
   try {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -373,7 +373,7 @@ export async function listCompaniesForStartup(ctx: PluginContext): Promise<Array
   return [{ id: fallbackCompanyId }];
 }
 
-async function resolveCompanyRuntimes(
+export async function resolveCompanyRuntimes(
   ctx: PluginContext,
   startupConfig: TelegramConfig,
   predicate: (config: TelegramConfig) => boolean,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -48,7 +48,7 @@ import { AGENT_ERROR_DEDUPLICATION_WINDOW_MS, METRIC_NAMES } from "./constants.j
 import { EscalationManager } from "./escalation.js";
 import type { EscalationEvent } from "./escalation.js";
 import { isTelegramUpdateAllowed, validateTelegramAllowlists } from "./allowlist.js";
-import { validateSecretRefFields } from "./secret-ref-validation.js";
+import { validateSecretRefFields, normalizeSecretRef } from "./secret-ref-validation.js";
 import { shouldNotifyApproval } from "./approval-routing.js";
 import { buildPaperclipAuthHeaders, fetchPaperclipApi } from "./paperclip-api.js";
 import {
@@ -236,7 +236,17 @@ async function resolveBoardApiToken(
     if (seen.has(candidate.ref)) continue;
     seen.add(candidate.ref);
     try {
-      return await ctx.secrets.resolve(candidate.ref, {
+      // The board-access state persists a bare UUID, which hosts requiring the
+      // object form reject outright — surfacing to the user as an unexplained
+      // 403 from whatever needed the token.
+      const ref = normalizeSecretRef(candidate.ref);
+      if (!ref) {
+        ctx.logger.warn("Board API token ref is not a usable secret reference", {
+          source: candidate.source,
+        });
+        continue;
+      }
+      return await ctx.secrets.resolve(ref as unknown as string, {
         companyId: companyId ?? undefined,
         configPath: candidate.source === "config" ? "paperclipBoardApiTokenRef" : undefined,
       });

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -310,12 +310,66 @@ type TelegramPollingRuntimeGroup = {
   runtimes: TelegramCompanyRuntime[];
 };
 
+/**
+ * Enumerate companies for startup, tolerating hosts where `companies.list` is
+ * not callable from setup(). Falls back to the company id recorded in the
+ * board-access state, which is written when board access is connected.
+ */
+async function listCompaniesForStartup(ctx: PluginContext): Promise<Array<{ id: string }>> {
+  let listed: Array<{ id: string }> = [];
+  let listError: unknown = null;
+  try {
+    listed = await ctx.companies.list();
+  } catch (err) {
+    listError = err;
+  }
+
+  // An empty array is the common case, not the exception: on this host
+  // companies.list SUCCEEDS from setup() and returns [], because there is no
+  // invocation scope to enumerate companies against. Treating only a thrown
+  // error as failure leaves runtimes empty and silently disables polling.
+  if (listed.length > 0) return listed;
+
+  let fallbackCompanyId: string | null = null;
+  try {
+    fallbackCompanyId = (await loadBoardAccessState(ctx)).companyId;
+  } catch {
+    // board-access state is optional; absence just means no fallback
+  }
+
+  if (!fallbackCompanyId) {
+    ctx.logger.warn("companies.list yielded no companies at startup and no fallback company id is known", {
+      error: listError ? String(listError) : "empty result",
+    });
+    return [];
+  }
+
+  ctx.logger.info("companies.list yielded no companies at startup; using the company id from board-access state", {
+    companyId: fallbackCompanyId,
+    reason: listError ? String(listError) : "empty result",
+  });
+  return [{ id: fallbackCompanyId }];
+}
+
 async function resolveCompanyRuntimes(
   ctx: PluginContext,
   startupConfig: TelegramConfig,
   predicate: (config: TelegramConfig) => boolean,
 ): Promise<TelegramCompanyRuntime[]> {
-  const companies = await ctx.companies.list();
+  // `ctx.companies.list()` is the natural way to enumerate companies, but it is
+  // not reliable from setup(): on hosts that enforce per-invocation scoping it
+  // can fail with "the worker referenced a missing, expired, or unknown
+  // invocation scope" (paperclipai/paperclip#9368, #11163). setup() runs
+  // outside any host-issued invocation, and the failure is order-dependent —
+  // an earlier failed host call makes the next one fail this way.
+  //
+  // When that happens the runtime list comes back empty and long polling is
+  // never started, so every inbound feature (commands, reply routing,
+  // approve/reject) is silently dead for the worker's life — there is no retry.
+  //
+  // Discovery is not actually required: the company is already known from the
+  // stored board-access state. Fall back to it rather than lose inbound.
+  const companies = await listCompaniesForStartup(ctx);
   const runtimes: TelegramCompanyRuntime[] = [];
 
   for (const company of companies) {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -669,11 +669,7 @@ const plugin = definePlugin({
       if (commandRegistrationRefs.has(runtime.config.telegramBotTokenRef)) continue;
       commandRegistrationRefs.add(runtime.config.telegramBotTokenRef);
 
-      const allCommands = [
-        ...BOT_COMMANDS,
-        { command: "commands", description: "Manage custom workflow commands" },
-      ];
-      setMyCommands(ctx, runtime.token, allCommands)
+      setMyCommands(ctx, runtime.token, BOT_COMMANDS)
         .then((registered) => {
           if (registered) {
             ctx.logger.info("Bot commands registered with Telegram", { companyId: runtime.companyId });

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -236,8 +236,10 @@ async function resolveBoardApiToken(
     if (seen.has(candidate.ref)) continue;
     seen.add(candidate.ref);
     try {
-      const resolveSecret = ctx.secrets.resolve as (secretRef: string, companyId?: string | null) => Promise<string>;
-      return await resolveSecret(candidate.ref, companyId);
+      return await ctx.secrets.resolve(candidate.ref, {
+        companyId: companyId ?? undefined,
+        configPath: candidate.source === "config" ? "paperclipBoardApiTokenRef" : undefined,
+      });
     } catch (err) {
       ctx.logger.warn("Failed to resolve board API token secret", {
         source: candidate.source,
@@ -273,8 +275,10 @@ async function resolveTelegramBotTokenRef(
   }
 
   try {
-    const resolveSecret = ctx.secrets.resolve as (secretRef: string, companyId?: string | null) => Promise<string>;
-    return await resolveSecret(tokenRef, companyId);
+    return await ctx.secrets.resolve(tokenRef, {
+      companyId,
+      configPath: "telegramBotTokenRef",
+    });
   } catch (err) {
     runtimeHealth = {
       status: "degraded",
@@ -317,10 +321,7 @@ async function resolveCompanyRuntimes(
   for (const company of companies) {
     let scopedConfig: Record<string, unknown>;
     try {
-      const getConfig = ctx.config.get as unknown as (
-        params?: { companyId?: string | null },
-      ) => Promise<Record<string, unknown>>;
-      scopedConfig = await getConfig({ companyId: company.id });
+      scopedConfig = await ctx.config.get(company.id);
     } catch (err) {
       ctx.logger.warn("Company-scoped Telegram plugin config unavailable; skipping company runtime", {
         companyId: company.id,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -615,7 +615,17 @@ async function resolveCompanyIdOrNull(ctx: PluginContext, chatId: string): Promi
 
 const plugin = definePlugin({
   async setup(ctx) {
-    const rawConfig = await loadStartupConfig(ctx, {} as Record<string, unknown>);
+    // Resolve the company BEFORE loading config. An unscoped ctx.config.get()
+    // fails from setup() on scope-enforcing hosts, and the silent fallback to
+    // defaults leaves paperclipBoardApiTokenRef unset — which surfaces much
+    // later, and intermittently, as a bare 403 from whatever needed the board
+    // token. Knowing the company up front turns that into a scoped retry.
+    const startupCompanies = await listCompaniesForStartup(ctx);
+    const rawConfig = await loadStartupConfig(
+      ctx,
+      {} as Record<string, unknown>,
+      startupCompanies[0]?.id ?? null,
+    );
     ctx.logger.info("Telegram plugin config loaded");
     const config = rawConfig as unknown as TelegramConfig;
     const baseUrl = config.paperclipBaseUrl || "http://localhost:3100";

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -44,6 +44,12 @@ import {
 import { getTelegramUpdateChatId, selectTelegramRuntimeForUpdate } from "./polling-dispatch.js";
 import { handleCommandsCommand, tryCustomCommand } from "./command-registry.js";
 import { handleRegisterWatch, checkWatches } from "./watch-registry.js";
+import {
+  isInteractionAnswerCallback,
+  resolveInteractionAnswerCallback,
+  finalizeReplyRejection,
+  isInteractionReplyMapping,
+} from "./interaction-answers.js";
 import { AGENT_ERROR_DEDUPLICATION_WINDOW_MS, METRIC_NAMES } from "./constants.js";
 import { EscalationManager } from "./escalation.js";
 import type { EscalationEvent } from "./escalation.js";
@@ -1626,6 +1632,15 @@ export async function handleUpdate(
           error: String(err),
         });
       }
+    } else if (isInteractionReplyMapping(mapping)) {
+      // Replying to a confirmation prompt is the reason text for rejecting
+      // it — the button-less half of the accept/reject flow (BLA-154). See
+      // interaction-answers.ts for why rejection, not acceptance, needs this.
+      const effectiveConfig = await resolveConfig(ctx, config, companyId);
+      const effectiveBaseUrl = effectiveConfig.paperclipBaseUrl || baseUrl;
+      const boardApiToken = await resolveBoardApiToken(ctx, effectiveConfig, companyId);
+      await finalizeReplyRejection(ctx, token, effectiveBaseUrl, boardApiToken, mapping, text, chatId);
+      await ctx.metrics.write(METRIC_NAMES.inboundRouted, 1);
     }
   }
 }
@@ -1644,6 +1659,11 @@ async function handleCallbackQuery(
   const chatId = query.message?.chat.id ? String(query.message.chat.id) : null;
   const messageId = query.message?.message_id;
   const originalMessageText = query.message?.text?.trim() ?? "";
+
+  if (isInteractionAnswerCallback(data)) {
+    await resolveInteractionAnswerCallback(ctx, token, data, query.id, baseUrl, boardApiToken, messageId);
+    return;
+  }
 
   if (data.startsWith("approve_")) {
     const approvalId = data.replace("approve_", "");

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -373,10 +373,11 @@ export async function listCompaniesForStartup(ctx: PluginContext): Promise<Array
   return [{ id: fallbackCompanyId }];
 }
 
-async function resolveCompanyRuntimes(
+export async function resolveCompanyRuntimes(
   ctx: PluginContext,
   startupConfig: TelegramConfig,
   predicate: (config: TelegramConfig) => boolean,
+  prefetchedCompanies?: Array<{ id: string }>,
 ): Promise<TelegramCompanyRuntime[]> {
   // `ctx.companies.list()` is the natural way to enumerate companies, but it is
   // not reliable from setup(): on hosts that enforce per-invocation scoping it
@@ -391,7 +392,11 @@ async function resolveCompanyRuntimes(
   //
   // Discovery is not actually required: the company is already known from the
   // stored board-access state. Fall back to it rather than lose inbound.
-  const companies = await listCompaniesForStartup(ctx);
+  //
+  // A caller that already resolved the list this startup (setup() does, to
+  // seed loadStartupConfig's fallback) passes it through instead of triggering
+  // a second companies.list()/board-access lookup for the same startup.
+  const companies = prefetchedCompanies ?? (await listCompaniesForStartup(ctx));
   const runtimes: TelegramCompanyRuntime[] = [];
 
   for (const company of companies) {
@@ -652,6 +657,7 @@ const plugin = definePlugin({
       ctx,
       config,
       (effectiveConfig) => Boolean(effectiveConfig.enableCommands || effectiveConfig.enableInbound),
+      startupCompanies,
     );
     if (pollingRuntimes.length === 0) {
       ctx.logger.warn("No company-scoped Telegram bot token is resolvable during startup; setup will continue without polling");

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -206,6 +206,18 @@ function getBoardAccessRegistration(
   };
 }
 
+/**
+ * Commands that call board-only Paperclip endpoints and therefore need the
+ * board token resolved before the handler runs. Without it the request goes out
+ * unauthenticated and the user sees a bare 403 with no explanation.
+ *
+ * Keep this in step with the handlers that take a `boardApiToken` argument.
+ * It is a list rather than "always resolve" because resolving a secret on every
+ * /help would be wasteful — the cost of that optimisation is this coupling, so
+ * it is asserted in tests.
+ */
+const BOARD_TOKEN_COMMANDS = new Set(["approve", "decisions"]);
+
 async function resolveBoardApiToken(
   ctx: PluginContext,
   config: TelegramConfig,
@@ -1550,8 +1562,10 @@ export async function handleUpdate(
     const handledCustom = await tryCustomCommand(ctx, token, chatId, command, args, threadId, companyId);
     if (handledCustom) return;
 
-    // Built-in commands
-    const boardApiToken = command === "approve" ? await resolveBoardApiToken(ctx, effectiveConfig, companyId) : undefined;
+    // Built-in commands.
+    const boardApiToken = BOARD_TOKEN_COMMANDS.has(command)
+      ? await resolveBoardApiToken(ctx, effectiveConfig, companyId)
+      : undefined;
     await handleCommand(ctx, token, chatId, command, args, threadId, effectiveBaseUrl, effectivePublicUrl, companyId, boardApiToken, effectiveConfig.maxAgentsPerThread);
     return;
   }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -50,7 +50,7 @@ import {
   finalizeReplyRejection,
   isInteractionReplyMapping,
 } from "./interaction-answers.js";
-import { AGENT_ERROR_DEDUPLICATION_WINDOW_MS, METRIC_NAMES } from "./constants.js";
+import { AGENT_ERROR_DEDUPLICATION_WINDOW_MS, DEFAULT_CONFIG, METRIC_NAMES } from "./constants.js";
 import { EscalationManager } from "./escalation.js";
 import type { EscalationEvent } from "./escalation.js";
 import { isTelegramUpdateAllowed, validateTelegramAllowlists } from "./allowlist.js";
@@ -418,7 +418,7 @@ export async function resolveCompanyRuntimes(
     }
     if (!("telegramBotTokenRef" in scopedConfig)) continue;
 
-    const effectiveConfig = { ...startupConfig, ...scopedConfig } as unknown as TelegramConfig;
+    const effectiveConfig = { ...DEFAULT_CONFIG, ...startupConfig, ...scopedConfig } as unknown as TelegramConfig;
     const hasCompanyTelegramRoute = [
       "telegramBotTokenRef",
       "defaultChatId",
@@ -634,7 +634,7 @@ const plugin = definePlugin({
     const startupCompanies = await listCompaniesForStartup(ctx);
     const rawConfig = await loadStartupConfig(
       ctx,
-      {} as Record<string, unknown>,
+      DEFAULT_CONFIG as unknown as Record<string, unknown>,
       startupCompanies[0]?.id ?? null,
     );
     ctx.logger.info("Telegram plugin config loaded");

--- a/tests/acp-bridge-agent-resolution.test.ts
+++ b/tests/acp-bridge-agent-resolution.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { PluginContext } from "@paperclipai/plugin-sdk";
+import { handleAcpCommand } from "../src/acp-bridge.js";
+
+let sentMessages: Array<{ chatId: string; text: string }> = [];
+let stateStore: Record<string, unknown> = {};
+let emittedEvents: Array<{ event: string; companyId: string; payload: unknown }> = [];
+
+vi.mock("../src/telegram-api.js", async () => {
+  const actual = await vi.importActual("../src/telegram-api.js") as Record<string, unknown>;
+  return {
+    ...actual,
+    sendMessage: vi.fn(async (_ctx: unknown, _token: string, chatId: string, text: string) => {
+      sentMessages.push({ chatId, text });
+      return 100;
+    }),
+    sendChatAction: vi.fn(),
+  };
+});
+
+function mockCtx(agentsListImpl?: () => Promise<unknown[]>): PluginContext {
+  return {
+    http: { fetch: vi.fn() },
+    metrics: { write: vi.fn() },
+    state: {
+      get: vi.fn(async (key: { stateKey: string }) => stateStore[key.stateKey] ?? null),
+      set: vi.fn(async (key: { stateKey: string }, value: unknown) => {
+        stateStore[key.stateKey] = value;
+      }),
+    },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    events: {
+      emit: vi.fn((event: string, companyId: string, payload: unknown) => {
+        emittedEvents.push({ event, companyId, payload });
+      }),
+      on: vi.fn(),
+    },
+    agents: {
+      get: vi.fn().mockRejectedValue(new Error("agents.get requires a UUID, not a name")),
+      list: vi.fn(agentsListImpl ?? (async () => [])),
+      sessions: {
+        create: vi.fn().mockResolvedValue({ sessionId: "native-session-1" }),
+        sendMessage: vi.fn(),
+        close: vi.fn(),
+      },
+    },
+    issues: {
+      create: vi.fn().mockResolvedValue({ id: "issue-1" }),
+      update: vi.fn().mockResolvedValue({ id: "issue-1" }),
+    },
+    projects: { list: vi.fn().mockResolvedValue([]) },
+  } as unknown as PluginContext;
+}
+
+async function spawn(ctx: PluginContext, agentName: string, chatId = "chat-1", threadId = 42, companyId = "company-1") {
+  await handleAcpCommand(ctx, "token", chatId, `spawn ${agentName}`, threadId, companyId);
+}
+
+function savedSessions(chatId = "chat-1", threadId = 42) {
+  return (stateStore[`sessions_${chatId}_${threadId}`] as Array<Record<string, unknown>>) ?? [];
+}
+
+beforeEach(() => {
+  sentMessages = [];
+  stateStore = {};
+  emittedEvents = [];
+});
+
+describe("agent resolution via /acp spawn (regression: ctx.agents.get() requires a UUID, not a name)", () => {
+  it("resolves the agent by exact name match and creates a native session", async () => {
+    const ctx = mockCtx(async () => [{ id: "uuid-1", name: "builder", urlKey: "builder" }]);
+    await spawn(ctx, "builder");
+
+    // The bug this pins: the plugin must never call ctx.agents.get() with a bare
+    // agent name — that always failed with a Postgres UUID-cast error.
+    expect(ctx.agents.get).not.toHaveBeenCalled();
+    expect(ctx.agents.list).toHaveBeenCalledWith({ companyId: "company-1" });
+    expect(ctx.agents.sessions.create).toHaveBeenCalledWith("uuid-1", "company-1", expect.anything());
+
+    const sessions = savedSessions();
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].transport).toBe("native");
+    expect(sessions[0].agentId).toBe("uuid-1");
+  });
+
+  it("matches by urlKey when the name does not match directly", async () => {
+    const ctx = mockCtx(async () => [{ id: "uuid-2", name: "The Builder", urlKey: "builder-agent" }]);
+    await spawn(ctx, "builder-agent");
+
+    const sessions = savedSessions();
+    expect(sessions[0].transport).toBe("native");
+    expect(sessions[0].agentId).toBe("uuid-2");
+  });
+
+  it("matches case-insensitively", async () => {
+    const ctx = mockCtx(async () => [{ id: "uuid-3", name: "CEO", urlKey: "ceo" }]);
+    await spawn(ctx, "ceo");
+
+    const sessions = savedSessions();
+    expect(sessions[0].transport).toBe("native");
+    expect(sessions[0].agentId).toBe("uuid-3");
+  });
+
+  it("falls back to ACP transport (not a thrown error) when no agent matches the name", async () => {
+    const ctx = mockCtx(async () => [{ id: "uuid-1", name: "builder", urlKey: "builder" }]);
+    await spawn(ctx, "nonexistent-agent");
+
+    const sessions = savedSessions();
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].transport).toBe("acp");
+    expect(sessions[0].agentId).toBe("");
+    expect(ctx.agents.sessions.create).not.toHaveBeenCalled();
+    expect(emittedEvents.some((e) => e.event === "acp-spawn")).toBe(true);
+  });
+
+  it("falls back to ACP transport (not a thrown error) when ctx.agents.list() itself throws", async () => {
+    const ctx = mockCtx(async () => {
+      throw new Error("no invocation scope");
+    });
+
+    await expect(spawn(ctx, "builder")).resolves.toBeUndefined();
+    const sessions = savedSessions();
+    expect(sessions[0].transport).toBe("acp");
+    expect(ctx.logger.error).toHaveBeenCalledWith(
+      "Failed to resolve agent by name",
+      expect.objectContaining({ agentName: "builder" }),
+    );
+  });
+
+  it("prefers the agentId field over id when agentId looks like a real UUID (regression: SDK returns UUID under different field names)", async () => {
+    const ctx = mockCtx(async () => [
+      { id: "not-a-uuid-slug", agentId: "11111111-2222-3333-4444-555555555555", name: "builder", urlKey: "builder" },
+    ]);
+    await spawn(ctx, "builder");
+
+    expect(ctx.agents.sessions.create).toHaveBeenCalledWith(
+      "11111111-2222-3333-4444-555555555555",
+      "company-1",
+      expect.anything(),
+    );
+  });
+
+  it("falls back to the id field when agentId does not look like a UUID", async () => {
+    const ctx = mockCtx(async () => [
+      { id: "11111111-2222-3333-4444-555555555555", agentId: "not-a-real-uuid", name: "builder", urlKey: "builder" },
+    ]);
+    await spawn(ctx, "builder");
+
+    expect(ctx.agents.sessions.create).toHaveBeenCalledWith(
+      "11111111-2222-3333-4444-555555555555",
+      "company-1",
+      expect.anything(),
+    );
+  });
+
+  it("falls back to ACP transport (without losing the spawn) when native session creation throws after a successful match", async () => {
+    const ctx = mockCtx(async () => [{ id: "uuid-1", name: "builder", urlKey: "builder" }]);
+    (ctx.agents.sessions.create as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("session service down"));
+
+    await spawn(ctx, "builder");
+
+    const sessions = savedSessions();
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].transport).toBe("acp");
+    expect(ctx.logger.error).toHaveBeenCalledWith(
+      "Native session creation failed, falling back to ACP",
+      expect.objectContaining({ agentName: "builder" }),
+    );
+  });
+});
+
+describe("/acp spawn - guard rails", () => {
+  it("rejects spawn/cancel/close on an unlinked chat without ever touching agent resolution", async () => {
+    const ctx = mockCtx();
+    await handleAcpCommand(ctx, "token", "chat-1", "spawn builder", 42, undefined);
+
+    expect(ctx.agents.list).not.toHaveBeenCalled();
+    expect(sentMessages.some((m) => m.text.includes("not linked"))).toBe(true);
+  });
+
+  it("requires a thread — spawning outside a topic thread does not create a session", async () => {
+    const ctx = mockCtx(async () => [{ id: "uuid-1", name: "builder", urlKey: "builder" }]);
+    await handleAcpCommand(ctx, "token", "chat-1", "spawn builder", undefined, "company-1");
+
+    expect(savedSessions()).toHaveLength(0);
+    expect(ctx.agents.list).not.toHaveBeenCalled();
+  });
+
+  it("refuses to spawn a 6th agent when maxAgentsPerThread is 5", async () => {
+    stateStore["sessions_chat-1_42"] = Array.from({ length: 5 }, (_, i) => ({
+      sessionId: `s${i}`,
+      agentId: `a${i}`,
+      agentName: `agent${i}`,
+      agentDisplayName: `Agent${i}`,
+      transport: "acp",
+      spawnedAt: "2026-01-01T00:00:00Z",
+      status: "active",
+      lastActivityAt: "2026-01-01T00:00:00Z",
+    }));
+    const ctx = mockCtx(async () => [{ id: "uuid-x", name: "one-more", urlKey: "one-more" }]);
+    await spawn(ctx, "one-more");
+
+    expect(savedSessions()).toHaveLength(5);
+    expect(sentMessages.some((m) => m.text.includes("already has 5 active agents"))).toBe(true);
+  });
+});

--- a/tests/acp-bridge-company-resolution.test.ts
+++ b/tests/acp-bridge-company-resolution.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { PluginContext } from "@paperclipai/plugin-sdk";
+import { handleAcpOutput, routeMessageToAgent } from "../src/acp-bridge.js";
+import { ACP_SPAWN_EVENT } from "../src/constants.js";
+
+/**
+ * BLA-162: the bridge used to resolve an unlinked chat's company id to the raw
+ * Telegram `chatId`. Nothing threw and nothing logged, so the failure surfaced
+ * only as host calls that could never succeed — and the discussion loop
+ * re-resolved once per turn, spending a fake id on every remaining turn.
+ *
+ * The invariant these tests hold: a Telegram chat id is NEVER used as a
+ * Paperclip company id, and a chat that cannot be resolved says so.
+ */
+
+let sentMessages: Array<{ chatId: string; text: string; options?: Record<string, unknown> }> = [];
+let stateStore: Record<string, unknown> = {};
+
+vi.mock("../src/telegram-api.js", async () => {
+  const actual = await vi.importActual("../src/telegram-api.js") as Record<string, unknown>;
+  return {
+    ...actual,
+    sendMessage: vi.fn(async (_ctx: unknown, _token: string, chatId: string, text: string, options?: Record<string, unknown>) => {
+      sentMessages.push({ chatId, text, options });
+      return 100;
+    }),
+    sendChatAction: vi.fn(async () => undefined),
+  };
+});
+
+function mockCtx(): PluginContext {
+  return {
+    state: {
+      get: vi.fn(async (key: { stateKey: string }) => stateStore[key.stateKey] ?? null),
+      set: vi.fn(async (key: { stateKey: string }, value: unknown) => {
+        stateStore[key.stateKey] = value;
+      }),
+    },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    events: { emit: vi.fn(), on: vi.fn() },
+  } as unknown as PluginContext;
+}
+
+function acpSession(sessionId: string, name: string) {
+  return {
+    sessionId,
+    agentId: `agent-${sessionId}`,
+    agentName: name,
+    agentDisplayName: name,
+    transport: "acp",
+    spawnedAt: "2026-01-01T00:00:00Z",
+    status: "active",
+    lastActivityAt: "2026-01-01T00:00:00Z",
+  };
+}
+
+/** Two ACP sessions mid-discussion, the shape that made this bug expensive. */
+function seedLoop() {
+  stateStore["sessions_chat-1_42"] = [acpSession("s1", "Builder"), acpSession("s2", "Reviewer")];
+  stateStore["loop_chat-1_42"] = {
+    loopId: "loop-1",
+    initiatorSessionId: "s1",
+    targetSessionId: "s2",
+    initiatorAgent: "Builder",
+    targetAgent: "Reviewer",
+    topic: "schema",
+    maxTurns: 6,
+    currentTurn: 0,
+    lastOutputHash: null,
+    previousOutputHash: null,
+    status: "active",
+    chatId: "chat-1",
+    threadId: 42,
+  };
+}
+
+const outputEvent = { sessionId: "s1", chatId: "chat-1", threadId: 42, text: "your turn", done: false };
+
+/** The company id every ACP_SPAWN_EVENT was emitted with. */
+function emittedCompanyIds(ctx: PluginContext): unknown[] {
+  return (ctx.events.emit as unknown as { mock: { calls: unknown[][] } }).mock.calls
+    .filter((c) => c[0] === ACP_SPAWN_EVENT)
+    .map((c) => c[1]);
+}
+
+beforeEach(() => {
+  sentMessages = [];
+  stateStore = {};
+});
+
+describe("discussion loop company resolution", () => {
+  it("routes the next turn with the company id the host put on the event", async () => {
+    seedLoop();
+    // A stale chat mapping is deliberately present and different: the envelope
+    // is the host's own value and must win over anything cached in chat state.
+    stateStore["chat_chat-1"] = { companyId: "stale-company" };
+    const ctx = mockCtx();
+
+    await handleAcpOutput(ctx, "token", outputEvent, "company-from-host");
+
+    expect(emittedCompanyIds(ctx)).toEqual(["company-from-host"]);
+  });
+
+  it("falls back to the chat's linked company when the event carries none", async () => {
+    seedLoop();
+    stateStore["chat_chat-1"] = { companyId: "linked-company" };
+    const ctx = mockCtx();
+
+    await handleAcpOutput(ctx, "token", outputEvent);
+
+    expect(emittedCompanyIds(ctx)).toEqual(["linked-company"]);
+  });
+
+  it("never spends the Telegram chat id as a company id", async () => {
+    // The regression itself. An unlinked chat used to resolve to "chat-1",
+    // which is a Telegram identifier and cannot address any company.
+    seedLoop();
+    const ctx = mockCtx();
+
+    await handleAcpOutput(ctx, "token", outputEvent);
+
+    expect(emittedCompanyIds(ctx)).not.toContain("chat-1");
+  });
+
+  it("pauses the discussion instead of continuing it with an unresolved company", async () => {
+    seedLoop();
+    const ctx = mockCtx();
+
+    await handleAcpOutput(ctx, "token", outputEvent);
+
+    expect(emittedCompanyIds(ctx)).toHaveLength(0);
+    expect((stateStore["loop_chat-1_42"] as { status: string }).status).toBe("paused");
+  });
+
+  it("says why the discussion stopped rather than going quiet", async () => {
+    // Silence here is indistinguishable from the agent having nothing to say.
+    seedLoop();
+    const ctx = mockCtx();
+
+    await handleAcpOutput(ctx, "token", outputEvent);
+
+    const paused = sentMessages.find((m) => m.text.includes("Paused"));
+    expect(paused).toBeDefined();
+    expect(paused!.text).toContain("/connect");
+  });
+
+  it("still routes normally once the chat is linked", async () => {
+    // Guards against "fix" by disabling the feature: the happy path must work.
+    seedLoop();
+    stateStore["chat_chat-1"] = { companyId: "linked-company" };
+    const ctx = mockCtx();
+
+    await handleAcpOutput(ctx, "token", outputEvent);
+
+    expect(emittedCompanyIds(ctx)).toEqual(["linked-company"]);
+    expect((stateStore["loop_chat-1_42"] as { status: string }).status).toBe("active");
+  });
+});
+
+describe("routeMessageToAgent company resolution", () => {
+  beforeEach(() => {
+    stateStore["sessions_chat-1_42"] = [acpSession("s1", "Builder")];
+  });
+
+  it("tells an unlinked chat to /connect instead of routing to a fake company", async () => {
+    const ctx = mockCtx();
+
+    const routed = await routeMessageToAgent(ctx, "token", "chat-1", 42, "do the thing");
+
+    expect(emittedCompanyIds(ctx)).toHaveLength(0);
+    expect(sentMessages[0]?.text).toContain("/connect");
+    // Reported as handled: the message was addressed to a live session, so
+    // falling through would leave the user with no reply at all.
+    expect(routed).toBe(true);
+  });
+
+  it("routes with the caller's company id when one is supplied", async () => {
+    const ctx = mockCtx();
+
+    await routeMessageToAgent(ctx, "token", "chat-1", 42, "do the thing", undefined, "company-abc");
+
+    expect(emittedCompanyIds(ctx)).toEqual(["company-abc"]);
+  });
+});

--- a/tests/acp-bridge-handoff.test.ts
+++ b/tests/acp-bridge-handoff.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { PluginContext } from "@paperclipai/plugin-sdk";
+import { handleHandoffApproval, handleHandoffRejection } from "../src/acp-bridge.js";
+
+let sentMessages: Array<{ chatId: string; text: string }> = [];
+let stateStore: Record<string, unknown> = {};
+let emittedEvents: Array<{ event: string; companyId: string; payload: unknown }> = [];
+
+vi.mock("../src/telegram-api.js", async () => {
+  const actual = await vi.importActual("../src/telegram-api.js") as Record<string, unknown>;
+  return {
+    ...actual,
+    sendMessage: vi.fn(async (_ctx: unknown, _token: string, chatId: string, text: string) => {
+      sentMessages.push({ chatId, text });
+      return 100;
+    }),
+  };
+});
+
+function mockCtx(agentsListImpl?: () => Promise<unknown[]>): PluginContext {
+  return {
+    http: { fetch: vi.fn() },
+    metrics: { write: vi.fn() },
+    state: {
+      get: vi.fn(async (key: { stateKey: string }) => stateStore[key.stateKey] ?? null),
+      set: vi.fn(async (key: { stateKey: string }, value: unknown) => {
+        stateStore[key.stateKey] = value;
+      }),
+    },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    events: { emit: vi.fn((e: string, c: string, p: unknown) => emittedEvents.push({ event: e, companyId: c, payload: p })), on: vi.fn() },
+    agents: {
+      list: vi.fn(agentsListImpl ?? (async () => [])),
+      sessions: { create: vi.fn().mockResolvedValue({ sessionId: "native-2" }), close: vi.fn() },
+    },
+    issues: {
+      create: vi.fn().mockResolvedValue({ id: "issue-1" }),
+      update: vi.fn().mockResolvedValue({ id: "issue-1" }),
+    },
+    projects: { list: vi.fn().mockResolvedValue([]) },
+  } as unknown as PluginContext;
+}
+
+function pendingHandoff(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    handoffId: "h1",
+    sourceSessionId: "s1",
+    sourceAgent: "Builder",
+    targetAgent: "tester",
+    reason: "needs testing",
+    contextSummary: "code is ready",
+    chatId: "chat-1",
+    threadId: 42,
+    companyId: "company-1",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  sentMessages = [];
+  stateStore = {};
+  emittedEvents = [];
+});
+
+describe("handleHandoffApproval", () => {
+  it("does nothing when the handoff id has no pending record (expired or already resolved)", async () => {
+    const ctx = mockCtx();
+    await handleHandoffApproval(ctx, "token", "missing-id", "alice", "cb-1", "chat-1", 99);
+    expect(sentMessages).toHaveLength(0);
+    expect(emittedEvents).toHaveLength(0);
+  });
+
+  it("routes to the existing target session when one is already active, without auto-spawning", async () => {
+    stateStore["handoff_h1"] = pendingHandoff();
+    stateStore["sessions_chat-1_42"] = [
+      { sessionId: "s1", agentId: "a1", agentName: "builder", agentDisplayName: "Builder", transport: "native", spawnedAt: "2026-01-01T00:00:00Z", status: "active", lastActivityAt: "2026-01-01T00:00:00Z" },
+      { sessionId: "s2", agentId: "a2", agentName: "tester", agentDisplayName: "Tester", transport: "native", spawnedAt: "2026-01-01T00:00:00Z", status: "active", lastActivityAt: "2026-01-01T00:00:00Z" },
+    ];
+    const ctx = mockCtx();
+
+    await handleHandoffApproval(ctx, "token", "h1", "alice", "cb-1", "chat-1", 99);
+
+    // No auto-spawn message because "tester" already has an active session
+    expect(sentMessages.some((m) => m.text.includes("Auto") && m.text.includes("spawned"))).toBe(false);
+    expect(ctx.issues.create).toHaveBeenCalledWith(expect.objectContaining({ assigneeAgentId: "a2" }));
+    // Pending handoff record must be cleared so a duplicate button press is a no-op
+    expect(stateStore["handoff_h1"]).toBeNull();
+  });
+
+  it("auto-spawns the target agent by resolved UUID (not by name) when no session exists yet", async () => {
+    stateStore["handoff_h1"] = pendingHandoff();
+    const ctx = mockCtx(async () => [{ id: "uuid-tester", name: "tester", urlKey: "tester" }]);
+
+    await handleHandoffApproval(ctx, "token", "h1", "alice", "cb-1", "chat-1", 99);
+
+    expect(ctx.agents.sessions.create).toHaveBeenCalledWith("uuid-tester", "company-1", expect.anything());
+    const sessions = stateStore["sessions_chat-1_42"] as Array<Record<string, unknown>>;
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].transport).toBe("native");
+    expect(sentMessages.some((m) => m.text.includes("Auto") && m.text.includes("spawned"))).toBe(true);
+  });
+
+  it("falls back to ACP transport when the target agent cannot be resolved by name", async () => {
+    stateStore["handoff_h1"] = pendingHandoff();
+    const ctx = mockCtx(async () => []);
+
+    await handleHandoffApproval(ctx, "token", "h1", "alice", "cb-1", "chat-1", 99);
+
+    const sessions = stateStore["sessions_chat-1_42"] as Array<Record<string, unknown>>;
+    expect(sessions[0].transport).toBe("acp");
+    expect(emittedEvents.some((e) => (e.payload as { type: string }).type === "spawn")).toBe(true);
+  });
+});
+
+describe("handleHandoffRejection", () => {
+  it("does nothing when the handoff id has no pending record", async () => {
+    const ctx = mockCtx();
+    await handleHandoffRejection(ctx, "token", "missing-id", "alice", "cb-1", "chat-1", 99);
+    expect(sentMessages).toHaveLength(0);
+  });
+
+  it("notifies the chat and clears the pending handoff so it cannot be approved after rejection", async () => {
+    stateStore["handoff_h1"] = pendingHandoff();
+    const ctx = mockCtx();
+
+    await handleHandoffRejection(ctx, "token", "h1", "alice", "cb-1", "chat-1", 99);
+
+    expect(sentMessages[0].text).toContain("rejected");
+    expect(stateStore["handoff_h1"]).toBeNull();
+  });
+});

--- a/tests/acp-bridge-output.test.ts
+++ b/tests/acp-bridge-output.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { PluginContext } from "@paperclipai/plugin-sdk";
+import { handleAcpOutput } from "../src/acp-bridge.js";
+
+let sentMessages: Array<{ chatId: string; text: string; options?: Record<string, unknown> }> = [];
+let stateStore: Record<string, unknown> = {};
+let nextMessageId = 100;
+
+vi.mock("../src/telegram-api.js", async () => {
+  const actual = await vi.importActual("../src/telegram-api.js") as Record<string, unknown>;
+  return {
+    ...actual,
+    sendMessage: vi.fn(async (_ctx: unknown, _token: string, chatId: string, text: string, options?: Record<string, unknown>) => {
+      sentMessages.push({ chatId, text, options });
+      return nextMessageId++;
+    }),
+  };
+});
+
+function mockCtx(): PluginContext {
+  return {
+    state: {
+      get: vi.fn(async (key: { stateKey: string }) => stateStore[key.stateKey] ?? null),
+      set: vi.fn(async (key: { stateKey: string }, value: unknown) => {
+        stateStore[key.stateKey] = value;
+      }),
+    },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    events: { emit: vi.fn(), on: vi.fn() },
+  } as unknown as PluginContext;
+}
+
+function activeSession(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    sessionId: "s1",
+    agentId: "a1",
+    agentName: "builder",
+    agentDisplayName: "Builder",
+    transport: "native",
+    spawnedAt: "2026-01-01T00:00:00Z",
+    status: "active",
+    lastActivityAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  sentMessages = [];
+  stateStore = {};
+  nextMessageId = 100;
+});
+
+describe("handleAcpOutput - chunking (regression: Telegram rejects messages over 4096 chars)", () => {
+  it("splits output longer than the chunk limit into multiple sendMessage calls", async () => {
+    stateStore["sessions_chat-1_42"] = [activeSession()];
+    const ctx = mockCtx();
+    const longText = "line\n".repeat(1000); // ~5000 chars, well over the 4000-char chunk budget
+
+    await handleAcpOutput(ctx, "token", { sessionId: "s1", chatId: "chat-1", threadId: 42, text: longText, done: true });
+
+    expect(sentMessages.length).toBeGreaterThan(1);
+    // No individual chunk may exceed Telegram's hard limit
+    for (const msg of sentMessages) {
+      expect(msg.text.length).toBeLessThanOrEqual(4096);
+    }
+  });
+
+  it("does not split output at or under the limit", async () => {
+    stateStore["sessions_chat-1_42"] = [activeSession()];
+    const ctx = mockCtx();
+    const shortText = "all good here";
+
+    await handleAcpOutput(ctx, "token", { sessionId: "s1", chatId: "chat-1", threadId: 42, text: shortText, done: true });
+
+    expect(sentMessages).toHaveLength(1);
+  });
+
+  it("maps the reply-to state key to the LAST chunk's message id, not the first (regression: multi-chunk replies must route to the same agent)", async () => {
+    stateStore["sessions_chat-1_42"] = [activeSession()];
+    const ctx = mockCtx();
+    const longText = "line\n".repeat(1000);
+
+    await handleAcpOutput(ctx, "token", { sessionId: "s1", chatId: "chat-1", threadId: 42, text: longText, done: true });
+
+    const lastMessageId = nextMessageId - 1;
+    expect(stateStore[`agent_msg_chat-1_${lastMessageId}`]).toEqual({ sessionId: "s1" });
+    // Earlier chunks must NOT have a reply-to mapping — only the final one does
+    for (let id = 100; id < lastMessageId; id++) {
+      expect(stateStore[`agent_msg_chat-1_${id}`]).toBeUndefined();
+    }
+  });
+});
+
+describe("handleAcpOutput - session bookkeeping", () => {
+  it("updates lastActivityAt for the matching session", async () => {
+    stateStore["sessions_chat-1_42"] = [activeSession({ lastActivityAt: "2020-01-01T00:00:00Z" })];
+    const ctx = mockCtx();
+
+    await handleAcpOutput(ctx, "token", { sessionId: "s1", chatId: "chat-1", threadId: 42, text: "hi", done: false });
+
+    const sessions = stateStore["sessions_chat-1_42"] as Array<Record<string, unknown>>;
+    expect(sessions[0].lastActivityAt).not.toBe("2020-01-01T00:00:00Z");
+  });
+
+  it("still sends output under the generic 'Agent' label when the session is unknown", async () => {
+    const ctx = mockCtx();
+    await handleAcpOutput(ctx, "token", { sessionId: "unknown-session", chatId: "chat-1", threadId: 42, text: "hi", done: true });
+
+    expect(sentMessages).toHaveLength(1);
+    expect(sentMessages[0].text).toContain("Agent");
+  });
+});
+
+describe("handleAcpOutput - multi-agent output sequencing (regression: interleaved agent output must not garble the transcript)", () => {
+  it("queues a second agent's output while a first agent is still mid-stream, then flushes it once the first is done", async () => {
+    stateStore["sessions_chat-1_42"] = [
+      activeSession({ sessionId: "s1", agentDisplayName: "Builder" }),
+      activeSession({ sessionId: "s2", agentDisplayName: "Tester" }),
+    ];
+    const ctx = mockCtx();
+
+    // Builder starts speaking (not done yet) — becomes the current speaker.
+    await handleAcpOutput(ctx, "token", { sessionId: "s1", chatId: "chat-1", threadId: 42, text: "building...", done: false });
+    expect(sentMessages).toHaveLength(1);
+    expect(sentMessages[0].text).toContain("Builder");
+
+    // Tester tries to speak while Builder still holds the floor — must be queued, not sent immediately.
+    await handleAcpOutput(ctx, "token", { sessionId: "s2", chatId: "chat-1", threadId: 42, text: "waiting to test", done: false });
+    expect(sentMessages).toHaveLength(1);
+
+    // Builder finishes — this should flush Tester's queued output.
+    await handleAcpOutput(ctx, "token", { sessionId: "s1", chatId: "chat-1", threadId: 42, text: "build complete", done: true });
+
+    expect(sentMessages).toHaveLength(3);
+    // The queued Tester output is flushed as soon as Builder yields the floor,
+    // before Builder's own "done" message is sent.
+    expect(sentMessages[1].text).toContain("Tester");
+    expect(sentMessages[1].text).toContain("waiting to test");
+    expect(sentMessages[2].text).toContain("Builder");
+    expect(sentMessages[2].text).toContain("build complete");
+  });
+
+  it("does not engage sequencing when only one agent is active in the thread", async () => {
+    stateStore["sessions_chat-1_42"] = [activeSession({ sessionId: "s1" })];
+    const ctx = mockCtx();
+
+    await handleAcpOutput(ctx, "token", { sessionId: "s1", chatId: "chat-1", threadId: 42, text: "solo output", done: false });
+
+    expect(sentMessages).toHaveLength(1);
+  });
+});

--- a/tests/acp-bridge-session-lifecycle.test.ts
+++ b/tests/acp-bridge-session-lifecycle.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { PluginContext } from "@paperclipai/plugin-sdk";
+import { handleAcpCommand } from "../src/acp-bridge.js";
+
+let sentMessages: Array<{ chatId: string; text: string }> = [];
+let stateStore: Record<string, unknown> = {};
+let emittedEvents: Array<{ event: string; companyId: string; payload: unknown }> = [];
+
+vi.mock("../src/telegram-api.js", async () => {
+  const actual = await vi.importActual("../src/telegram-api.js") as Record<string, unknown>;
+  return {
+    ...actual,
+    sendMessage: vi.fn(async (_ctx: unknown, _token: string, chatId: string, text: string) => {
+      sentMessages.push({ chatId, text });
+      return 100;
+    }),
+    sendChatAction: vi.fn(),
+  };
+});
+
+function mockCtx(): PluginContext {
+  return {
+    http: { fetch: vi.fn() },
+    metrics: { write: vi.fn() },
+    state: {
+      get: vi.fn(async (key: { stateKey: string }) => stateStore[key.stateKey] ?? null),
+      set: vi.fn(async (key: { stateKey: string }, value: unknown) => {
+        stateStore[key.stateKey] = value;
+      }),
+    },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    events: { emit: vi.fn((e: string, c: string, p: unknown) => emittedEvents.push({ event: e, companyId: c, payload: p })), on: vi.fn() },
+    agents: {
+      get: vi.fn(),
+      list: vi.fn().mockResolvedValue([]),
+      sessions: { create: vi.fn(), sendMessage: vi.fn(), close: vi.fn().mockResolvedValue(undefined) },
+    },
+    issues: { create: vi.fn(), update: vi.fn() },
+    projects: { list: vi.fn().mockResolvedValue([]) },
+  } as unknown as PluginContext;
+}
+
+function session(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    sessionId: "s1",
+    agentId: "a1",
+    agentName: "builder",
+    agentDisplayName: "Builder",
+    transport: "native",
+    spawnedAt: "2026-01-01T00:00:00Z",
+    status: "active",
+    lastActivityAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  sentMessages = [];
+  stateStore = {};
+  emittedEvents = [];
+});
+
+describe("/acp status", () => {
+  it("asks the user to run it inside a thread when there is no messageThreadId", async () => {
+    const ctx = mockCtx();
+    await handleAcpCommand(ctx, "token", "chat-1", "status", undefined, "company-1");
+    expect(sentMessages[0].text).toContain("inside a thread");
+  });
+
+  it("reports no sessions bound to an empty thread", async () => {
+    const ctx = mockCtx();
+    await handleAcpCommand(ctx, "token", "chat-1", "status", 42, "company-1");
+    expect(sentMessages[0].text).toContain("No agent sessions bound");
+  });
+
+  it("lists only active sessions, not closed ones", async () => {
+    stateStore["sessions_chat-1_42"] = [
+      session({ sessionId: "s1", agentDisplayName: "Builder", status: "active" }),
+      session({ sessionId: "s2", agentDisplayName: "Tester", status: "closed" }),
+    ];
+    const ctx = mockCtx();
+    await handleAcpCommand(ctx, "token", "chat-1", "status", 42, "company-1");
+    expect(sentMessages[0].text).toContain("Builder");
+    expect(sentMessages[0].text).not.toContain("Tester");
+  });
+});
+
+describe("/acp cancel", () => {
+  it("cancels the most recently active native session via ctx.agents.sessions.close", async () => {
+    stateStore["sessions_chat-1_42"] = [
+      session({ sessionId: "older", lastActivityAt: "2026-01-01T00:00:00Z" }),
+      session({ sessionId: "newer", lastActivityAt: "2026-01-02T00:00:00Z" }),
+    ];
+    const ctx = mockCtx();
+    await handleAcpCommand(ctx, "token", "chat-1", "cancel", 42, "company-1");
+
+    expect(ctx.agents.sessions.close).toHaveBeenCalledWith("newer", "company-1");
+  });
+
+  it("emits an acp-spawn cancel event for ACP-transport sessions instead of calling sessions.close", async () => {
+    stateStore["sessions_chat-1_42"] = [session({ transport: "acp" })];
+    const ctx = mockCtx();
+    await handleAcpCommand(ctx, "token", "chat-1", "cancel", 42, "company-1");
+
+    expect(ctx.agents.sessions.close).not.toHaveBeenCalled();
+    expect(emittedEvents.some((e) => e.event === "acp-spawn" && (e.payload as { type: string }).type === "cancel")).toBe(true);
+  });
+
+  it("still answers the user (does not throw) when native session close fails", async () => {
+    stateStore["sessions_chat-1_42"] = [session()];
+    const ctx = mockCtx();
+    (ctx.agents.sessions.close as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("gone"));
+
+    await expect(handleAcpCommand(ctx, "token", "chat-1", "cancel", 42, "company-1")).resolves.toBeUndefined();
+    expect(ctx.logger.error).toHaveBeenCalledWith("Failed to close native session", expect.anything());
+    expect(sentMessages.some((m) => m.text.includes("Cancellation requested"))).toBe(true);
+  });
+});
+
+describe("/acp close", () => {
+  it("closes by exact agent name match, case-insensitively", async () => {
+    stateStore["sessions_chat-1_42"] = [
+      session({ sessionId: "s1", agentName: "builder" }),
+      session({ sessionId: "s2", agentName: "tester" }),
+    ];
+    const ctx = mockCtx();
+    await handleAcpCommand(ctx, "token", "chat-1", "close Builder", 42, "company-1");
+
+    expect(ctx.agents.sessions.close).toHaveBeenCalledWith("s1", "company-1");
+    const sessions = stateStore["sessions_chat-1_42"] as Array<Record<string, unknown>>;
+    expect(sessions.find((s) => s.sessionId === "s1")!.status).toBe("closed");
+    expect(sessions.find((s) => s.sessionId === "s2")!.status).toBe("active");
+  });
+
+  it("closes by partial agent name match when no exact match exists", async () => {
+    stateStore["sessions_chat-1_42"] = [session({ sessionId: "s1", agentName: "codebuilder" })];
+    const ctx = mockCtx();
+    await handleAcpCommand(ctx, "token", "chat-1", "close build", 42, "company-1");
+
+    expect(ctx.agents.sessions.close).toHaveBeenCalledWith("s1", "company-1");
+  });
+
+  it("lists active agents and closes nothing when the requested name matches no one", async () => {
+    stateStore["sessions_chat-1_42"] = [session({ sessionId: "s1", agentName: "builder", agentDisplayName: "Builder" })];
+    const ctx = mockCtx();
+    await handleAcpCommand(ctx, "token", "chat-1", "close nonexistent", 42, "company-1");
+
+    expect(ctx.agents.sessions.close).not.toHaveBeenCalled();
+    expect(sentMessages[0].text).toContain('No agent named "nonexistent" found');
+    expect(sentMessages[0].text).toContain("Builder");
+    const sessions = stateStore["sessions_chat-1_42"] as Array<Record<string, unknown>>;
+    expect(sessions[0].status).toBe("active");
+  });
+
+  it("closes the most recently active session when no name is given", async () => {
+    stateStore["sessions_chat-1_42"] = [
+      session({ sessionId: "older", lastActivityAt: "2026-01-01T00:00:00Z" }),
+      session({ sessionId: "newer", lastActivityAt: "2026-01-02T00:00:00Z" }),
+    ];
+    const ctx = mockCtx();
+    await handleAcpCommand(ctx, "token", "chat-1", "close", 42, "company-1");
+
+    expect(ctx.agents.sessions.close).toHaveBeenCalledWith("newer", "company-1");
+  });
+});

--- a/tests/adapter.test.ts
+++ b/tests/adapter.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { PluginContext } from "@paperclipai/plugin-sdk";
+
+let sendMessageCalls: Array<unknown[]> = [];
+let editMessageCalls: Array<unknown[]> = [];
+
+vi.mock("../src/telegram-api.js", async () => {
+  const actual = await vi.importActual("../src/telegram-api.js") as Record<string, unknown>;
+  return {
+    ...actual,
+    sendMessage: vi.fn(async (...args: unknown[]) => {
+      sendMessageCalls.push(args);
+      return 555;
+    }),
+    editMessage: vi.fn(async (...args: unknown[]) => {
+      editMessageCalls.push(args);
+      return true;
+    }),
+  };
+});
+
+import { TelegramAdapter } from "../src/adapter.js";
+
+function mockCtx(): PluginContext {
+  return {} as PluginContext;
+}
+
+beforeEach(() => {
+  sendMessageCalls = [];
+  editMessageCalls = [];
+});
+
+describe("TelegramAdapter", () => {
+  it("reports the telegram platform id", () => {
+    const adapter = new TelegramAdapter(mockCtx(), "token");
+    expect(adapter.platformId).toBe("telegram");
+  });
+
+  it("sendText forwards thread, reply-to, and silent options and returns a MessageRef", async () => {
+    const adapter = new TelegramAdapter(mockCtx(), "token");
+    const ref = await adapter.sendText("chat-1", "42", "hello", { replyTo: "10", silent: true });
+
+    expect(sendMessageCalls).toHaveLength(1);
+    const [, , chatId, text, options] = sendMessageCalls[0] as [unknown, unknown, string, string, Record<string, unknown>];
+    expect(chatId).toBe("chat-1");
+    expect(text).toBe("hello");
+    expect(options.messageThreadId).toBe(42);
+    expect(options.replyToMessageId).toBe(10);
+    expect(options.disableNotification).toBe(true);
+    expect(ref).toEqual({ chatId: "chat-1", threadId: "42", messageId: "555" });
+  });
+
+  it("sendText omits messageThreadId when no thread is given", async () => {
+    const adapter = new TelegramAdapter(mockCtx(), "token");
+    await adapter.sendText("chat-1", undefined, "hello");
+
+    const [, , , , options] = sendMessageCalls[0] as [unknown, unknown, unknown, unknown, Record<string, unknown>];
+    expect(options.messageThreadId).toBeUndefined();
+  });
+
+  it("sendButtons chunks buttons two per row", async () => {
+    const adapter = new TelegramAdapter(mockCtx(), "token");
+    await adapter.sendButtons("chat-1", undefined, "pick one", [
+      { label: "A", callbackData: "a" },
+      { label: "B", callbackData: "b" },
+      { label: "C", callbackData: "c" },
+    ]);
+
+    const [, , , , options] = sendMessageCalls[0] as [unknown, unknown, unknown, unknown, { inlineKeyboard: Array<Array<{ text: string }>> }];
+    expect(options.inlineKeyboard).toHaveLength(2);
+    expect(options.inlineKeyboard[0]).toHaveLength(2);
+    expect(options.inlineKeyboard[1]).toHaveLength(1);
+    expect(options.inlineKeyboard[0][0].text).toBe("A");
+    expect(options.inlineKeyboard[1][0].text).toBe("C");
+  });
+
+  it("editMessage passes numeric messageId and rebuilds the keyboard from buttons", async () => {
+    const adapter = new TelegramAdapter(mockCtx(), "token");
+    await adapter.editMessage(
+      { chatId: "chat-1", threadId: "", messageId: "999" },
+      "updated text",
+      [{ label: "OK", callbackData: "ok" }],
+    );
+
+    expect(editMessageCalls).toHaveLength(1);
+    const [, , chatId, messageId, text, options] = editMessageCalls[0] as [
+      unknown, unknown, string, number, string, { inlineKeyboard: Array<Array<{ text: string }>> },
+    ];
+    expect(chatId).toBe("chat-1");
+    expect(messageId).toBe(999);
+    expect(text).toBe("updated text");
+    expect(options.inlineKeyboard[0][0].text).toBe("OK");
+  });
+
+  it("editMessage passes an undefined keyboard when no buttons are given", async () => {
+    const adapter = new TelegramAdapter(mockCtx(), "token");
+    await adapter.editMessage({ chatId: "chat-1", threadId: "", messageId: "999" }, "updated text");
+
+    const [, , , , , options] = editMessageCalls[0] as [unknown, unknown, unknown, unknown, unknown, { inlineKeyboard: unknown }];
+    expect(options.inlineKeyboard).toBeUndefined();
+  });
+
+  it("formatAgentLabel escapes MarkdownV2 special characters", () => {
+    const adapter = new TelegramAdapter(mockCtx(), "token");
+    expect(adapter.formatAgentLabel("builder-agent")).toBe("*\\[builder\\-agent\\]*");
+  });
+
+  it("formatMention escapes the user id", () => {
+    const adapter = new TelegramAdapter(mockCtx(), "token");
+    expect(adapter.formatMention("user.name")).toBe("@user\\.name");
+  });
+
+  it("formatCodeBlock wraps with a language fence when given", () => {
+    const adapter = new TelegramAdapter(mockCtx(), "token");
+    expect(adapter.formatCodeBlock("const x = 1;", "ts")).toBe("```ts\nconst x = 1;\n```");
+  });
+
+  it("formatCodeBlock wraps without a language fence when omitted", () => {
+    const adapter = new TelegramAdapter(mockCtx(), "token");
+    expect(adapter.formatCodeBlock("plain text")).toBe("```\nplain text\n```");
+  });
+});

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -538,11 +538,14 @@ describe("/start", () => {
 describe("BOT_COMMANDS", () => {
   it("has all expected commands", () => {
     const names = BOT_COMMANDS.map(c => c.command);
+    expect(names).toContain("create");
     expect(names).toContain("status");
     expect(names).toContain("issues");
     expect(names).toContain("agents");
     expect(names).toContain("approve");
     expect(names).toContain("help");
+    expect(names).toContain("acp");
+    expect(names).toContain("commands");
     expect(names).toContain("connect");
     expect(names).toContain("connect_topic");
     expect(names).toContain("topics");
@@ -558,5 +561,19 @@ describe("BOT_COMMANDS", () => {
     // Removed deliberately: it duplicated /create and bypassed the org's own
     // routing. Leaving it in the menu would keep offering a deleted handler.
     expect(BOT_COMMANDS.map(c => c.command)).not.toContain("choose");
+  });
+
+  it("leads with daily-use commands, trailing forum-only and one-time setup commands", () => {
+    const names = BOT_COMMANDS.map(c => c.command);
+    const dailyUse = ["create", "decisions", "status", "issues", "agents", "approve"];
+    const setupOrForumOnly = ["connect", "connect_topic", "topics"];
+    const lastDailyUseIndex = Math.max(...dailyUse.map(c => names.indexOf(c)));
+    const firstSetupIndex = Math.min(...setupOrForumOnly.map(c => names.indexOf(c)));
+    expect(lastDailyUseIndex).toBeLessThan(firstSetupIndex);
+  });
+
+  it("gives every command a unique name — Telegram's setMyCommands rejects duplicates", () => {
+    const names = BOT_COMMANDS.map(c => c.command);
+    expect(new Set(names).size).toBe(names.length);
   });
 });

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -547,4 +547,16 @@ describe("BOT_COMMANDS", () => {
     expect(names).toContain("connect_topic");
     expect(names).toContain("topics");
   });
+
+  it("advertises /decisions, otherwise it is invisible in the / menu", () => {
+    // A command that works but is not registered may as well not exist: the
+    // only discovery path in Telegram is the menu this list populates.
+    expect(BOT_COMMANDS.map(c => c.command)).toContain("decisions");
+  });
+
+  it("no longer advertises /choose", () => {
+    // Removed deliberately: it duplicated /create and bypassed the org's own
+    // routing. Leaving it in the menu would keep offering a deleted handler.
+    expect(BOT_COMMANDS.map(c => c.command)).not.toContain("choose");
+  });
 });

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -501,6 +501,40 @@ describe("resolveNotificationThreadId", () => {
   });
 });
 
+describe("/start", () => {
+  // Telegram sends /start automatically the first time anyone opens the bot,
+  // so it is the first thing every new user sees. It answered "Unknown command"
+  // — the bot's own greeting told you it was broken.
+  it("answers with help rather than an unknown-command error", async () => {
+    const ctx = mockCtx();
+    await handleCommand(ctx, "token", "123", "start", "");
+
+    expect(sentMessages.length).toBe(1);
+    expect(sentMessages[0].text).toContain("Paperclip Bot Commands");
+    expect(sentMessages[0].text).not.toContain("Unknown command");
+  });
+
+  it("answers identically to /help, since it is the same entry point", async () => {
+    const start = mockCtx();
+    await handleCommand(start, "token", "123", "start", "");
+    const startText = sentMessages[0].text;
+
+    sentMessages = [];
+    const help = mockCtx();
+    await handleCommand(help, "token", "123", "help", "");
+
+    expect(startText).toBe(sentMessages[0].text);
+  });
+
+  it("still reports genuinely unknown commands", async () => {
+    // The fix must not be "answer everything with help".
+    const ctx = mockCtx();
+    await handleCommand(ctx, "token", "123", "definitely_not_a_command", "");
+
+    expect(sentMessages[0].text).toContain("Unknown command");
+  });
+});
+
 describe("BOT_COMMANDS", () => {
   it("has all expected commands", () => {
     const names = BOT_COMMANDS.map(c => c.command);

--- a/tests/config-compat.test.ts
+++ b/tests/config-compat.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+import { loadStartupConfig, resolveCompatibleConfig } from "../src/config-compat.js";
+
+function createContext(configGet: (...args: unknown[]) => Promise<Record<string, unknown>>) {
+  return {
+    config: { get: configGet },
+    logger: {
+      warn: vi.fn(),
+    },
+  } as any;
+}
+
+describe("loadStartupConfig", () => {
+  it("merges startup config with defaults", async () => {
+    const ctx = createContext(async () => ({ enableCommands: true }));
+
+    await expect(loadStartupConfig(ctx, {
+      enableCommands: false,
+      telegramBotTokenRef: "",
+    })).resolves.toEqual({
+      enableCommands: true,
+      telegramBotTokenRef: "",
+    });
+  });
+
+  it("falls back to defaults when startup config cannot load", async () => {
+    const ctx = createContext(async () => {
+      throw new Error("config unavailable");
+    });
+    const fallback = { telegramBotTokenRef: "global-secret" };
+
+    await expect(loadStartupConfig(ctx, fallback)).resolves.toEqual(fallback);
+    expect(ctx.logger.warn).toHaveBeenCalledWith(
+      "Failed to load Telegram plugin config; using defaults",
+      expect.objectContaining({ companyId: null }),
+    );
+  });
+});
+
+describe("resolveCompatibleConfig", () => {
+  it("uses company-scoped config when Paperclip supports it", async () => {
+    const ctx = createContext(async (params) => (
+      params && typeof params === "object" && "companyId" in params
+        ? { defaultChatId: "company-chat" }
+        : { defaultChatId: "global-chat" }
+    ));
+
+    await expect(resolveCompatibleConfig(ctx, {
+      defaultChatId: "fallback-chat",
+      telegramBotTokenRef: "global-secret",
+    }, "company-1")).resolves.toEqual({
+      defaultChatId: "company-chat",
+      telegramBotTokenRef: "global-secret",
+    });
+  });
+
+  it("falls back to global config when scoped config is unsupported", async () => {
+    const ctx = createContext(async (params) => {
+      if (params) throw new Error("scoped plugin config unsupported");
+      return { defaultChatId: "global-chat" };
+    });
+    const fallback = {
+      defaultChatId: "global-chat",
+      telegramBotTokenRef: "global-secret",
+    };
+
+    await expect(resolveCompatibleConfig(ctx, fallback, "company-1")).resolves.toEqual(fallback);
+    expect(ctx.logger.warn).toHaveBeenCalledWith(
+      "Company-scoped Telegram plugin config unavailable; using global config",
+      expect.objectContaining({ companyId: "company-1" }),
+    );
+  });
+});

--- a/tests/config-compat.test.ts
+++ b/tests/config-compat.test.ts
@@ -39,8 +39,8 @@ describe("loadStartupConfig", () => {
 
 describe("resolveCompatibleConfig", () => {
   it("uses company-scoped config when Paperclip supports it", async () => {
-    const ctx = createContext(async (params) => (
-      params && typeof params === "object" && "companyId" in params
+    const ctx = createContext(async (companyId) => (
+      companyId === "company-1"
         ? { defaultChatId: "company-chat" }
         : { defaultChatId: "global-chat" }
     ));

--- a/tests/config-compat.test.ts
+++ b/tests/config-compat.test.ts
@@ -23,7 +23,7 @@ describe("loadStartupConfig", () => {
     });
   });
 
-  it("falls back to defaults when startup config cannot load", async () => {
+  it("falls back to defaults when startup config cannot load and no fallback company id is given", async () => {
     const ctx = createContext(async () => {
       throw new Error("config unavailable");
     });
@@ -33,6 +33,38 @@ describe("loadStartupConfig", () => {
     expect(ctx.logger.warn).toHaveBeenCalledWith(
       "Failed to load Telegram plugin config; using defaults",
       expect.objectContaining({ companyId: null }),
+    );
+  });
+
+  it("retries with the fallback company id when the unscoped call fails for lack of company context", async () => {
+    // Regression: on hosts that enforce per-invocation company scoping,
+    // ctx.config.get() with no companyId fails from setup() with "company
+    // context is required" every single time. Without this retry, the plugin
+    // silently runs on defaults forever — paperclipBoardApiTokenRef stays
+    // empty and board access looks broken even though the token is fine.
+    const ctx = createContext(async (companyId?: string) => {
+      if (!companyId) throw new Error("company context is required");
+      return companyId === "co-fallback" ? { defaultChatId: "company-chat" } : {};
+    });
+    const fallback = { telegramBotTokenRef: "global-secret", defaultChatId: "" };
+
+    await expect(loadStartupConfig(ctx, fallback, "co-fallback")).resolves.toEqual({
+      telegramBotTokenRef: "global-secret",
+      defaultChatId: "company-chat",
+    });
+    expect(ctx.logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("falls back to defaults when both the unscoped and the scoped retry fail", async () => {
+    const ctx = createContext(async () => {
+      throw new Error("company context is required");
+    });
+    const fallback = { telegramBotTokenRef: "global-secret" };
+
+    await expect(loadStartupConfig(ctx, fallback, "co-fallback")).resolves.toEqual(fallback);
+    expect(ctx.logger.warn).toHaveBeenCalledWith(
+      "Failed to load Telegram plugin config; using defaults",
+      expect.objectContaining({ companyId: "co-fallback" }),
     );
   });
 });

--- a/tests/decisions.test.ts
+++ b/tests/decisions.test.ts
@@ -43,6 +43,7 @@ const {
   renderAttentionItem,
   describeSourceKind,
   describeDecisionsError,
+  toAttentionItem,
 } = await import("../src/decisions.js");
 
 function makeCtx(): PluginContext {
@@ -292,6 +293,33 @@ describe("sendAttentionList — inline answering (BLA-154)", () => {
     expect(answerableSendCalls[0]!.interaction).toMatchObject({ kind: "request_confirmation" });
   });
 
+  it("keeps the Open link for an interaction that was answered since the feed was read", async () => {
+    // The /attention feed is a snapshot. Between reading it and fetching the
+    // interaction, someone can answer it in the web UI. Offering buttons for it
+    // anyway invites an answer the host will reject, and the user is told
+    // nothing about why — so a non-pending status must fall back to the link.
+    fetchedInteraction = {
+      id: "921ee29e",
+      status: "answered",
+      kind: "ask_user_questions",
+      payload: {
+        version: 1,
+        questions: [{ id: "q1", prompt: "Which?", selectionMode: "single", options: [{ id: "o1", label: "Acme" }] }],
+      },
+    };
+    const items = [toItem(questionItem)];
+
+    await sendAttentionList(makeCtx(), "tok", "chat-1", { items, totalCount: 1 }, {
+      baseUrl: "http://x",
+      boardApiToken: "tok",
+      companyId: "co-1",
+      publicUrl: "https://paperclip.example",
+    });
+
+    expect(answerableSendCalls).toHaveLength(0);
+    expect(sent[0]).toContain("https://paperclip.example/BLA/issues/BLA-134");
+  });
+
   it("keeps the Open link for an interaction kind Telegram cannot render as buttons", async () => {
     fetchedInteraction = { id: "921ee29e", status: "pending", kind: "suggest_tasks", payload: { version: 1 } };
     const items = [toItem(questionItem)];
@@ -344,6 +372,34 @@ describe("sendAttentionList — inline answering (BLA-154)", () => {
     expect(answerableSendCalls).toHaveLength(0);
   });
 
+  it("honours inlineResolvable: false on an interaction, without even fetching it", async () => {
+    // The blocker_attention case above is also screened out by its sourceKind,
+    // so it cannot prove this flag is read. An interaction the host declined to
+    // mark inline-resolvable is the only case where inlineResolvable is the
+    // deciding guard: the host's verdict wins, and we do not spend a fetch
+    // second-guessing it.
+    const notInlineInteraction = { ...questionItem, inlineResolvable: false };
+    fetchedInteraction = {
+      id: "921ee29e",
+      status: "pending",
+      kind: "ask_user_questions",
+      payload: {
+        version: 1,
+        questions: [{ id: "q1", prompt: "Which?", selectionMode: "single", options: [{ id: "o1", label: "Acme" }] }],
+      },
+    };
+
+    await sendAttentionList(makeCtx(), "tok", "chat-1", { items: [toItem(notInlineInteraction)], totalCount: 1 }, {
+      baseUrl: "http://x",
+      boardApiToken: "tok",
+      companyId: "co-1",
+      publicUrl: "https://paperclip.example",
+    });
+
+    expect(answerableSendCalls).toHaveLength(0);
+    expect(sent[0]).toContain("https://paperclip.example/BLA/issues/BLA-134");
+  });
+
   it("does not attempt an inline answer for non-interaction items, even when inlineResolvable", async () => {
     const approvalItem = {
       ...toItem(blockerItem),
@@ -393,28 +449,8 @@ describe("describeSourceKind", () => {
 });
 
 // Round-trips a raw fixture through the real parser so render tests exercise
-// the same mapping the fetch path produces.
-function toItem(raw: Record<string, unknown>) {
-  const subject = (raw.subject ?? {}) as Record<string, unknown>;
-  const relatedIssue = (raw.relatedIssue ?? {}) as Record<string, unknown>;
-  const detail = raw.detail as Record<string, unknown> | undefined;
-  const subjectMetadata = (subject.metadata ?? {}) as Record<string, unknown>;
-  const isInteraction = raw.sourceKind === "issue_thread_interaction";
-  return {
-    id: String(raw.id),
-    sourceKind: String(raw.sourceKind),
-    title: String(subject.title),
-    issueIdentifier: relatedIssue.identifier as string | undefined,
-    issueHref: subject.href as string | undefined,
-    whyNow: raw.whyNow as string | undefined,
-    severity: raw.severity as string | undefined,
-    excerpt: (detail?.firstQuestionText ?? detail?.promptExcerpt) as string | undefined,
-    verbs: Array.isArray(raw.decisionVerbs)
-      ? (raw.decisionVerbs as Array<{ label: string }>).map((v) => v.label)
-      : [],
-    inlineResolvable: raw.inlineResolvable === true,
-    interactionId: isInteraction ? (subject.id as string | undefined) : undefined,
-    issueId: isInteraction ? (subjectMetadata.issueId as string | undefined) : undefined,
-    interactionKind: isInteraction ? (subjectMetadata.kind as string | undefined) : undefined,
-  };
-}
+// the same mapping the fetch path produces. This MUST delegate rather than
+// re-derive: an earlier hand-copy of toAttentionItem kept these tests passing
+// while the production mapper was broken (a mutation that forced
+// `inlineResolvable: true` — offering blockers inline — went undetected).
+const toItem = toAttentionItem;

--- a/tests/decisions.test.ts
+++ b/tests/decisions.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { PluginContext } from "@paperclipai/plugin-sdk";
+
+const sent: string[] = [];
+const apiCalls: string[] = [];
+let interactionsByIssue: Record<string, unknown[]> = {};
+
+vi.mock("../src/telegram-api.js", () => ({
+  sendMessage: vi.fn(async (_c: unknown, _t: string, _chat: string, text: string) => {
+    sent.push(text);
+    return { ok: true };
+  }),
+  escapeMarkdownV2: (s: string) => s,
+}));
+
+vi.mock("../src/paperclip-api.js", () => ({
+  buildPaperclipAuthHeaders: (t?: string) => (t ? { Authorization: `Bearer ${t}` } : {}),
+  fetchPaperclipApi: vi.fn(async (_ctx: unknown, url: string) => {
+    apiCalls.push(url);
+    const issueId = url.match(/\/issues\/([^/]+)\/interactions/)?.[1] ?? "";
+    if (issueId === "boom") throw new Error("unreadable");
+    return { json: async () => interactionsByIssue[issueId] ?? [] };
+  }),
+}));
+
+const { fetchPendingInteractions, sendPendingList, renderPendingInteraction, describeKind } =
+  await import("../src/decisions.js");
+
+function makeCtx(issues: Array<{ id: string; identifier?: string }>): PluginContext {
+  return {
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    issues: { list: vi.fn(async () => issues) },
+  } as unknown as PluginContext;
+}
+
+function interaction(over: Record<string, unknown> = {}) {
+  return {
+    id: "int-1",
+    kind: "ask_user_questions",
+    status: "pending",
+    title: 'Who is "the first client"?',
+    summary: "BLA-76 references a first client that is not named anywhere.",
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  sent.length = 0;
+  apiCalls.length = 0;
+  interactionsByIssue = {};
+});
+
+describe("fetchPendingInteractions", () => {
+  it("collects pending interactions across issues", async () => {
+    interactionsByIssue = {
+      i1: [interaction()],
+      i2: [interaction({ id: "int-2", status: "answered" })],
+    };
+    const ctx = makeCtx([{ id: "i1", identifier: "BLA-134" }, { id: "i2", identifier: "BLA-2" }]);
+
+    const { pending, scanned } = await fetchPendingInteractions(ctx, "http://x", "c1", "tok");
+
+    // Only the pending one; "answered" is history, not a queue item.
+    expect(pending).toHaveLength(1);
+    expect(pending[0]).toMatchObject({ issueIdentifier: "BLA-134", kind: "ask_user_questions" });
+    expect(scanned).toBe(2);
+  });
+
+  it("does not query /decisions — that endpoint is a different, empty feature", async () => {
+    interactionsByIssue = { i1: [interaction()] };
+    await fetchPendingInteractions(makeCtx([{ id: "i1" }]), "http://x", "c1", "tok");
+    expect(apiCalls.every((u) => u.includes("/interactions"))).toBe(true);
+    expect(apiCalls.some((u) => /\/decisions(\?|$)/.test(u))).toBe(false);
+  });
+
+  it("survives an unreadable issue rather than failing the whole command", async () => {
+    interactionsByIssue = { ok1: [interaction()] };
+    const ctx = makeCtx([{ id: "boom" }, { id: "ok1" }]);
+    const { pending } = await fetchPendingInteractions(ctx, "http://x", "c1", "tok");
+    expect(pending).toHaveLength(1);
+  });
+
+  it("bounds how many issues it scans", async () => {
+    const many = Array.from({ length: 100 }, (_, i) => ({ id: `i${i}` }));
+    const ctx = makeCtx(many);
+    await fetchPendingInteractions(ctx, "http://x", "c1", "tok", 10);
+    expect((ctx.issues.list as ReturnType<typeof vi.fn>)).toHaveBeenCalledWith({ companyId: "c1", limit: 10 });
+  });
+});
+
+describe("sendPendingList", () => {
+  it("says how far it looked when nothing is pending", async () => {
+    // "Nothing pending" is only trustworthy if it says what it checked.
+    await sendPendingList(makeCtx([]), "tok", "chat-1", { pending: [], scanned: 30 });
+    expect(sent.at(-1)).toContain("30 most recent issues");
+  });
+
+  it("caps output and reports the remainder", async () => {
+    const pending = Array.from({ length: 7 }, (_, i) => ({
+      id: `x${i}`, issueId: `i${i}`, issueIdentifier: `BLA-${i}`,
+      kind: "ask_user_questions", title: `Q${i}`, summary: null, status: "pending",
+    }));
+    await sendPendingList(makeCtx([]), "tok", "chat-1", { pending, scanned: 30 }, { limit: 2 });
+    expect(sent).toHaveLength(3);
+    expect(sent.at(-1)).toContain("5 more");
+  });
+});
+
+describe("renderPendingInteraction", () => {
+  it("shows the kind and the issue it belongs to", () => {
+    const text = renderPendingInteraction({
+      id: "1", issueId: "i1", issueIdentifier: "BLA-134",
+      kind: "ask_user_questions", title: "Who is the first client?",
+      summary: "Not named anywhere.", status: "pending",
+    });
+    expect(text).toContain("Who is the first client?");
+    expect(text).toContain("Question");
+    expect(text).toContain("BLA-134");
+  });
+
+  it("links out rather than pretending buttons can answer a form", () => {
+    const text = renderPendingInteraction(
+      { id: "1", issueId: "i1", issueIdentifier: "BLA-134", kind: "ask_user_questions", title: "Q", status: "pending" },
+      "https://paperclip.example",
+    );
+    expect(text).toContain("https://paperclip.example/decisions");
+  });
+});
+
+describe("describeKind", () => {
+  it("labels known kinds and degrades gracefully", () => {
+    expect(describeKind("ask_user_questions")).toBe("Question");
+    expect(describeKind("request_confirmation")).toBe("Confirmation");
+    expect(describeKind("some_new_kind")).toBe("some new kind");
+  });
+});

--- a/tests/decisions.test.ts
+++ b/tests/decisions.test.ts
@@ -147,6 +147,15 @@ describe("fetchAttention", () => {
     await fetchAttention(makeCtx(), "http://x", "c1", "tok");
     expect(apiCalls[0]).toContain("/attention");
   });
+
+  it("defaults verbs to an empty list when the host sends no decisionVerbs", async () => {
+    const { decisionVerbs: _drop, ...withoutVerbs } = questionItem;
+    response = { totalCount: 1, items: [withoutVerbs] };
+
+    const { items } = await fetchAttention(makeCtx(), "http://x", "c1", "tok");
+
+    expect(items[0]!.verbs).toEqual([]);
+  });
 });
 
 describe("renderAttentionItem", () => {
@@ -253,6 +262,79 @@ describe("sendAttentionList — inline answering (BLA-154)", () => {
     const items = [toItem(questionItem)];
 
     await sendAttentionList(makeCtx(), "tok", "chat-1", { items, totalCount: 1 }, {
+      baseUrl: "http://x",
+      boardApiToken: "tok",
+      companyId: "co-1",
+      publicUrl: "https://paperclip.example",
+    });
+
+    expect(answerableSendCalls).toHaveLength(0);
+  });
+
+  it("fetches the full interaction and sends an interactive prompt for a request_confirmation item", async () => {
+    fetchedInteraction = {
+      id: "921ee29e",
+      status: "pending",
+      kind: "request_confirmation",
+      payload: { version: 1, prompt: "Ship it?", rejectRequiresReason: true },
+    };
+    const items = [toItem(questionItem)];
+
+    await sendAttentionList(makeCtx(), "tok", "chat-1", { items, totalCount: 1 }, {
+      baseUrl: "http://x",
+      boardApiToken: "tok",
+      companyId: "co-1",
+      publicUrl: "https://paperclip.example",
+    });
+
+    expect(sent[0]).not.toContain("https://paperclip.example/BLA/issues/BLA-134");
+    expect(answerableSendCalls).toHaveLength(1);
+    expect(answerableSendCalls[0]!.interaction).toMatchObject({ kind: "request_confirmation" });
+  });
+
+  it("keeps the Open link for an interaction kind Telegram cannot render as buttons", async () => {
+    fetchedInteraction = { id: "921ee29e", status: "pending", kind: "suggest_tasks", payload: { version: 1 } };
+    const items = [toItem(questionItem)];
+
+    await sendAttentionList(makeCtx(), "tok", "chat-1", { items, totalCount: 1 }, {
+      baseUrl: "http://x",
+      boardApiToken: "tok",
+      companyId: "co-1",
+      publicUrl: "https://paperclip.example",
+    });
+
+    expect(sent[0]).toContain("https://paperclip.example/BLA/issues/BLA-134");
+    expect(answerableSendCalls).toHaveLength(0);
+  });
+
+  it("keeps the Open link when only one of several questions has a free-text option", async () => {
+    fetchedInteraction = {
+      id: "921ee29e",
+      status: "pending",
+      kind: "ask_user_questions",
+      payload: {
+        version: 1,
+        questions: [
+          { id: "q1", prompt: "Which?", selectionMode: "single", options: [{ id: "o1", label: "Acme" }] },
+          { id: "q2", prompt: "Why?", selectionMode: "single", options: [{ id: "o2", label: "Other", freeText: true }] },
+        ],
+      },
+    };
+    const items = [toItem(questionItem)];
+
+    await sendAttentionList(makeCtx(), "tok", "chat-1", { items, totalCount: 1 }, {
+      baseUrl: "http://x",
+      boardApiToken: "tok",
+      companyId: "co-1",
+      publicUrl: "https://paperclip.example",
+    });
+
+    expect(sent[0]).toContain("https://paperclip.example/BLA/issues/BLA-134");
+    expect(answerableSendCalls).toHaveLength(0);
+  });
+
+  it("never attempts an inline answer for a blocker_attention item, which the host marks inlineResolvable: false", async () => {
+    await sendAttentionList(makeCtx(), "tok", "chat-1", { items: [toItem(blockerItem)], totalCount: 1 }, {
       baseUrl: "http://x",
       boardApiToken: "tok",
       companyId: "co-1",

--- a/tests/decisions.test.ts
+++ b/tests/decisions.test.ts
@@ -3,7 +3,8 @@ import type { PluginContext } from "@paperclipai/plugin-sdk";
 
 const sent: string[] = [];
 const apiCalls: string[] = [];
-let interactionsByIssue: Record<string, unknown[]> = {};
+let response: unknown = { totalCount: 0, items: [] };
+let shouldThrow: Error | null = null;
 
 vi.mock("../src/telegram-api.js", () => ({
   sendMessage: vi.fn(async (_c: unknown, _t: string, _chat: string, text: string) => {
@@ -17,120 +18,216 @@ vi.mock("../src/paperclip-api.js", () => ({
   buildPaperclipAuthHeaders: (t?: string) => (t ? { Authorization: `Bearer ${t}` } : {}),
   fetchPaperclipApi: vi.fn(async (_ctx: unknown, url: string) => {
     apiCalls.push(url);
-    const issueId = url.match(/\/issues\/([^/]+)\/interactions/)?.[1] ?? "";
-    if (issueId === "boom") throw new Error("unreadable");
-    return { json: async () => interactionsByIssue[issueId] ?? [] };
+    if (shouldThrow) throw shouldThrow;
+    return { json: async () => response };
   }),
 }));
 
-const { fetchPendingInteractions, sendPendingList, renderPendingInteraction, describeKind } =
-  await import("../src/decisions.js");
+const {
+  fetchAttention,
+  sendAttentionList,
+  renderAttentionItem,
+  describeSourceKind,
+  describeDecisionsError,
+} = await import("../src/decisions.js");
 
-function makeCtx(issues: Array<{ id: string; identifier?: string }>): PluginContext {
+function makeCtx(): PluginContext {
   return {
     logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-    issues: { list: vi.fn(async () => issues) },
   } as unknown as PluginContext;
 }
 
-function interaction(over: Record<string, unknown> = {}) {
-  return {
-    id: "int-1",
-    kind: "ask_user_questions",
-    status: "pending",
-    title: 'Who is "the first client"?',
-    summary: "BLA-76 references a first client that is not named anywhere.",
-    ...over,
-  };
-}
+/**
+ * Fixtures below are trimmed copies of real /attention responses from a live
+ * instance, not invented shapes — the previous implementation passed its own
+ * tests while being wrong about the API, so the shapes are the thing under
+ * test as much as the logic.
+ */
+const questionItem = {
+  id: "issue_thread_interaction:interaction:921ee29e",
+  sourceKind: "issue_thread_interaction",
+  subject: {
+    kind: "interaction",
+    title: 'Who is "the first client" for BLA-76\'s discovery interviews?',
+    href: "/BLA/issues/BLA-134#interaction-921ee29e",
+  },
+  relatedIssue: { identifier: "BLA-134", title: "Confirm the first client" },
+  whyNow: "Questions need answers on an issue thread.",
+  severity: "medium",
+  inlineResolvable: true,
+  decisionVerbs: [{ id: "respond", label: "Respond" }],
+  detail: { kind: "questions", questionCount: 1, firstQuestionText: "Who is the first client?" },
+};
+
+const blockerItem = {
+  id: "blocker_attention:blocker:2aaf008c",
+  sourceKind: "blocker_attention",
+  subject: { kind: "issue", title: "Upstream wait_approval is inert", href: "/BLA/issues/BLA-156" },
+  relatedIssue: { identifier: "BLA-156" },
+  whyNow: "Blocks 0 tasks and needs human attention.",
+  severity: "high",
+  inlineResolvable: false,
+  decisionVerbs: [
+    { id: "unblock", label: "Unblock" },
+    { id: "reassign", label: "Reassign" },
+  ],
+  detail: { kind: "blocker", blockedTaskCount: 0 },
+};
 
 beforeEach(() => {
   sent.length = 0;
   apiCalls.length = 0;
-  interactionsByIssue = {};
+  shouldThrow = null;
+  response = { totalCount: 0, items: [] };
 });
 
-describe("fetchPendingInteractions", () => {
-  it("collects pending interactions across issues", async () => {
-    interactionsByIssue = {
-      i1: [interaction()],
-      i2: [interaction({ id: "int-2", status: "answered" })],
-    };
-    const ctx = makeCtx([{ id: "i1", identifier: "BLA-134" }, { id: "i2", identifier: "BLA-2" }]);
+describe("fetchAttention", () => {
+  it("reads the endpoint the Decisions page renders", async () => {
+    response = { totalCount: 2, items: [questionItem, blockerItem] };
 
-    const { pending, scanned } = await fetchPendingInteractions(ctx, "http://x", "c1", "tok");
+    const result = await fetchAttention(makeCtx(), "http://x", "c1", "tok");
 
-    // Only the pending one; "answered" is history, not a queue item.
-    expect(pending).toHaveLength(1);
-    expect(pending[0]).toMatchObject({ issueIdentifier: "BLA-134", kind: "ask_user_questions" });
-    expect(scanned).toBe(2);
+    expect(apiCalls).toEqual(["http://x/api/companies/c1/attention"]);
+    expect(result.totalCount).toBe(2);
+    expect(result.items).toHaveLength(2);
   });
 
-  it("does not query /decisions — that endpoint is a different, empty feature", async () => {
-    interactionsByIssue = { i1: [interaction()] };
-    await fetchPendingInteractions(makeCtx([{ id: "i1" }]), "http://x", "c1", "tok");
-    expect(apiCalls.every((u) => u.includes("/interactions"))).toBe(true);
-    expect(apiCalls.some((u) => /\/decisions(\?|$)/.test(u))).toBe(false);
+  it("includes blocker_attention, which a per-issue interaction scan can never find", async () => {
+    // The bug this replaces: the page showed six items and the bot showed one,
+    // because four of them were blockers and were not interactions at all.
+    response = { totalCount: 2, items: [questionItem, blockerItem] };
+
+    const { items } = await fetchAttention(makeCtx(), "http://x", "c1", "tok");
+
+    expect(items.map((i) => i.sourceKind)).toContain("blocker_attention");
+    expect(items.find((i) => i.sourceKind === "blocker_attention")?.issueIdentifier).toBe("BLA-156");
   });
 
-  it("survives an unreadable issue rather than failing the whole command", async () => {
-    interactionsByIssue = { ok1: [interaction()] };
-    const ctx = makeCtx([{ id: "boom" }, { id: "ok1" }]);
-    const { pending } = await fetchPendingInteractions(ctx, "http://x", "c1", "tok");
-    expect(pending).toHaveLength(1);
+  it("makes ONE request regardless of how much is pending", async () => {
+    response = { totalCount: 30, items: Array.from({ length: 30 }, () => questionItem) };
+
+    await fetchAttention(makeCtx(), "http://x", "c1", "tok");
+
+    expect(apiCalls).toHaveLength(1);
   });
 
-  it("bounds how many issues it scans", async () => {
-    const many = Array.from({ length: 100 }, (_, i) => ({ id: `i${i}` }));
-    const ctx = makeCtx(many);
-    await fetchPendingInteractions(ctx, "http://x", "c1", "tok", 10);
-    expect((ctx.issues.list as ReturnType<typeof vi.fn>)).toHaveBeenCalledWith({ companyId: "c1", limit: 10 });
-  });
-});
+  it("propagates a failure instead of reporting an empty queue", async () => {
+    // "Nothing is pending" and "we could not ask" must never look identical.
+    shouldThrow = new Error('Paperclip API request failed with 403: {"error":"Board access required"}');
 
-describe("sendPendingList", () => {
-  it("says how far it looked when nothing is pending", async () => {
-    // "Nothing pending" is only trustworthy if it says what it checked.
-    await sendPendingList(makeCtx([]), "tok", "chat-1", { pending: [], scanned: 30 });
-    expect(sent.at(-1)).toContain("30 most recent issues");
+    await expect(fetchAttention(makeCtx(), "http://x", "c1", "tok")).rejects.toThrow("403");
   });
 
-  it("caps output and reports the remainder", async () => {
-    const pending = Array.from({ length: 7 }, (_, i) => ({
-      id: `x${i}`, issueId: `i${i}`, issueIdentifier: `BLA-${i}`,
-      kind: "ask_user_questions", title: `Q${i}`, summary: null, status: "pending",
-    }));
-    await sendPendingList(makeCtx([]), "tok", "chat-1", { pending, scanned: 30 }, { limit: 2 });
-    expect(sent).toHaveLength(3);
-    expect(sent.at(-1)).toContain("5 more");
+  it("survives a response with no items array", async () => {
+    response = {};
+    const result = await fetchAttention(makeCtx(), "http://x", "c1", "tok");
+    expect(result).toEqual({ items: [], totalCount: 0 });
+  });
+
+  it("carries the board token when one is available", async () => {
+    response = { totalCount: 0, items: [] };
+    await fetchAttention(makeCtx(), "http://x", "c1", "tok");
+    expect(apiCalls[0]).toContain("/attention");
   });
 });
 
-describe("renderPendingInteraction", () => {
-  it("shows the kind and the issue it belongs to", () => {
-    const text = renderPendingInteraction({
-      id: "1", issueId: "i1", issueIdentifier: "BLA-134",
-      kind: "ask_user_questions", title: "Who is the first client?",
-      summary: "Not named anywhere.", status: "pending",
-    });
-    expect(text).toContain("Who is the first client?");
-    expect(text).toContain("Question");
+describe("renderAttentionItem", () => {
+  it("leads with the title and says what kind of decision it is", () => {
+    const [item] = [questionItem].map((r) => toItem(r));
+    const text = renderAttentionItem(item);
+
+    expect(text).toContain("the first client");
+    expect(text).toContain("Needs your answer");
     expect(text).toContain("BLA-134");
   });
 
-  it("links out rather than pretending buttons can answer a form", () => {
-    const text = renderPendingInteraction(
-      { id: "1", issueId: "i1", issueIdentifier: "BLA-134", kind: "ask_user_questions", title: "Q", status: "pending" },
-      "https://paperclip.example",
-    );
-    expect(text).toContain("https://paperclip.example/decisions");
+  it("uses the host's own whyNow rather than inventing urgency", () => {
+    const text = renderAttentionItem(toItem(blockerItem));
+    expect(text).toContain("Blocks 0 tasks and needs human attention.");
+  });
+
+  it("lists the available options so the reader knows what the choice is", () => {
+    const text = renderAttentionItem(toItem(blockerItem));
+    expect(text).toContain("Unblock / Reassign");
+  });
+
+  it("deep-links to the item, not to the Decisions index", () => {
+    const text = renderAttentionItem(toItem(questionItem), "https://paperclip.example");
+    expect(text).toContain("https://paperclip.example/BLA/issues/BLA-134#interaction-921ee29e");
+  });
+
+  it("omits the link when no public URL is configured", () => {
+    expect(renderAttentionItem(toItem(questionItem))).not.toContain("Open:");
+  });
+
+  it("marks high severity differently from medium", () => {
+    expect(renderAttentionItem(toItem(blockerItem))).toContain("🔴");
+    expect(renderAttentionItem(toItem(questionItem))).toContain("🟡");
   });
 });
 
-describe("describeKind", () => {
-  it("labels known kinds and degrades gracefully", () => {
-    expect(describeKind("ask_user_questions")).toBe("Question");
-    expect(describeKind("request_confirmation")).toBe("Confirmation");
-    expect(describeKind("some_new_kind")).toBe("some new kind");
+describe("sendAttentionList", () => {
+  it("says nothing is waiting only when the fetch actually succeeded", async () => {
+    await sendAttentionList(makeCtx(), "tok", "chat-1", { items: [], totalCount: 0 });
+    expect(sent).toEqual(["Nothing is waiting on your input."]);
+  });
+
+  it("caps output and reports the true remaining count", async () => {
+    const items = Array.from({ length: 6 }, () => toItem(questionItem));
+    await sendAttentionList(makeCtx(), "tok", "chat-1", { items, totalCount: 6 }, { limit: 2 });
+
+    expect(sent).toHaveLength(3);
+    expect(sent.at(-1)).toContain("4 more");
+  });
+
+  it("reports the server's total, not the page size, when they differ", async () => {
+    const items = Array.from({ length: 2 }, () => toItem(questionItem));
+    await sendAttentionList(makeCtx(), "tok", "chat-1", { items, totalCount: 17 }, { limit: 2 });
+    expect(sent.at(-1)).toContain("15 more");
   });
 });
+
+describe("describeDecisionsError", () => {
+  it("explains a 403 instead of dumping it", () => {
+    const text = describeDecisionsError(
+      new Error('Paperclip API request failed with 403: {"error":"Board access required"}'),
+    );
+    expect(text).toContain("no board access");
+    expect(text).toContain("worker restart");
+    expect(text).not.toContain('{"error"');
+  });
+
+  it("passes other failures through so real outages stay visible", () => {
+    expect(describeDecisionsError(new Error("ECONNREFUSED"))).toContain("ECONNREFUSED");
+  });
+});
+
+describe("describeSourceKind", () => {
+  it("labels known kinds and degrades gracefully", () => {
+    expect(describeSourceKind("issue_thread_interaction")).toBe("Needs your answer");
+    expect(describeSourceKind("blocker_attention")).toBe("Blocked");
+    expect(describeSourceKind("some_new_kind")).toBe("some new kind");
+  });
+});
+
+// Round-trips a raw fixture through the real parser so render tests exercise
+// the same mapping the fetch path produces.
+function toItem(raw: Record<string, unknown>) {
+  const subject = (raw.subject ?? {}) as Record<string, unknown>;
+  const relatedIssue = (raw.relatedIssue ?? {}) as Record<string, unknown>;
+  const detail = raw.detail as Record<string, unknown> | undefined;
+  return {
+    id: String(raw.id),
+    sourceKind: String(raw.sourceKind),
+    title: String(subject.title),
+    issueIdentifier: relatedIssue.identifier as string | undefined,
+    issueHref: subject.href as string | undefined,
+    whyNow: raw.whyNow as string | undefined,
+    severity: raw.severity as string | undefined,
+    excerpt: (detail?.firstQuestionText ?? detail?.promptExcerpt) as string | undefined,
+    verbs: Array.isArray(raw.decisionVerbs)
+      ? (raw.decisionVerbs as Array<{ label: string }>).map((v) => v.label)
+      : [],
+    inlineResolvable: raw.inlineResolvable === true,
+  };
+}

--- a/tests/decisions.test.ts
+++ b/tests/decisions.test.ts
@@ -23,6 +23,20 @@ vi.mock("../src/paperclip-api.js", () => ({
   }),
 }));
 
+const answerableSendCalls: Array<{ chatId: string; interaction: unknown; opts: unknown }> = [];
+let fetchedInteraction: { id: string; status: string; kind: string; payload: unknown } | null = null;
+vi.mock("../src/interaction-answers.js", () => ({
+  fetchInteraction: vi.fn(async () => fetchedInteraction),
+  sendAnswerableInteraction: vi.fn(async (_ctx: unknown, _token: string, chatId: string, interaction: unknown, opts: unknown) => {
+    answerableSendCalls.push({ chatId, interaction, opts });
+    return true;
+  }),
+  isAskUserQuestionsAnswerable: (payload: { questions?: Array<{ options?: Array<{ freeText?: boolean }> }> }) =>
+    Array.isArray(payload?.questions) &&
+    payload.questions.length > 0 &&
+    payload.questions.every((q) => (q.options ?? []).every((o) => o.freeText !== true)),
+}));
+
 const {
   fetchAttention,
   sendAttentionList,
@@ -48,8 +62,10 @@ const questionItem = {
   sourceKind: "issue_thread_interaction",
   subject: {
     kind: "interaction",
+    id: "921ee29e",
     title: 'Who is "the first client" for BLA-76\'s discovery interviews?',
     href: "/BLA/issues/BLA-134#interaction-921ee29e",
+    metadata: { kind: "ask_user_questions", issueId: "issue-134" },
   },
   relatedIssue: { identifier: "BLA-134", title: "Confirm the first client" },
   whyNow: "Questions need answers on an issue thread.",
@@ -79,6 +95,8 @@ beforeEach(() => {
   apiCalls.length = 0;
   shouldThrow = null;
   response = { totalCount: 0, items: [] };
+  answerableSendCalls.length = 0;
+  fetchedInteraction = null;
 });
 
 describe("fetchAttention", () => {
@@ -187,6 +205,88 @@ describe("sendAttentionList", () => {
   });
 });
 
+describe("sendAttentionList — inline answering (BLA-154)", () => {
+  it("fetches the full interaction and sends an interactive prompt for a pick-only ask_user_questions item", async () => {
+    fetchedInteraction = {
+      id: "921ee29e",
+      status: "pending",
+      kind: "ask_user_questions",
+      payload: { version: 1, questions: [{ id: "q1", prompt: "Who?", selectionMode: "single", options: [{ id: "o1", label: "Acme" }] }] },
+    };
+    const items = [toItem(questionItem)];
+
+    await sendAttentionList(makeCtx(), "tok", "chat-1", { items, totalCount: 1 }, {
+      baseUrl: "http://x",
+      boardApiToken: "tok",
+      companyId: "co-1",
+      publicUrl: "https://paperclip.example",
+    });
+
+    expect(sent[0]).not.toContain("https://paperclip.example/BLA/issues/BLA-134");
+    expect(answerableSendCalls).toHaveLength(1);
+    expect(answerableSendCalls[0]!.chatId).toBe("chat-1");
+    expect(answerableSendCalls[0]!.opts).toMatchObject({ issueId: "issue-134", companyId: "co-1" });
+  });
+
+  it("keeps the Open link and does not send a prompt when a question has a free-text option", async () => {
+    fetchedInteraction = {
+      id: "921ee29e",
+      status: "pending",
+      kind: "ask_user_questions",
+      payload: { version: 1, questions: [{ id: "q1", prompt: "Who?", selectionMode: "single", options: [{ id: "o1", label: "Other", freeText: true }] }] },
+    };
+    const items = [toItem(questionItem)];
+
+    await sendAttentionList(makeCtx(), "tok", "chat-1", { items, totalCount: 1 }, {
+      baseUrl: "http://x",
+      boardApiToken: "tok",
+      companyId: "co-1",
+      publicUrl: "https://paperclip.example",
+    });
+
+    expect(sent[0]).toContain("https://paperclip.example/BLA/issues/BLA-134");
+    expect(answerableSendCalls).toHaveLength(0);
+  });
+
+  it("keeps the Open link when the interaction resolved elsewhere since the feed was read", async () => {
+    fetchedInteraction = { id: "921ee29e", status: "answered", kind: "ask_user_questions", payload: { version: 1, questions: [] } };
+    const items = [toItem(questionItem)];
+
+    await sendAttentionList(makeCtx(), "tok", "chat-1", { items, totalCount: 1 }, {
+      baseUrl: "http://x",
+      boardApiToken: "tok",
+      companyId: "co-1",
+      publicUrl: "https://paperclip.example",
+    });
+
+    expect(answerableSendCalls).toHaveLength(0);
+  });
+
+  it("does not attempt an inline answer for non-interaction items, even when inlineResolvable", async () => {
+    const approvalItem = {
+      ...toItem(blockerItem),
+      sourceKind: "approval",
+      inlineResolvable: true,
+    };
+
+    await sendAttentionList(makeCtx(), "tok", "chat-1", { items: [approvalItem], totalCount: 1 }, {
+      baseUrl: "http://x",
+      boardApiToken: "tok",
+      companyId: "co-1",
+    });
+
+    expect(answerableSendCalls).toHaveLength(0);
+  });
+
+  it("does not fetch anything when no baseUrl is supplied", async () => {
+    const items = [toItem(questionItem)];
+
+    await sendAttentionList(makeCtx(), "tok", "chat-1", { items, totalCount: 1 }, { companyId: "co-1" });
+
+    expect(answerableSendCalls).toHaveLength(0);
+  });
+});
+
 describe("describeDecisionsError", () => {
   it("explains a 403 instead of dumping it", () => {
     const text = describeDecisionsError(
@@ -216,6 +316,8 @@ function toItem(raw: Record<string, unknown>) {
   const subject = (raw.subject ?? {}) as Record<string, unknown>;
   const relatedIssue = (raw.relatedIssue ?? {}) as Record<string, unknown>;
   const detail = raw.detail as Record<string, unknown> | undefined;
+  const subjectMetadata = (subject.metadata ?? {}) as Record<string, unknown>;
+  const isInteraction = raw.sourceKind === "issue_thread_interaction";
   return {
     id: String(raw.id),
     sourceKind: String(raw.sourceKind),
@@ -229,5 +331,8 @@ function toItem(raw: Record<string, unknown>) {
       ? (raw.decisionVerbs as Array<{ label: string }>).map((v) => v.label)
       : [],
     inlineResolvable: raw.inlineResolvable === true,
+    interactionId: isInteraction ? (subject.id as string | undefined) : undefined,
+    issueId: isInteraction ? (subjectMetadata.issueId as string | undefined) : undefined,
+    interactionKind: isInteraction ? (subjectMetadata.kind as string | undefined) : undefined,
   };
 }

--- a/tests/formatters.test.ts
+++ b/tests/formatters.test.ts
@@ -233,6 +233,18 @@ describe("formatAgentRunStarted", () => {
     const msg = formatAgentRunStarted(mockEvent());
     expect(msg.options.disableNotification).toBe(true);
   });
+
+  it("includes issue identifier and run_id", () => {
+    const msg = formatAgentRunStarted(mockEvent({
+      issueIdentifier: "PAC-175",
+      runId: "run-456",
+    }));
+    expect(msg.text).toContain("started a new run");
+    expect(msg.text).toContain("*PAC\\-175*");
+    expect(msg.text).toContain("\nrun\\_id: `run\\-456`");
+    expect(msg.text).not.toContain("\n\nrun\\_id");
+    expect(msg.text).not.toContain("issue\\_id");
+  });
 });
 
 describe("formatAgentRunFinished", () => {
@@ -245,5 +257,17 @@ describe("formatAgentRunFinished", () => {
   it("disables notification", () => {
     const msg = formatAgentRunFinished(mockEvent());
     expect(msg.options.disableNotification).toBe(true);
+  });
+
+  it("includes issue identifier and run_id", () => {
+    const msg = formatAgentRunFinished(mockEvent({
+      issueIdentifier: "PAC-175",
+      runId: "run-456",
+    }));
+    expect(msg.text).toContain("completed successfully");
+    expect(msg.text).toContain("*PAC\\-175*");
+    expect(msg.text).toContain("\nrun\\_id: `run\\-456`");
+    expect(msg.text).not.toContain("\n\nrun\\_id");
+    expect(msg.text).not.toContain("issue\\_id");
   });
 });

--- a/tests/formatters.test.ts
+++ b/tests/formatters.test.ts
@@ -233,18 +233,6 @@ describe("formatAgentRunStarted", () => {
     const msg = formatAgentRunStarted(mockEvent());
     expect(msg.options.disableNotification).toBe(true);
   });
-
-  it("includes issue identifier and run_id", () => {
-    const msg = formatAgentRunStarted(mockEvent({
-      issueIdentifier: "PAC-175",
-      runId: "run-456",
-    }));
-    expect(msg.text).toContain("started a new run");
-    expect(msg.text).toContain("*PAC\\-175*");
-    expect(msg.text).toContain("\nrun\\_id: `run\\-456`");
-    expect(msg.text).not.toContain("\n\nrun\\_id");
-    expect(msg.text).not.toContain("issue\\_id");
-  });
 });
 
 describe("formatAgentRunFinished", () => {
@@ -257,17 +245,5 @@ describe("formatAgentRunFinished", () => {
   it("disables notification", () => {
     const msg = formatAgentRunFinished(mockEvent());
     expect(msg.options.disableNotification).toBe(true);
-  });
-
-  it("includes issue identifier and run_id", () => {
-    const msg = formatAgentRunFinished(mockEvent({
-      issueIdentifier: "PAC-175",
-      runId: "run-456",
-    }));
-    expect(msg.text).toContain("completed successfully");
-    expect(msg.text).toContain("*PAC\\-175*");
-    expect(msg.text).toContain("\nrun\\_id: `run\\-456`");
-    expect(msg.text).not.toContain("\n\nrun\\_id");
-    expect(msg.text).not.toContain("issue\\_id");
   });
 });

--- a/tests/interaction-answers.test.ts
+++ b/tests/interaction-answers.test.ts
@@ -1,0 +1,462 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { PluginContext } from "@paperclipai/plugin-sdk";
+
+type SentMessage = { chatId: string; text: string; options?: Record<string, unknown> };
+type EditedMessage = { chatId: string; messageId: number; text: string; options?: Record<string, unknown> };
+type ApiCall = { url: string; method: string; body?: unknown };
+
+let sent: SentMessage[] = [];
+let edited: EditedMessage[] = [];
+let answers: Array<{ id: string; text: string }> = [];
+let apiCalls: ApiCall[] = [];
+let stateStore: Record<string, unknown> = {};
+let freshInteractions: Array<{ id: string; status: string; kind: string }> = [];
+let postResponses: Record<string, { status: string }> = {};
+
+vi.mock("../src/telegram-api.js", async () => {
+  const actual = await vi.importActual("../src/telegram-api.js") as Record<string, unknown>;
+  return {
+    ...actual,
+    sendMessage: vi.fn(async (_ctx: unknown, _token: string, chatId: string, text: string, options?: Record<string, unknown>) => {
+      sent.push({ chatId, text, options });
+      return sent.length; // unique-ish message id
+    }),
+    editMessage: vi.fn(async (_ctx: unknown, _token: string, chatId: string, messageId: number, text: string, options?: Record<string, unknown>) => {
+      edited.push({ chatId, messageId, text, options });
+      return true;
+    }),
+    answerCallbackQuery: vi.fn(async (_ctx: unknown, _token: string, id: string, text: string) => {
+      answers.push({ id, text });
+    }),
+  };
+});
+
+vi.mock("../src/paperclip-api.js", () => ({
+  buildPaperclipAuthHeaders: (t?: string) => (t ? { Authorization: `Bearer ${t}` } : {}),
+  fetchPaperclipApi: vi.fn(async (_ctx: unknown, url: string, init?: { method?: string; body?: string }) => {
+    const method = init?.method ?? "GET";
+    const body = init?.body ? JSON.parse(init.body) : undefined;
+    apiCalls.push({ url, method, body });
+    if (method === "GET") {
+      return { json: async () => freshInteractions };
+    }
+    const action = url.split("/").at(-1) as string;
+    const response = postResponses[action] ?? { status: "unknown" };
+    return { json: async () => response };
+  }),
+}));
+
+const {
+  isAskUserQuestionsAnswerable,
+  isInteractionAnswerCallback,
+  sendAnswerableInteraction,
+  resolveInteractionAnswerCallback,
+  finalizeReplyRejection,
+  isInteractionReplyMapping,
+  fetchInteraction,
+} = await import("../src/interaction-answers.js");
+
+function mockCtx(): PluginContext {
+  return {
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    metrics: { write: vi.fn() },
+    state: {
+      get: vi.fn(async (key: { stateKey: string; scopeId?: string }) => stateStore[`${key.scopeId ?? ""}:${key.stateKey}`] ?? null),
+      set: vi.fn(async (key: { stateKey: string; scopeId?: string }, value: unknown) => {
+        stateStore[`${key.scopeId ?? ""}:${key.stateKey}`] = value;
+      }),
+      delete: vi.fn(async (key: { stateKey: string; scopeId?: string }) => {
+        delete stateStore[`${key.scopeId ?? ""}:${key.stateKey}`];
+      }),
+    },
+  } as unknown as PluginContext;
+}
+
+beforeEach(() => {
+  sent = [];
+  edited = [];
+  answers = [];
+  apiCalls = [];
+  stateStore = {};
+  freshInteractions = [];
+  postResponses = {};
+});
+
+function lastCallbackData(): string {
+  const keyboard = sent.at(-1)?.options?.inlineKeyboard as Array<Array<{ callback_data: string }>>;
+  return keyboard[0]![0]!.callback_data;
+}
+
+function pickSafeQuestion(over: Record<string, unknown> = {}) {
+  return {
+    id: "q1",
+    prompt: "Which environment?",
+    selectionMode: "single" as const,
+    required: true,
+    options: [
+      { id: "opt-a", label: "Staging" },
+      { id: "opt-b", label: "Production" },
+    ],
+    ...over,
+  };
+}
+
+describe("isAskUserQuestionsAnswerable", () => {
+  it("is answerable when every option on every question is a plain pick", () => {
+    expect(isAskUserQuestionsAnswerable({ version: 1, questions: [pickSafeQuestion()] })).toBe(true);
+  });
+
+  it("is not answerable when any option is designer-declared free text", () => {
+    const payload = {
+      version: 1 as const,
+      questions: [pickSafeQuestion({ options: [{ id: "o1", label: "Other", freeText: true }] })],
+    };
+    expect(isAskUserQuestionsAnswerable(payload)).toBe(false);
+  });
+
+  it("is not answerable with zero questions", () => {
+    expect(isAskUserQuestionsAnswerable({ version: 1, questions: [] })).toBe(false);
+  });
+});
+
+describe("isInteractionAnswerCallback", () => {
+  it("recognizes the int_ prefix and nothing else", () => {
+    expect(isInteractionAnswerCallback("int_abc_accept")).toBe(true);
+    expect(isInteractionAnswerCallback("approve_123")).toBe(false);
+    expect(isInteractionAnswerCallback("dec_abc_0")).toBe(false);
+  });
+});
+
+describe("sendAnswerableInteraction — ask_user_questions", () => {
+  it("sends the first question with option buttons when pick-safe", async () => {
+    const ctx = mockCtx();
+    const ok = await sendAnswerableInteraction(ctx, "tok", "chat-1", {
+      id: "int-1",
+      kind: "ask_user_questions",
+      payload: { version: 1, questions: [pickSafeQuestion()] },
+    }, { issueId: "issue-1" });
+
+    expect(ok).toBe(true);
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.text).toContain("Question 1 of 1");
+    const keyboard = sent[0]!.options!.inlineKeyboard as unknown[];
+    expect(keyboard).toHaveLength(2); // one row per option, single-select has no extra "Continue" row
+  });
+
+  it("returns false and sends nothing when a question has a free-text option", async () => {
+    const ctx = mockCtx();
+    const ok = await sendAnswerableInteraction(ctx, "tok", "chat-1", {
+      id: "int-1",
+      kind: "ask_user_questions",
+      payload: { version: 1, questions: [pickSafeQuestion({ options: [{ id: "o1", label: "Other", freeText: true }] })] },
+    }, { issueId: "issue-1" });
+
+    expect(ok).toBe(false);
+    expect(sent).toHaveLength(0);
+  });
+
+  it("adds a Continue row for multi-select questions", async () => {
+    const ctx = mockCtx();
+    await sendAnswerableInteraction(ctx, "tok", "chat-1", {
+      id: "int-1",
+      kind: "ask_user_questions",
+      payload: { version: 1, questions: [pickSafeQuestion({ selectionMode: "multi" })] },
+    }, { issueId: "issue-1" });
+
+    const keyboard = sent[0]!.options!.inlineKeyboard as Array<Array<{ text: string }>>;
+    expect(keyboard.at(-1)![0]!.text).toContain("Continue");
+  });
+});
+
+describe("sendAnswerableInteraction — request_confirmation", () => {
+  it("shows Accept and Reject when no reason is required", async () => {
+    const ctx = mockCtx();
+    await sendAnswerableInteraction(ctx, "tok", "chat-1", {
+      id: "int-1",
+      kind: "request_confirmation",
+      payload: { version: 1, prompt: "Ship it?" },
+    }, { issueId: "issue-1", companyId: "co-1" });
+
+    const keyboard = sent[0]!.options!.inlineKeyboard as Array<Array<{ text: string }>>;
+    expect(keyboard[0]!.map((b) => b.text).join(",")).toContain("Accept");
+    expect(keyboard[0]!.map((b) => b.text).join(",")).toContain("Reject");
+  });
+
+  it("hides the Reject button and points to reply-with-reason when a reason is required", async () => {
+    const ctx = mockCtx();
+    await sendAnswerableInteraction(ctx, "tok", "chat-1", {
+      id: "int-1",
+      kind: "request_confirmation",
+      payload: { version: 1, prompt: "Ship it?", rejectRequiresReason: true },
+    }, { issueId: "issue-1", companyId: "co-1" });
+
+    const keyboard = sent[0]!.options!.inlineKeyboard as Array<Array<{ text: string }>>;
+    expect(keyboard[0]).toHaveLength(1);
+    expect(sent[0]!.text).toContain("Reply to this message with your reason");
+  });
+
+  it("registers a company-scoped reply mapping so replying can reject with a reason", async () => {
+    const ctx = mockCtx();
+    await sendAnswerableInteraction(ctx, "tok", "chat-1", {
+      id: "int-1",
+      kind: "request_confirmation",
+      payload: { version: 1, prompt: "Ship it?" },
+    }, { issueId: "issue-1", companyId: "co-1" });
+
+    const mapping = stateStore[`co-1:msg_chat-1_1`] as { entityType: string; entityId: string; issueId: string };
+    expect(mapping.entityType).toBe("interaction_reject_reason");
+    expect(mapping.entityId).toBe("int-1");
+    expect(mapping.issueId).toBe("issue-1");
+  });
+});
+
+describe("fetchInteraction", () => {
+  it("fetches the issue's interactions and returns the payload, not just status", async () => {
+    freshInteractions = [
+      { id: "int-1", status: "pending", kind: "request_confirmation", payload: { version: 1, prompt: "Ship it?" } } as never,
+    ];
+    const ctx = mockCtx();
+
+    const result = await fetchInteraction(ctx, "http://x", "issue-1", "int-1", "board-tok");
+
+    expect(apiCalls[0]!.url).toBe("http://x/api/issues/issue-1/interactions");
+    expect(result?.payload).toEqual({ version: 1, prompt: "Ship it?" });
+  });
+
+  it("returns null when the fetch fails", async () => {
+    const ctx = { ...mockCtx(), state: mockCtx().state } as PluginContext;
+    // Force fetchPaperclipApi to throw by asking for an id that never resolves a JSON body.
+    freshInteractions = [];
+    const result = await fetchInteraction(ctx, "http://x", "issue-1", "missing", "board-tok");
+    expect(result).toBeNull();
+  });
+});
+
+describe("resolveInteractionAnswerCallback — expiry and staleness", () => {
+  it("reports expired when the key has no parked state (restart or already-resolved)", async () => {
+    const ctx = mockCtx();
+    const handled = await resolveInteractionAnswerCallback(ctx, "tok", "int_nope_accept", "cbid", "http://x", "board-tok");
+    expect(handled).toBe(true);
+    expect(answers[0]!.text).toContain("expired or was already answered");
+    expect(apiCalls).toHaveLength(0);
+  });
+
+  it("ignores non-interaction callback data", async () => {
+    const ctx = mockCtx();
+    const handled = await resolveInteractionAnswerCallback(ctx, "tok", "approve_123", "cbid", "http://x", "board-tok");
+    expect(handled).toBe(false);
+  });
+
+  it("refuses to act when the interaction is no longer pending, and clears the parked state", async () => {
+    const ctx = mockCtx();
+    await sendAnswerableInteraction(ctx, "tok", "chat-1", {
+      id: "int-1",
+      kind: "request_confirmation",
+      payload: { version: 1, prompt: "Ship it?" },
+    }, { issueId: "issue-1", companyId: "co-1" });
+    const key = lastCallbackData().split("_")[1];
+    freshInteractions = [{ id: "int-1", status: "expired", kind: "request_confirmation" }];
+
+    await resolveInteractionAnswerCallback(ctx, "tok", `int_${key}_accept`, "cbid", "http://x", "board-tok", 42);
+
+    expect(answers.at(-1)!.text).toContain("no longer pending");
+    expect(apiCalls.some((c) => c.method === "POST")).toBe(false);
+    // Cleared: a second tap gets the generic expired message, not another staleness check.
+    apiCalls = [];
+    await resolveInteractionAnswerCallback(ctx, "tok", `int_${key}_accept`, "cbid", "http://x", "board-tok", 42);
+    expect(apiCalls).toHaveLength(0);
+  });
+});
+
+describe("resolveInteractionAnswerCallback — ask_user_questions", () => {
+  async function parkTwoQuestionFlow(ctx: PluginContext) {
+    await sendAnswerableInteraction(ctx, "tok", "chat-1", {
+      id: "int-1",
+      kind: "ask_user_questions",
+      payload: {
+        version: 1,
+        questions: [
+          pickSafeQuestion({ id: "q1" }),
+          pickSafeQuestion({ id: "q2", selectionMode: "multi", required: true }),
+        ],
+      },
+    }, { issueId: "issue-1" });
+    freshInteractions = [{ id: "int-1", status: "pending", kind: "ask_user_questions" }];
+    return lastCallbackData().split("_")[1] as string;
+  }
+
+  it("advances to the next question on a single-select tap", async () => {
+    const ctx = mockCtx();
+    const key = await parkTwoQuestionFlow(ctx);
+
+    await resolveInteractionAnswerCallback(ctx, "tok", `int_${key}_o1`, "cbid", "http://x", "board-tok", 1);
+
+    expect(sent).toHaveLength(2);
+    expect(sent[1]!.text).toContain("Question 2 of 2");
+    expect(apiCalls.some((c) => c.method === "POST")).toBe(false);
+  });
+
+  it("submits accumulated answers via /respond after the last question", async () => {
+    const ctx = mockCtx();
+    const key = await parkTwoQuestionFlow(ctx);
+    postResponses.respond = { status: "answered" };
+
+    await resolveInteractionAnswerCallback(ctx, "tok", `int_${key}_o0`, "cbid", "http://x", "board-tok", 1);
+    // Multi-select toggle then submit.
+    await resolveInteractionAnswerCallback(ctx, "tok", `int_${key}_o1`, "cbid", "http://x", "board-tok", 2);
+    await resolveInteractionAnswerCallback(ctx, "tok", `int_${key}_done`, "cbid", "http://x", "board-tok", 2);
+
+    const respondCall = apiCalls.find((c) => c.url.endsWith("/respond"));
+    expect(respondCall).toBeDefined();
+    expect(respondCall!.body).toEqual({
+      answers: [
+        { questionId: "q1", optionIds: ["opt-a"] },
+        { questionId: "q2", optionIds: ["opt-b"] },
+      ],
+    });
+    expect(edited.at(-1)!.text).toContain("Answer recorded");
+  });
+
+  it("refuses to advance past a required multi-select question with nothing picked", async () => {
+    const ctx = mockCtx();
+    const key = await parkTwoQuestionFlow(ctx);
+    await resolveInteractionAnswerCallback(ctx, "tok", `int_${key}_o0`, "cbid", "http://x", "board-tok", 1);
+
+    await resolveInteractionAnswerCallback(ctx, "tok", `int_${key}_done`, "cbid", "http://x", "board-tok", 2);
+
+    expect(answers.at(-1)!.text).toContain("Pick at least one");
+    expect(sent).toHaveLength(2); // no third message sent — did not advance
+  });
+
+  it("refuses to skip a required question even if the action is forged", async () => {
+    const ctx = mockCtx();
+    const key = await parkTwoQuestionFlow(ctx);
+    await resolveInteractionAnswerCallback(ctx, "tok", `int_${key}_o0`, "cbid", "http://x", "board-tok", 1);
+
+    await resolveInteractionAnswerCallback(ctx, "tok", `int_${key}_skip`, "cbid", "http://x", "board-tok", 2);
+
+    expect(answers.at(-1)!.text).toContain("requires an answer");
+    expect(apiCalls.some((c) => c.method === "POST")).toBe(false);
+  });
+
+  it("records a skip as an empty answer for a non-required question", async () => {
+    const ctx = mockCtx();
+    await sendAnswerableInteraction(ctx, "tok", "chat-1", {
+      id: "int-2",
+      kind: "ask_user_questions",
+      payload: { version: 1, questions: [pickSafeQuestion({ required: false })] },
+    }, { issueId: "issue-1" });
+    freshInteractions = [{ id: "int-2", status: "pending", kind: "ask_user_questions" }];
+    const key = lastCallbackData().split("_")[1] as string;
+    postResponses.respond = { status: "answered" };
+
+    await resolveInteractionAnswerCallback(ctx, "tok", `int_${key}_skip`, "cbid", "http://x", "board-tok", 1);
+
+    const respondCall = apiCalls.find((c) => c.url.endsWith("/respond"));
+    expect(respondCall!.body).toEqual({ answers: [{ questionId: "q1", optionIds: [] }] });
+  });
+
+  it("toggles a multi-select option in place without advancing", async () => {
+    const ctx = mockCtx();
+    const key = await parkTwoQuestionFlow(ctx);
+    await resolveInteractionAnswerCallback(ctx, "tok", `int_${key}_o0`, "cbid", "http://x", "board-tok", 1);
+
+    await resolveInteractionAnswerCallback(ctx, "tok", `int_${key}_o0`, "cbid", "http://x", "board-tok", 2);
+
+    expect(sent).toHaveLength(2); // no new message — same question re-rendered
+    expect(edited).toHaveLength(1);
+    expect(edited[0]!.text).toContain("Question 2 of 2");
+  });
+});
+
+describe("resolveInteractionAnswerCallback — request_confirmation", () => {
+  async function parkConfirmation(ctx: PluginContext, payload: Record<string, unknown> = {}) {
+    await sendAnswerableInteraction(ctx, "tok", "chat-1", {
+      id: "int-1",
+      kind: "request_confirmation",
+      payload: { version: 1, prompt: "Ship it?", ...payload },
+    }, { issueId: "issue-1", companyId: "co-1" });
+    freshInteractions = [{ id: "int-1", status: "pending", kind: "request_confirmation" }];
+    const keyboard = sent.at(-1)!.options!.inlineKeyboard as Array<Array<{ callback_data: string }>>;
+    return keyboard[0]![0]!.callback_data.split("_")[1] as string;
+  }
+
+  it("accepts and edits the message on tap", async () => {
+    const ctx = mockCtx();
+    const key = await parkConfirmation(ctx);
+    postResponses.accept = { status: "accepted" };
+
+    await resolveInteractionAnswerCallback(ctx, "tok", `int_${key}_accept`, "cbid", "http://x", "board-tok", 1);
+
+    expect(apiCalls.find((c) => c.url.endsWith("/accept"))).toBeDefined();
+    expect(edited.at(-1)!.text).toContain("Accepted");
+  });
+
+  it("rejects on tap when no reason is required", async () => {
+    const ctx = mockCtx();
+    const key = await parkConfirmation(ctx);
+    postResponses.reject = { status: "rejected" };
+
+    await resolveInteractionAnswerCallback(ctx, "tok", `int_${key}_reject`, "cbid", "http://x", "board-tok", 1);
+
+    const rejectCall = apiCalls.find((c) => c.url.endsWith("/reject"));
+    expect(rejectCall!.body).toEqual({});
+    expect(edited.at(-1)!.text).toContain("Rejected");
+  });
+
+  it("a redelivered accept after resolution does not double-apply", async () => {
+    const ctx = mockCtx();
+    const key = await parkConfirmation(ctx);
+    postResponses.accept = { status: "accepted" };
+    await resolveInteractionAnswerCallback(ctx, "tok", `int_${key}_accept`, "cbid", "http://x", "board-tok", 1);
+    apiCalls = [];
+
+    await resolveInteractionAnswerCallback(ctx, "tok", `int_${key}_accept`, "cbid", "http://x", "board-tok", 1);
+
+    expect(apiCalls).toHaveLength(0);
+    expect(answers.at(-1)!.text).toContain("expired or was already answered");
+  });
+});
+
+describe("finalizeReplyRejection", () => {
+  it("rejects with the reply text as the reason", async () => {
+    const ctx = mockCtx();
+    freshInteractions = [{ id: "int-1", status: "pending", kind: "request_confirmation" }];
+    postResponses.reject = { status: "rejected" };
+
+    await finalizeReplyRejection(ctx, "tok", "http://x", "board-tok", {
+      entityId: "int-1",
+      entityType: "interaction_reject_reason",
+      companyId: "co-1",
+      issueId: "issue-1",
+    }, "not ready for prod", "chat-1");
+
+    const rejectCall = apiCalls.find((c) => c.url.endsWith("/reject"));
+    expect(rejectCall!.body).toEqual({ reason: "not ready for prod" });
+    expect(sent.at(-1)!.text).toContain("Rejected with your reason");
+  });
+
+  it("reports staleness instead of rejecting when the interaction already moved on", async () => {
+    const ctx = mockCtx();
+    freshInteractions = [{ id: "int-1", status: "accepted", kind: "request_confirmation" }];
+
+    await finalizeReplyRejection(ctx, "tok", "http://x", "board-tok", {
+      entityId: "int-1",
+      entityType: "interaction_reject_reason",
+      companyId: "co-1",
+      issueId: "issue-1",
+    }, "too late", "chat-1");
+
+    expect(apiCalls.some((c) => c.method === "POST")).toBe(false);
+    expect(sent.at(-1)!.text).toContain("no longer pending");
+  });
+});
+
+describe("isInteractionReplyMapping", () => {
+  it("matches only the interaction_reject_reason entity type", () => {
+    expect(isInteractionReplyMapping({ entityType: "interaction_reject_reason" })).toBe(true);
+    expect(isInteractionReplyMapping({ entityType: "issue" })).toBe(false);
+    expect(isInteractionReplyMapping(null)).toBe(false);
+    expect(isInteractionReplyMapping("interaction_reject_reason")).toBe(false);
+  });
+});

--- a/tests/media-pipeline.test.ts
+++ b/tests/media-pipeline.test.ts
@@ -184,6 +184,7 @@ describe("Audio type detection", () => {
 
     // Should show transcription preview
     expect(sentMessages.some(m => m.text.includes("Transcription"))).toBe(true);
+    expect(ctx.secrets.resolve).toHaveBeenCalledWith("openai-key", "company-1");
   });
 
   it("detects audio messages as audio", async () => {

--- a/tests/media-pipeline.test.ts
+++ b/tests/media-pipeline.test.ts
@@ -184,7 +184,10 @@ describe("Audio type detection", () => {
 
     // Should show transcription preview
     expect(sentMessages.some(m => m.text.includes("Transcription"))).toBe(true);
-    expect(ctx.secrets.resolve).toHaveBeenCalledWith("openai-key", "company-1");
+    expect(ctx.secrets.resolve).toHaveBeenCalledWith("openai-key", {
+      companyId: "company-1",
+      configPath: "transcriptionApiKeyRef",
+    });
   });
 
   it("detects audio messages as audio", async () => {

--- a/tests/polling-dispatch.test.ts
+++ b/tests/polling-dispatch.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import {
+  getTelegramUpdateChatId,
+  selectTelegramRuntimeForUpdate,
+  telegramRuntimeChatIds,
+} from "../src/polling-dispatch.js";
+
+const pacoRuntime = {
+  companyId: "paco",
+  config: {
+    defaultChatId: "-1003800613668",
+    allowedTelegramChatIds: ["-1003800613668"],
+    errorsChatId: "-1003800613668",
+  },
+};
+
+const superpowersRuntime = {
+  companyId: "superpowers",
+  config: {
+    defaultChatId: "-1004295856824",
+    allowedTelegramChatIds: ["-1004295856824"],
+    digestChatId: "-1004295856824",
+  },
+};
+
+describe("Telegram polling dispatch", () => {
+  it("extracts message and callback chat ids", () => {
+    expect(getTelegramUpdateChatId({
+      message: { chat: { id: -1004295856824 } },
+    })).toBe("-1004295856824");
+
+    expect(getTelegramUpdateChatId({
+      callback_query: {
+        message: { chat: { id: -1003800613668 } },
+      },
+    })).toBe("-1003800613668");
+  });
+
+  it("collects all configured chat ids for a runtime", () => {
+    expect([...telegramRuntimeChatIds({
+      defaultChatId: "-1001",
+      approvalsChatId: "-1002",
+      errorsChatId: "-1003",
+      digestChatId: "-1004",
+      escalationChatId: "-1005",
+      allowedTelegramChatIds: ["-1006"],
+      briefAgentChatIds: ["-1007"],
+    })].sort()).toEqual([
+      "-1001",
+      "-1002",
+      "-1003",
+      "-1004",
+      "-1005",
+      "-1006",
+      "-1007",
+    ]);
+  });
+
+  it("selects the matching company runtime before allowlist handling", () => {
+    const runtime = selectTelegramRuntimeForUpdate(
+      [pacoRuntime, superpowersRuntime],
+      {
+        update_id: 77604974,
+        message: { chat: { id: -1004295856824 } },
+      },
+    );
+
+    expect(runtime?.companyId).toBe("superpowers");
+  });
+
+  it("does not route an unmatched chat when multiple companies share one bot token", () => {
+    const runtime = selectTelegramRuntimeForUpdate(
+      [pacoRuntime, superpowersRuntime],
+      {
+        update_id: 77604975,
+        message: { chat: { id: -1009999999999 } },
+      },
+    );
+
+    expect(runtime).toBeNull();
+  });
+
+  it("keeps single-company fallback behavior for legacy configs with sparse chat metadata", () => {
+    const runtime = selectTelegramRuntimeForUpdate(
+      [pacoRuntime],
+      {
+        update_id: 77604976,
+        message: { chat: { id: -1009999999999 } },
+      },
+    );
+
+    expect(runtime?.companyId).toBe("paco");
+  });
+});

--- a/tests/secret-ref-validation.test.ts
+++ b/tests/secret-ref-validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isValidSecretRef, validateSecretRefFields } from "../src/secret-ref-validation.js";
+import { isValidSecretRef, validateSecretRefFields, normalizeSecretRef } from "../src/secret-ref-validation.js";
 
 const VALID_UUID = "12f7ed4a-1234-4d0c-9abc-bd58d44d15e1";
 const VALID_UUID_2 = "abcdef01-2345-6789-abcd-ef0123456789";
@@ -93,5 +93,26 @@ describe("validateSecretRefFields", () => {
       telegramBotTokenRef: { id: VALID_UUID } as unknown as string,
     });
     expect(errors[0]).toContain("<object>");
+  });
+});
+
+describe("normalizeSecretRef", () => {
+  it("wraps a bare UUID into the object form the host requires", () => {
+    expect(normalizeSecretRef("11111111-2222-4333-8444-555555555555")).toEqual({
+      type: "secret_ref",
+      secretId: "11111111-2222-4333-8444-555555555555",
+    });
+  });
+
+  it("passes an already-correct object through unchanged", () => {
+    const ref = { type: "secret_ref", secretId: "11111111-2222-4333-8444-555555555555" };
+    expect(normalizeSecretRef(ref)).toBe(ref);
+  });
+
+  it("rejects values that are not usable refs", () => {
+    expect(normalizeSecretRef("not-a-uuid")).toBeNull();
+    expect(normalizeSecretRef("")).toBeNull();
+    expect(normalizeSecretRef(null)).toBeNull();
+    expect(normalizeSecretRef({ type: "other", secretId: "x" })).toBeNull();
   });
 });

--- a/tests/status-agents.test.ts
+++ b/tests/status-agents.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { Agent, PluginContext } from "@paperclipai/plugin-sdk";
+
+const sent: string[] = [];
+
+vi.mock("../src/telegram-api.js", () => ({
+  sendMessage: vi.fn(async (_c: unknown, _t: string, _chat: string, text: string) => {
+    sent.push(text);
+    return { ok: true };
+  }),
+  sendChatAction: vi.fn(async () => ({ ok: true })),
+  escapeMarkdownV2: (s: string) => s,
+}));
+
+const { handleCommand } = await import("../src/commands.js");
+
+function agent(status: string): Agent {
+  return { id: `a-${status}-${Math.random()}`, name: `Agent ${status}`, status } as Agent;
+}
+
+function makeCtx(agents: Agent[]): PluginContext {
+  return {
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    metrics: { write: vi.fn(async () => undefined) },
+    agents: { list: vi.fn(async () => agents) },
+    issues: { list: vi.fn(async () => []) },
+    state: { get: vi.fn(async () => null), set: vi.fn(async () => undefined) },
+  } as unknown as PluginContext;
+}
+
+describe("/status agent counts", () => {
+  beforeEach(() => {
+    sent.length = 0;
+  });
+
+  it("counts running agents — the old filter looked for a status that never occurs", async () => {
+    // Agents report "running"/"idle"; nothing is ever "active", so the previous
+    // `status === "active"` filter reported 0 while agents were working.
+    const ctx = makeCtx([agent("running"), agent("idle"), agent("idle")]);
+    await handleCommand(ctx, "tok", "chat-1", "status", "", undefined, undefined, undefined, "company-1");
+    expect(sent.at(-1)).toContain("1* running");
+  });
+
+  it("still counts a legacy 'active' status as running", async () => {
+    const ctx = makeCtx([agent("active"), agent("idle")]);
+    await handleCommand(ctx, "tok", "chat-1", "status", "", undefined, undefined, undefined, "company-1");
+    expect(sent.at(-1)).toContain("1* running");
+  });
+
+  it("reports availability separately from running, and flags paused/error", async () => {
+    const ctx = makeCtx([agent("running"), agent("idle"), agent("paused"), agent("error")]);
+    await handleCommand(ctx, "tok", "chat-1", "status", "", undefined, undefined, undefined, "company-1");
+    const text = sent.at(-1)!;
+    expect(text).toContain("1* running");
+    expect(text).toContain("2* available");
+    expect(text).toContain("2 paused/error");
+  });
+
+  it("omits the paused/error note when everything is healthy", async () => {
+    const ctx = makeCtx([agent("idle"), agent("idle")]);
+    await handleCommand(ctx, "tok", "chat-1", "status", "", undefined, undefined, undefined, "company-1");
+    expect(sent.at(-1)).not.toContain("paused/error");
+  });
+});

--- a/tests/telegram-send.test.ts
+++ b/tests/telegram-send.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { PluginContext } from "@paperclipai/plugin-sdk";
+import {
+  sendMessage,
+  editMessage,
+  setMyCommands,
+  answerCallbackQuery,
+  isForum,
+} from "../src/telegram-api.js";
+import { METRIC_NAMES } from "../src/constants.js";
+
+/**
+ * Every user-visible byte this plugin produces goes through sendMessage, and it
+ * was entirely untested — the existing telegram-api tests only cover the two
+ * pure string helpers. The transport is where a message gets silently dropped:
+ * on failure it returns null and logs, so a caller sees nothing wrong.
+ */
+
+// A real backoff, kept sub-millisecond so the retry path runs for real rather
+// than behind fake timers.
+const TINY_RETRY_AFTER = 0.001;
+
+type FetchCall = { url: string; init: { body: string } };
+
+let calls: FetchCall[] = [];
+let responses: unknown[] = [];
+
+function makeCtx(): PluginContext {
+  return {
+    http: {
+      fetch: vi.fn(async (url: string, init: { body: string }) => {
+        calls.push({ url, init });
+        const next = responses.shift() ?? { ok: true, result: { message_id: 1 } };
+        if (next instanceof Error) throw next;
+        return { json: async () => next };
+      }),
+    },
+    metrics: { write: vi.fn(async () => {}) },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  } as unknown as PluginContext;
+}
+
+function bodyOf(call: FetchCall): Record<string, unknown> {
+  return JSON.parse(call.init.body) as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  calls = [];
+  responses = [];
+});
+
+describe("sendMessage", () => {
+  it("posts to the bot's sendMessage endpoint and returns the message id", async () => {
+    responses = [{ ok: true, result: { message_id: 4242 } }];
+    const ctx = makeCtx();
+
+    const id = await sendMessage(ctx, "tok", "chat-1", "hello");
+
+    expect(id).toBe(4242);
+    expect(calls[0].url).toBe("https://api.telegram.org/bottok/sendMessage");
+    expect(bodyOf(calls[0])).toMatchObject({ chat_id: "chat-1", text: "hello" });
+    expect(ctx.metrics.write).toHaveBeenCalledWith(METRIC_NAMES.sent, 1);
+  });
+
+  it("omits optional fields rather than sending nulls Telegram would reject", async () => {
+    const ctx = makeCtx();
+    await sendMessage(ctx, "tok", "chat-1", "hello");
+
+    const body = bodyOf(calls[0]);
+    expect(body).not.toHaveProperty("parse_mode");
+    expect(body).not.toHaveProperty("message_thread_id");
+    expect(body).not.toHaveProperty("reply_markup");
+  });
+
+  it("passes the thread id through, which is what keeps forum replies in-topic", async () => {
+    const ctx = makeCtx();
+    await sendMessage(ctx, "tok", "chat-1", "hi", { messageThreadId: 77 });
+
+    expect(bodyOf(calls[0])).toMatchObject({ message_thread_id: 77 });
+  });
+
+  it("wraps an inline keyboard in reply_markup", async () => {
+    const ctx = makeCtx();
+    await sendMessage(ctx, "tok", "chat-1", "pick", {
+      inlineKeyboard: [[{ text: "Yes", callback_data: "y" }]],
+    });
+
+    expect(bodyOf(calls[0]).reply_markup).toEqual({
+      inline_keyboard: [[{ text: "Yes", callback_data: "y" }]],
+    });
+  });
+
+  it("retries a failed MarkdownV2 send as plain text instead of dropping it", async () => {
+    // This is the safety net under /decisions: a single unescaped character
+    // makes Telegram reject the whole message. Without the retry the user gets
+    // silence, which reads as "nothing is pending".
+    responses = [
+      { ok: false, description: "Bad Request: can't parse entities" },
+      { ok: true, result: { message_id: 9 } },
+    ];
+    const ctx = makeCtx();
+
+    const id = await sendMessage(ctx, "tok", "chat-1", "*bold* \\.", { parseMode: "MarkdownV2" });
+
+    expect(id).toBe(9);
+    expect(calls).toHaveLength(2);
+    expect(bodyOf(calls[1])).not.toHaveProperty("parse_mode");
+    // The retry strips the markup rather than resending characters that failed.
+    expect(bodyOf(calls[1]).text).toBe("bold .");
+  });
+
+  it("records a failure metric when a plain-text send is rejected", async () => {
+    responses = [{ ok: false, description: "chat not found" }];
+    const ctx = makeCtx();
+
+    expect(await sendMessage(ctx, "tok", "chat-1", "hi")).toBeNull();
+    expect(ctx.metrics.write).toHaveBeenCalledWith(METRIC_NAMES.failed, 1);
+    expect(ctx.logger.error).toHaveBeenCalled();
+  });
+
+  it("returns null instead of throwing when the network fails", async () => {
+    // Callers are fire-and-forget; a throw here would kill the polling loop.
+    responses = [new Error("ECONNREFUSED")];
+    const ctx = makeCtx();
+
+    await expect(sendMessage(ctx, "tok", "chat-1", "hi")).resolves.toBeNull();
+    expect(ctx.metrics.write).toHaveBeenCalledWith(METRIC_NAMES.failed, 1);
+  });
+
+  it("retries once when Telegram rate limits, then succeeds", async () => {
+    responses = [
+      { ok: false, parameters: { retry_after: TINY_RETRY_AFTER } },
+      { ok: true, result: { message_id: 5 } },
+    ];
+    const ctx = makeCtx();
+
+    expect(await sendMessage(ctx, "tok", "chat-1", "hi")).toBe(5);
+    expect(calls).toHaveLength(2);
+    expect(ctx.logger.warn).toHaveBeenCalledWith(
+      "Telegram rate limited, retrying",
+      expect.objectContaining({ retryAfter: TINY_RETRY_AFTER }),
+    );
+  });
+
+  it("gives up after the third rate-limited attempt rather than looping", async () => {
+    responses = [
+      { ok: false, parameters: { retry_after: TINY_RETRY_AFTER } },
+      { ok: false, parameters: { retry_after: TINY_RETRY_AFTER } },
+      { ok: false, parameters: { retry_after: TINY_RETRY_AFTER }, description: "Too Many Requests" },
+    ];
+    const ctx = makeCtx();
+
+    expect(await sendMessage(ctx, "tok", "chat-1", "hi")).toBeNull();
+    expect(calls).toHaveLength(3);
+  });
+
+  it("treats retry_after: 0 as a plain failure, not a retry", async () => {
+    // Documenting real behaviour, not endorsing it: `retry_after` is checked
+    // for truthiness, so a zero-second backoff falls through to the error path.
+    // Harmless in practice — Telegram does not send 0 — but a reader comparing
+    // this code to the API docs would otherwise expect a retry here.
+    responses = [{ ok: false, parameters: { retry_after: 0 }, description: "Too Many Requests" }];
+    const ctx = makeCtx();
+
+    expect(await sendMessage(ctx, "tok", "chat-1", "hi")).toBeNull();
+    expect(calls).toHaveLength(1);
+  });
+});
+
+describe("editMessage", () => {
+  it("clears the keyboard by default, so a pressed button cannot be pressed twice", async () => {
+    const ctx = makeCtx();
+    await editMessage(ctx, "tok", "chat-1", 12, "done");
+
+    expect(bodyOf(calls[0])).toMatchObject({
+      message_id: 12,
+      reply_markup: { inline_keyboard: [] },
+    });
+  });
+
+  it("returns false rather than throwing when the edit fails", async () => {
+    responses = [new Error("boom")];
+    const ctx = makeCtx();
+
+    await expect(editMessage(ctx, "tok", "chat-1", 12, "x")).resolves.toBe(false);
+  });
+});
+
+describe("setMyCommands", () => {
+  it("sends the command list that populates the / menu", async () => {
+    responses = [{ ok: true }];
+    const ctx = makeCtx();
+
+    const ok = await setMyCommands(ctx, "tok", [{ command: "decisions", description: "d" }]);
+
+    expect(ok).toBe(true);
+    expect(bodyOf(calls[0])).toEqual({ commands: [{ command: "decisions", description: "d" }] });
+  });
+
+  it("reports false when Telegram rejects the list", async () => {
+    responses = [{ ok: false }];
+    expect(await setMyCommands(makeCtx(), "tok", [])).toBe(false);
+  });
+});
+
+describe("answerCallbackQuery", () => {
+  it("swallows failures — a missed spinner must not break the handler", async () => {
+    responses = [new Error("gone")];
+    const ctx = makeCtx();
+
+    await expect(answerCallbackQuery(ctx, "tok", "cbq-1", "ok")).resolves.toBeUndefined();
+    expect(ctx.logger.error).toHaveBeenCalled();
+  });
+});
+
+describe("isForum", () => {
+  it("caches per chat, so repeated sends do not re-query getChat", async () => {
+    responses = [{ ok: true, result: { is_forum: true } }];
+    const ctx = makeCtx();
+
+    expect(await isForum(ctx, "tok", "chat-cache-probe")).toBe(true);
+    expect(await isForum(ctx, "tok", "chat-cache-probe")).toBe(true);
+    expect(calls).toHaveLength(1);
+  });
+
+  it("treats an unreachable getChat as not-a-forum rather than failing the send", async () => {
+    responses = [new Error("offline")];
+    expect(await isForum(makeCtx(), "tok", "chat-offline-probe")).toBe(false);
+  });
+});

--- a/tests/worker-company-runtimes.test.ts
+++ b/tests/worker-company-runtimes.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { PluginContext } from "@paperclipai/plugin-sdk";
+
+import { listCompaniesForStartup, resolveCompanyRuntimes } from "../src/worker.js";
+
+let stateStore: Record<string, unknown> = {};
+let configByCompany: Record<string, Record<string, unknown>> = {};
+
+function mockCtx(overrides: Partial<PluginContext> = {}): PluginContext {
+  return {
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    state: {
+      get: vi.fn(async (key: { stateKey: string }) => stateStore[key.stateKey] ?? null),
+      set: vi.fn(async (key: { stateKey: string }, value: unknown) => {
+        stateStore[key.stateKey] = value;
+      }),
+    },
+    companies: {
+      list: vi.fn().mockResolvedValue([]),
+      get: vi.fn().mockResolvedValue(null),
+    },
+    config: {
+      get: vi.fn(async (companyId: string) => configByCompany[companyId] ?? {}),
+    },
+    secrets: {
+      resolve: vi.fn().mockResolvedValue("bot-token-123"),
+    },
+    ...overrides,
+  } as unknown as PluginContext;
+}
+
+beforeEach(() => {
+  stateStore = {};
+  configByCompany = {};
+});
+
+describe("listCompaniesForStartup (regression: companies.list returning [] must not silently disable polling)", () => {
+  it("returns the companies.list result when it is non-empty", async () => {
+    const ctx = mockCtx({
+      companies: { list: vi.fn().mockResolvedValue([{ id: "co-1" }, { id: "co-2" }]), get: vi.fn() } as unknown as PluginContext["companies"],
+    });
+
+    const result = await listCompaniesForStartup(ctx);
+    expect(result).toEqual([{ id: "co-1" }, { id: "co-2" }]);
+  });
+
+  it("falls back to the board-access companyId when companies.list SUCCEEDS but returns []", async () => {
+    stateStore["telegram.board-access.v1"] = { companyId: "co-fallback" };
+    const ctx = mockCtx({
+      companies: { list: vi.fn().mockResolvedValue([]), get: vi.fn() } as unknown as PluginContext["companies"],
+    });
+
+    const result = await listCompaniesForStartup(ctx);
+
+    // This is the exact bug this function exists to prevent: an empty array
+    // returned WITHOUT a thrown error must still fall back, or polling never starts.
+    expect(result).toEqual([{ id: "co-fallback" }]);
+  });
+
+  it("falls back to the board-access companyId when companies.list throws", async () => {
+    stateStore["telegram.board-access.v1"] = { companyId: "co-fallback" };
+    const ctx = mockCtx({
+      companies: { list: vi.fn().mockRejectedValue(new Error("no invocation scope")), get: vi.fn() } as unknown as PluginContext["companies"],
+    });
+
+    const result = await listCompaniesForStartup(ctx);
+    expect(result).toEqual([{ id: "co-fallback" }]);
+  });
+
+  it("returns [] and logs a warning when there is no fallback company id either", async () => {
+    const ctx = mockCtx({
+      companies: { list: vi.fn().mockResolvedValue([]), get: vi.fn() } as unknown as PluginContext["companies"],
+    });
+
+    const result = await listCompaniesForStartup(ctx);
+    expect(result).toEqual([]);
+    expect(ctx.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("no fallback company id is known"),
+      expect.anything(),
+    );
+  });
+});
+
+describe("resolveCompanyRuntimes (config merge + company-runtime resolution)", () => {
+  const startupConfig = {
+    telegramBotTokenRef: "",
+    defaultChatId: "",
+    paperclipBaseUrl: "http://startup-base",
+  } as unknown as Parameters<typeof resolveCompanyRuntimes>[1];
+
+  it("skips a company whose scoped config throws instead of aborting the whole resolution", async () => {
+    stateStore["telegram.board-access.v1"] = { companyId: "co-1" };
+    configByCompany = {
+      "co-1": undefined as unknown as Record<string, unknown>,
+      "co-2": { telegramBotTokenRef: "ref-2", defaultChatId: "chat-2" },
+    };
+    const ctx = mockCtx({
+      companies: { list: vi.fn().mockResolvedValue([{ id: "co-1" }, { id: "co-2" }]), get: vi.fn() } as unknown as PluginContext["companies"],
+      config: {
+        get: vi.fn(async (companyId: string) => {
+          if (companyId === "co-1") throw new Error("scope unavailable");
+          return configByCompany[companyId] ?? {};
+        }),
+      } as unknown as PluginContext["config"],
+    });
+
+    const runtimes = await resolveCompanyRuntimes(ctx, startupConfig, () => true);
+
+    expect(runtimes).toHaveLength(1);
+    expect(runtimes[0].companyId).toBe("co-2");
+    expect(ctx.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("config unavailable"),
+      expect.objectContaining({ companyId: "co-1" }),
+    );
+  });
+
+  it("skips companies with no telegramBotTokenRef key at all in scoped config", async () => {
+    configByCompany = { "co-1": { someOtherKey: "x" } };
+    const ctx = mockCtx({
+      companies: { list: vi.fn().mockResolvedValue([{ id: "co-1" }]), get: vi.fn() } as unknown as PluginContext["companies"],
+    });
+
+    const runtimes = await resolveCompanyRuntimes(ctx, startupConfig, () => true);
+    expect(runtimes).toEqual([]);
+  });
+
+  it("merges scoped config over startup config so company-specific values win", async () => {
+    configByCompany = {
+      "co-1": { telegramBotTokenRef: "ref-1", defaultChatId: "company-chat" },
+    };
+    const ctx = mockCtx({
+      companies: { list: vi.fn().mockResolvedValue([{ id: "co-1" }]), get: vi.fn() } as unknown as PluginContext["companies"],
+    });
+
+    const runtimes = await resolveCompanyRuntimes(ctx, startupConfig, () => true);
+
+    expect(runtimes).toHaveLength(1);
+    expect(runtimes[0].config.defaultChatId).toBe("company-chat");
+    // paperclipBaseUrl was not overridden by the company, so the startup value survives the merge
+    expect(runtimes[0].baseUrl).toBe("http://startup-base");
+  });
+
+  it("excludes a company when the predicate rejects its effective config", async () => {
+    configByCompany = {
+      "co-1": { telegramBotTokenRef: "ref-1", defaultChatId: "company-chat", enableCommands: false, enableInbound: false },
+    };
+    const ctx = mockCtx({
+      companies: { list: vi.fn().mockResolvedValue([{ id: "co-1" }]), get: vi.fn() } as unknown as PluginContext["companies"],
+    });
+
+    const runtimes = await resolveCompanyRuntimes(
+      ctx,
+      startupConfig,
+      (config) => Boolean(config.enableCommands || config.enableInbound),
+    );
+    expect(runtimes).toEqual([]);
+  });
+
+  it("skips a company when the bot token secret fails to resolve", async () => {
+    configByCompany = {
+      "co-1": { telegramBotTokenRef: "ref-1", defaultChatId: "company-chat" },
+    };
+    const ctx = mockCtx({
+      companies: { list: vi.fn().mockResolvedValue([{ id: "co-1" }]), get: vi.fn() } as unknown as PluginContext["companies"],
+      secrets: { resolve: vi.fn().mockRejectedValue(new Error("secret gone")) } as unknown as PluginContext["secrets"],
+    });
+
+    const runtimes = await resolveCompanyRuntimes(ctx, startupConfig, () => true);
+    expect(runtimes).toEqual([]);
+  });
+
+  it("excludes a company whose scoped routing values are identical to startup's (no real per-company override)", async () => {
+    // hasCompanyTelegramRoute requires at least one routing key to differ from
+    // the startup value. A company that echoes back the same blank/startup
+    // values has no real Telegram route configured and must be skipped.
+    configByCompany = {
+      "co-1": { telegramBotTokenRef: "", defaultChatId: "" },
+    };
+    const ctx = mockCtx({
+      companies: { list: vi.fn().mockResolvedValue([{ id: "co-1" }]), get: vi.fn() } as unknown as PluginContext["companies"],
+    });
+
+    const runtimes = await resolveCompanyRuntimes(ctx, startupConfig, () => true);
+    expect(runtimes).toEqual([]);
+  });
+});

--- a/tests/worker-company-runtimes.test.ts
+++ b/tests/worker-company-runtimes.test.ts
@@ -140,6 +140,25 @@ describe("resolveCompanyRuntimes (config merge + company-runtime resolution)", (
     expect(runtimes[0].baseUrl).toBe("http://startup-base");
   });
 
+  it("defaults omitted enable flags to true so a company remains pollable", async () => {
+    configByCompany = {
+      "co-1": { telegramBotTokenRef: "ref-1", defaultChatId: "company-chat" },
+    };
+    const ctx = mockCtx({
+      companies: { list: vi.fn().mockResolvedValue([{ id: "co-1" }]), get: vi.fn() } as unknown as PluginContext["companies"],
+    });
+
+    const runtimes = await resolveCompanyRuntimes(
+      ctx,
+      startupConfig,
+      (config) => Boolean(config.enableCommands || config.enableInbound),
+    );
+
+    expect(runtimes).toHaveLength(1);
+    expect(runtimes[0].config.enableCommands).toBe(true);
+    expect(runtimes[0].config.enableInbound).toBe(true);
+  });
+
   it("excludes a company when the predicate rejects its effective config", async () => {
     configByCompany = {
       "co-1": { telegramBotTokenRef: "ref-1", defaultChatId: "company-chat", enableCommands: false, enableInbound: false },

--- a/tests/worker-company-runtimes.test.ts
+++ b/tests/worker-company-runtimes.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { PluginContext } from "@paperclipai/plugin-sdk";
+
+import { listCompaniesForStartup, resolveCompanyRuntimes } from "../src/worker.js";
+
+let stateStore: Record<string, unknown> = {};
+let configByCompany: Record<string, Record<string, unknown>> = {};
+
+function mockCtx(overrides: Partial<PluginContext> = {}): PluginContext {
+  return {
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    state: {
+      get: vi.fn(async (key: { stateKey: string }) => stateStore[key.stateKey] ?? null),
+      set: vi.fn(async (key: { stateKey: string }, value: unknown) => {
+        stateStore[key.stateKey] = value;
+      }),
+    },
+    companies: {
+      list: vi.fn().mockResolvedValue([]),
+      get: vi.fn().mockResolvedValue(null),
+    },
+    config: {
+      get: vi.fn(async (companyId: string) => configByCompany[companyId] ?? {}),
+    },
+    secrets: {
+      resolve: vi.fn().mockResolvedValue("bot-token-123"),
+    },
+    ...overrides,
+  } as unknown as PluginContext;
+}
+
+beforeEach(() => {
+  stateStore = {};
+  configByCompany = {};
+});
+
+describe("listCompaniesForStartup (regression: companies.list returning [] must not silently disable polling)", () => {
+  it("returns the companies.list result when it is non-empty", async () => {
+    const ctx = mockCtx({
+      companies: { list: vi.fn().mockResolvedValue([{ id: "co-1" }, { id: "co-2" }]), get: vi.fn() } as unknown as PluginContext["companies"],
+    });
+
+    const result = await listCompaniesForStartup(ctx);
+    expect(result).toEqual([{ id: "co-1" }, { id: "co-2" }]);
+  });
+
+  it("falls back to the board-access companyId when companies.list SUCCEEDS but returns []", async () => {
+    stateStore["telegram.board-access.v1"] = { companyId: "co-fallback" };
+    const ctx = mockCtx({
+      companies: { list: vi.fn().mockResolvedValue([]), get: vi.fn() } as unknown as PluginContext["companies"],
+    });
+
+    const result = await listCompaniesForStartup(ctx);
+
+    // This is the exact bug this function exists to prevent: an empty array
+    // returned WITHOUT a thrown error must still fall back, or polling never starts.
+    expect(result).toEqual([{ id: "co-fallback" }]);
+  });
+
+  it("falls back to the board-access companyId when companies.list throws", async () => {
+    stateStore["telegram.board-access.v1"] = { companyId: "co-fallback" };
+    const ctx = mockCtx({
+      companies: { list: vi.fn().mockRejectedValue(new Error("no invocation scope")), get: vi.fn() } as unknown as PluginContext["companies"],
+    });
+
+    const result = await listCompaniesForStartup(ctx);
+    expect(result).toEqual([{ id: "co-fallback" }]);
+  });
+
+  it("returns [] and logs a warning when there is no fallback company id either", async () => {
+    const ctx = mockCtx({
+      companies: { list: vi.fn().mockResolvedValue([]), get: vi.fn() } as unknown as PluginContext["companies"],
+    });
+
+    const result = await listCompaniesForStartup(ctx);
+    expect(result).toEqual([]);
+    expect(ctx.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("no fallback company id is known"),
+      expect.anything(),
+    );
+  });
+});
+
+describe("resolveCompanyRuntimes (config merge + company-runtime resolution)", () => {
+  const startupConfig = {
+    telegramBotTokenRef: "",
+    defaultChatId: "",
+    paperclipBaseUrl: "http://startup-base",
+  } as unknown as Parameters<typeof resolveCompanyRuntimes>[1];
+
+  it("skips a company whose scoped config throws instead of aborting the whole resolution", async () => {
+    stateStore["telegram.board-access.v1"] = { companyId: "co-1" };
+    configByCompany = {
+      "co-1": undefined as unknown as Record<string, unknown>,
+      "co-2": { telegramBotTokenRef: "ref-2", defaultChatId: "chat-2" },
+    };
+    const ctx = mockCtx({
+      companies: { list: vi.fn().mockResolvedValue([{ id: "co-1" }, { id: "co-2" }]), get: vi.fn() } as unknown as PluginContext["companies"],
+      config: {
+        get: vi.fn(async (companyId: string) => {
+          if (companyId === "co-1") throw new Error("scope unavailable");
+          return configByCompany[companyId] ?? {};
+        }),
+      } as unknown as PluginContext["config"],
+    });
+
+    const runtimes = await resolveCompanyRuntimes(ctx, startupConfig, () => true);
+
+    expect(runtimes).toHaveLength(1);
+    expect(runtimes[0].companyId).toBe("co-2");
+    expect(ctx.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("config unavailable"),
+      expect.objectContaining({ companyId: "co-1" }),
+    );
+  });
+
+  it("skips companies with no telegramBotTokenRef key at all in scoped config", async () => {
+    configByCompany = { "co-1": { someOtherKey: "x" } };
+    const ctx = mockCtx({
+      companies: { list: vi.fn().mockResolvedValue([{ id: "co-1" }]), get: vi.fn() } as unknown as PluginContext["companies"],
+    });
+
+    const runtimes = await resolveCompanyRuntimes(ctx, startupConfig, () => true);
+    expect(runtimes).toEqual([]);
+  });
+
+  it("merges scoped config over startup config so company-specific values win", async () => {
+    configByCompany = {
+      "co-1": { telegramBotTokenRef: "ref-1", defaultChatId: "company-chat" },
+    };
+    const ctx = mockCtx({
+      companies: { list: vi.fn().mockResolvedValue([{ id: "co-1" }]), get: vi.fn() } as unknown as PluginContext["companies"],
+    });
+
+    const runtimes = await resolveCompanyRuntimes(ctx, startupConfig, () => true);
+
+    expect(runtimes).toHaveLength(1);
+    expect(runtimes[0].config.defaultChatId).toBe("company-chat");
+    // paperclipBaseUrl was not overridden by the company, so the startup value survives the merge
+    expect(runtimes[0].baseUrl).toBe("http://startup-base");
+  });
+
+  it("excludes a company when the predicate rejects its effective config", async () => {
+    configByCompany = {
+      "co-1": { telegramBotTokenRef: "ref-1", defaultChatId: "company-chat", enableCommands: false, enableInbound: false },
+    };
+    const ctx = mockCtx({
+      companies: { list: vi.fn().mockResolvedValue([{ id: "co-1" }]), get: vi.fn() } as unknown as PluginContext["companies"],
+    });
+
+    const runtimes = await resolveCompanyRuntimes(
+      ctx,
+      startupConfig,
+      (config) => Boolean(config.enableCommands || config.enableInbound),
+    );
+    expect(runtimes).toEqual([]);
+  });
+
+  it("skips a company when the bot token secret fails to resolve", async () => {
+    configByCompany = {
+      "co-1": { telegramBotTokenRef: "ref-1", defaultChatId: "company-chat" },
+    };
+    const ctx = mockCtx({
+      companies: { list: vi.fn().mockResolvedValue([{ id: "co-1" }]), get: vi.fn() } as unknown as PluginContext["companies"],
+      secrets: { resolve: vi.fn().mockRejectedValue(new Error("secret gone")) } as unknown as PluginContext["secrets"],
+    });
+
+    const runtimes = await resolveCompanyRuntimes(ctx, startupConfig, () => true);
+    expect(runtimes).toEqual([]);
+  });
+
+  it("uses a pre-fetched companies list instead of re-deriving it, when one is passed in", async () => {
+    // setup() resolves listCompaniesForStartup once (to seed loadStartupConfig's
+    // fallback) and should pass that same list through here rather than
+    // triggering a second companies.list()/board-access lookup for one startup.
+    configByCompany = {
+      "co-1": { telegramBotTokenRef: "ref-1", defaultChatId: "company-chat" },
+    };
+    const companiesList = vi.fn().mockResolvedValue([{ id: "co-should-not-be-used" }]);
+    const ctx = mockCtx({
+      companies: { list: companiesList, get: vi.fn() } as unknown as PluginContext["companies"],
+    });
+
+    const runtimes = await resolveCompanyRuntimes(ctx, startupConfig, () => true, [{ id: "co-1" }]);
+
+    expect(runtimes).toHaveLength(1);
+    expect(runtimes[0].companyId).toBe("co-1");
+    expect(companiesList).not.toHaveBeenCalled();
+  });
+
+  it("excludes a company whose scoped routing values are identical to startup's (no real per-company override)", async () => {
+    // hasCompanyTelegramRoute requires at least one routing key to differ from
+    // the startup value. A company that echoes back the same blank/startup
+    // values has no real Telegram route configured and must be skipped.
+    configByCompany = {
+      "co-1": { telegramBotTokenRef: "", defaultChatId: "" },
+    };
+    const ctx = mockCtx({
+      companies: { list: vi.fn().mockResolvedValue([{ id: "co-1" }]), get: vi.fn() } as unknown as PluginContext["companies"],
+    });
+
+    const runtimes = await resolveCompanyRuntimes(ctx, startupConfig, () => true);
+    expect(runtimes).toEqual([]);
+  });
+});

--- a/tests/worker-handle-update.test.ts
+++ b/tests/worker-handle-update.test.ts
@@ -1,0 +1,467 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { PluginContext } from "@paperclipai/plugin-sdk";
+
+let sentMessages: Array<{ chatId: string; text: string }> = [];
+let editedMessages: Array<{ chatId: string; messageId: number; text: string }> = [];
+let answeredCallbacks: Array<{ id: string; text?: string }> = [];
+let handleCommandCalls: Array<unknown[]> = [];
+let tryCustomCommandResult = false;
+let routeMessageToAgentResult = false;
+let routeMessageToAgentCalls: Array<unknown[]> = [];
+let fetchCalls: Array<{ url: string; init?: RequestInit }> = [];
+let handoffApprovalCalls: Array<unknown[]> = [];
+let handoffRejectionCalls: Array<unknown[]> = [];
+
+vi.mock("@paperclipai/plugin-sdk", async () => {
+  const actual = await vi.importActual("@paperclipai/plugin-sdk") as Record<string, unknown>;
+  return { ...actual, runWorker: vi.fn() };
+});
+
+vi.mock("../src/telegram-api.js", async () => {
+  const actual = await vi.importActual("../src/telegram-api.js") as Record<string, unknown>;
+  return {
+    ...actual,
+    sendMessage: vi.fn(async (_ctx: unknown, _token: string, chatId: string, text: string) => {
+      sentMessages.push({ chatId, text });
+      return 1;
+    }),
+    editMessage: vi.fn(async (_ctx: unknown, _token: string, chatId: string, messageId: number, text: string) => {
+      editedMessages.push({ chatId, messageId, text });
+      return true;
+    }),
+    answerCallbackQuery: vi.fn(async (_ctx: unknown, _token: string, id: string, text?: string) => {
+      answeredCallbacks.push({ id, text });
+      return true;
+    }),
+    sendChatAction: vi.fn(),
+  };
+});
+
+vi.mock("../src/commands.js", async () => {
+  const actual = await vi.importActual("../src/commands.js") as Record<string, unknown>;
+  return {
+    ...actual,
+    handleCommand: vi.fn(async (...args: unknown[]) => {
+      handleCommandCalls.push(args);
+    }),
+  };
+});
+
+vi.mock("../src/command-registry.js", async () => {
+  const actual = await vi.importActual("../src/command-registry.js") as Record<string, unknown>;
+  return {
+    ...actual,
+    tryCustomCommand: vi.fn(async () => tryCustomCommandResult),
+    handleCommandsCommand: vi.fn(),
+  };
+});
+
+vi.mock("../src/acp-bridge.js", async () => {
+  const actual = await vi.importActual("../src/acp-bridge.js") as Record<string, unknown>;
+  return {
+    ...actual,
+    routeMessageToAgent: vi.fn(async (...args: unknown[]) => {
+      routeMessageToAgentCalls.push(args);
+      return routeMessageToAgentResult;
+    }),
+    handleHandoffApproval: vi.fn(async (...args: unknown[]) => {
+      handoffApprovalCalls.push(args);
+    }),
+    handleHandoffRejection: vi.fn(async (...args: unknown[]) => {
+      handoffRejectionCalls.push(args);
+    }),
+    setupAcpOutputListener: vi.fn(),
+  };
+});
+
+let handleMediaMessageCalls: Array<unknown[]> = [];
+let handleMediaMessageResult = false;
+
+vi.mock("../src/media-pipeline.js", async () => {
+  const actual = await vi.importActual("../src/media-pipeline.js") as Record<string, unknown>;
+  return {
+    ...actual,
+    handleMediaMessage: vi.fn(async (...args: unknown[]) => {
+      handleMediaMessageCalls.push(args);
+      return handleMediaMessageResult;
+    }),
+  };
+});
+
+let escalationRespondCalls: Array<unknown[]> = [];
+
+vi.mock("../src/escalation.js", async () => {
+  const actual = await vi.importActual("../src/escalation.js") as Record<string, unknown>;
+  return {
+    ...actual,
+    EscalationManager: vi.fn().mockImplementation(() => ({
+      respond: vi.fn(async (...args: unknown[]) => {
+        escalationRespondCalls.push(args);
+      }),
+      handleCallback: vi.fn(),
+    })),
+  };
+});
+
+const originalFetch = global.fetch;
+
+import { handleUpdate } from "../src/worker.js";
+
+const LINKED_CHAT_ID = 111;
+const COMPANY_ID = "company-1";
+
+function mockCtx(): PluginContext {
+  return {
+    http: { fetch: vi.fn().mockResolvedValue({ json: () => Promise.resolve({ ok: true }) }) },
+    metrics: { write: vi.fn().mockResolvedValue(undefined) },
+    state: {
+      get: vi.fn(async (key: { stateKey: string }) => {
+        if (key.stateKey === `chat_${LINKED_CHAT_ID}`) return { companyId: COMPANY_ID };
+        return null;
+      }),
+      set: vi.fn().mockResolvedValue(undefined),
+    },
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    companies: { get: vi.fn().mockResolvedValue(null) },
+    projects: { list: vi.fn().mockResolvedValue([]) },
+    agents: { list: vi.fn().mockResolvedValue([]) },
+    issues: { list: vi.fn().mockResolvedValue([]) },
+    secrets: { resolve: vi.fn().mockResolvedValue("secret") },
+  } as unknown as PluginContext;
+}
+
+const config = { enableCommands: true, enableInbound: true } as Parameters<typeof handleUpdate>[2];
+const baseUrl = "http://localhost:3100";
+
+beforeEach(() => {
+  sentMessages = [];
+  editedMessages = [];
+  answeredCallbacks = [];
+  handleCommandCalls = [];
+  tryCustomCommandResult = false;
+  routeMessageToAgentResult = false;
+  routeMessageToAgentCalls = [];
+  fetchCalls = [];
+  handoffApprovalCalls = [];
+  handoffRejectionCalls = [];
+  handleMediaMessageCalls = [];
+  handleMediaMessageResult = false;
+  escalationRespondCalls = [];
+  global.fetch = vi.fn(async (url: string, init?: RequestInit) => {
+    fetchCalls.push({ url, init });
+    return { ok: true, json: async () => ({ ok: true }) } as Response;
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+describe("handleUpdate - command dispatch", () => {
+  it("routes a bot command to handleCommand with the resolved companyId", async () => {
+    const ctx = mockCtx();
+    const update = {
+      update_id: 1,
+      message: {
+        message_id: 1,
+        chat: { id: LINKED_CHAT_ID },
+        from: { id: 42 },
+        text: "/status",
+        entities: [{ type: "bot_command", offset: 0, length: 7 }],
+      },
+    } as Parameters<typeof handleUpdate>[3];
+
+    await handleUpdate(ctx, "token", config, update, baseUrl);
+
+    expect(handleCommandCalls).toHaveLength(1);
+    const [, , chatIdArg, commandArg, , , , , companyIdArg] = handleCommandCalls[0] as [
+      unknown, string, string, string, string, number | undefined, string, string, string,
+    ];
+    expect(chatIdArg).toBe(String(LINKED_CHAT_ID));
+    expect(commandArg).toBe("status");
+    expect(companyIdArg).toBe(COMPANY_ID);
+  });
+
+  it("gives custom commands precedence over built-in commands", async () => {
+    tryCustomCommandResult = true;
+    const ctx = mockCtx();
+    const update = {
+      update_id: 2,
+      message: {
+        message_id: 2,
+        chat: { id: LINKED_CHAT_ID },
+        from: { id: 42 },
+        text: "/mycustom",
+        entities: [{ type: "bot_command", offset: 0, length: 9 }],
+      },
+    } as Parameters<typeof handleUpdate>[3];
+
+    await handleUpdate(ctx, "token", config, update, baseUrl);
+
+    // handleCommand must NOT be called once a custom command has already handled it,
+    // otherwise the bot would answer the same command twice.
+    expect(handleCommandCalls).toHaveLength(0);
+  });
+
+  it("does not dispatch commands when enableCommands is false", async () => {
+    const ctx = mockCtx();
+    const disabledConfig = { ...config, enableCommands: false } as Parameters<typeof handleUpdate>[2];
+    const update = {
+      update_id: 3,
+      message: {
+        message_id: 3,
+        chat: { id: LINKED_CHAT_ID },
+        from: { id: 42 },
+        text: "/status",
+        entities: [{ type: "bot_command", offset: 0, length: 7 }],
+      },
+    } as Parameters<typeof handleUpdate>[3];
+
+    await handleUpdate(ctx, "token", disabledConfig, update, baseUrl);
+    expect(handleCommandCalls).toHaveLength(0);
+  });
+});
+
+describe("handleUpdate - thread message routing to agents", () => {
+  it("routes non-command thread text to an agent session when the chat is linked", async () => {
+    routeMessageToAgentResult = true;
+    const ctx = mockCtx();
+    const update = {
+      update_id: 4,
+      message: {
+        message_id: 4,
+        chat: { id: LINKED_CHAT_ID },
+        from: { id: 42 },
+        message_thread_id: 7,
+        text: "please continue",
+      },
+    } as Parameters<typeof handleUpdate>[3];
+
+    await handleUpdate(ctx, "token", config, update, baseUrl);
+
+    expect(routeMessageToAgentCalls).toHaveLength(1);
+  });
+
+  it("does not attempt agent routing for command text even inside a thread", async () => {
+    const ctx = mockCtx();
+    const update = {
+      update_id: 5,
+      message: {
+        message_id: 5,
+        chat: { id: LINKED_CHAT_ID },
+        from: { id: 42 },
+        message_thread_id: 7,
+        text: "/status",
+        entities: [{ type: "bot_command", offset: 0, length: 7 }],
+      },
+    } as Parameters<typeof handleUpdate>[3];
+
+    await handleUpdate(ctx, "token", config, update, baseUrl);
+    expect(routeMessageToAgentCalls).toHaveLength(0);
+  });
+});
+
+describe("handleUpdate - callback query dispatch", () => {
+  function callbackUpdate(data: string, updateId: number) {
+    return {
+      update_id: updateId,
+      callback_query: {
+        id: `cb-${updateId}`,
+        from: { id: 42, username: "alice" },
+        message: { message_id: 99, chat: { id: LINKED_CHAT_ID }, text: "Approval Requested" },
+        data,
+      },
+    } as Parameters<typeof handleUpdate>[3];
+  }
+
+  it("approves via the board API and edits the message on approve_", async () => {
+    const ctx = mockCtx();
+    await handleUpdate(ctx, "token", config, callbackUpdate("approve_apr-1", 10), baseUrl);
+
+    expect(fetchCalls.some((c) => c.url.includes("/api/approvals/apr-1/approve"))).toBe(true);
+    expect(answeredCallbacks.some((a) => a.text === "Approved")).toBe(true);
+    expect(editedMessages).toHaveLength(1);
+    expect(editedMessages[0].text).toContain("Approved");
+  });
+
+  it("rejects via the board API and edits the message on reject_", async () => {
+    const ctx = mockCtx();
+    await handleUpdate(ctx, "token", config, callbackUpdate("reject_apr-2", 11), baseUrl);
+
+    expect(fetchCalls.some((c) => c.url.includes("/api/approvals/apr-2/reject"))).toBe(true);
+    expect(answeredCallbacks.some((a) => a.text === "Rejected")).toBe(true);
+  });
+
+  it("answers with the failure reason when the approval API call fails, rather than throwing", async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500, text: async () => "boom" }) as unknown as typeof fetch;
+    const ctx = mockCtx();
+
+    await expect(
+      handleUpdate(ctx, "token", config, callbackUpdate("approve_apr-3", 12), baseUrl),
+    ).resolves.toBeUndefined();
+
+    expect(answeredCallbacks.some((a) => a.text?.startsWith("Failed"))).toBe(true);
+    // Must not have edited the message on failure — that would show a false "Approved" state.
+    expect(editedMessages).toHaveLength(0);
+  });
+
+  it("dispatches handoff_approve_ to handleHandoffApproval", async () => {
+    const ctx = mockCtx();
+    await handleUpdate(ctx, "token", config, callbackUpdate("handoff_approve_h1", 13), baseUrl);
+    expect(handoffApprovalCalls).toHaveLength(1);
+    expect(answeredCallbacks.some((a) => a.text === "Handoff approved")).toBe(true);
+  });
+
+  it("dispatches handoff_reject_ to handleHandoffRejection", async () => {
+    const ctx = mockCtx();
+    await handleUpdate(ctx, "token", config, callbackUpdate("handoff_reject_h2", 14), baseUrl);
+    expect(handoffRejectionCalls).toHaveLength(1);
+    expect(answeredCallbacks.some((a) => a.text === "Handoff rejected")).toBe(true);
+  });
+
+  it("answers Unknown action for unrecognized callback data instead of hanging silently", async () => {
+    const ctx = mockCtx();
+    await handleUpdate(ctx, "token", config, callbackUpdate("something_bogus", 15), baseUrl);
+    expect(answeredCallbacks.some((a) => a.text === "Unknown action")).toBe(true);
+  });
+});
+
+describe("handleUpdate - allowlist enforcement (regression: blocked updates must not reach any handler)", () => {
+  it("drops a message from a chat outside the allowlist without dispatching a command", async () => {
+    const ctx = mockCtx();
+    const restrictedConfig = {
+      ...config,
+      allowedTelegramChatIds: ["999999"],
+      allowedTelegramUserIds: [],
+    } as Parameters<typeof handleUpdate>[2];
+    const update = {
+      update_id: 20,
+      message: {
+        message_id: 20,
+        chat: { id: LINKED_CHAT_ID },
+        from: { id: 42 },
+        text: "/status",
+        entities: [{ type: "bot_command", offset: 0, length: 7 }],
+      },
+    } as Parameters<typeof handleUpdate>[3];
+
+    await handleUpdate(ctx, "token", restrictedConfig, update, baseUrl);
+    expect(handleCommandCalls).toHaveLength(0);
+    expect(ctx.logger.warn).toHaveBeenCalledWith(
+      "Blocked unauthorized Telegram update",
+      expect.anything(),
+    );
+  });
+});
+
+describe("handleUpdate - media message dispatch", () => {
+  function mediaUpdate(updateId: number, chatId: number) {
+    return {
+      update_id: updateId,
+      message: {
+        message_id: updateId,
+        chat: { id: chatId },
+        from: { id: 42 },
+        voice: { file_id: "f1", duration: 3 },
+      },
+    } as Parameters<typeof handleUpdate>[3];
+  }
+
+  it("dispatches to handleMediaMessage with the resolved companyId when the chat is linked", async () => {
+    const ctx = mockCtx();
+    await handleUpdate(ctx, "token", config, mediaUpdate(30, LINKED_CHAT_ID), baseUrl);
+
+    expect(handleMediaMessageCalls).toHaveLength(1);
+    const [, , , , companyIdArg] = handleMediaMessageCalls[0] as [unknown, unknown, unknown, unknown, string];
+    expect(companyIdArg).toBe(COMPANY_ID);
+  });
+
+  it("never calls handleMediaMessage for an unlinked chat (regression: must not spend transcription budget on unknown chats)", async () => {
+    const ctx = mockCtx();
+    const UNLINKED = 555;
+    await handleUpdate(ctx, "token", config, mediaUpdate(31, UNLINKED), baseUrl);
+
+    expect(handleMediaMessageCalls).toHaveLength(0);
+  });
+
+  it("falls through to text handling when handleMediaMessage reports it did not handle the message", async () => {
+    handleMediaMessageResult = false;
+    const ctx = mockCtx();
+    const update = mediaUpdate(32, LINKED_CHAT_ID);
+    // no text on this message, so falling through should simply return without dispatching a command
+    await handleUpdate(ctx, "token", config, update, baseUrl);
+    expect(handleMediaMessageCalls).toHaveLength(1);
+    expect(handleCommandCalls).toHaveLength(0);
+  });
+});
+
+describe("handleUpdate - bot-reply routing (inbound)", () => {
+  function replyUpdate(updateId: number, replyToId: number, text: string) {
+    return {
+      update_id: updateId,
+      message: {
+        message_id: updateId,
+        chat: { id: LINKED_CHAT_ID },
+        from: { id: 42, username: "alice" },
+        text,
+        reply_to_message: { message_id: replyToId, from: { is_bot: true } },
+      },
+    } as Parameters<typeof handleUpdate>[3];
+  }
+
+  it("routes a reply mapped to an escalation through EscalationManager.respond", async () => {
+    const ctx = mockCtx();
+    (ctx.state.get as ReturnType<typeof vi.fn>).mockImplementation(async (key: { stateKey: string }) => {
+      if (key.stateKey === `chat_${LINKED_CHAT_ID}`) return { companyId: COMPANY_ID };
+      if (key.stateKey === `msg_${LINKED_CHAT_ID}_500`) {
+        return { entityId: "esc-1", entityType: "escalation", companyId: COMPANY_ID };
+      }
+      return null;
+    });
+
+    await handleUpdate(ctx, "token", config, replyUpdate(40, 500, "here's my answer"), baseUrl);
+
+    expect(escalationRespondCalls).toHaveLength(1);
+    const [, , , payload] = escalationRespondCalls[0] as [unknown, unknown, unknown, { responseText: string }];
+    expect(payload.responseText).toBe("here's my answer");
+  });
+
+  it("routes a reply mapped to an issue through ctx.issues.createComment", async () => {
+    const ctx = mockCtx();
+    (ctx.issues as unknown as { createComment: ReturnType<typeof vi.fn> }).createComment = vi.fn().mockResolvedValue(undefined);
+    (ctx.state.get as ReturnType<typeof vi.fn>).mockImplementation(async (key: { stateKey: string }) => {
+      if (key.stateKey === `chat_${LINKED_CHAT_ID}`) return { companyId: COMPANY_ID };
+      if (key.stateKey === `msg_${LINKED_CHAT_ID}_501`) {
+        return { entityId: "issue-1", entityType: "issue", companyId: COMPANY_ID };
+      }
+      return null;
+    });
+
+    await handleUpdate(ctx, "token", config, replyUpdate(41, 501, "fixed in the latest commit"), baseUrl);
+
+    expect(ctx.issues.createComment).toHaveBeenCalledWith("issue-1", "fixed in the latest commit", COMPANY_ID);
+  });
+
+  it("does nothing (no throw) when the reply target has no mapping at all", async () => {
+    const ctx = mockCtx();
+    await expect(
+      handleUpdate(ctx, "token", config, replyUpdate(42, 999, "orphan reply"), baseUrl),
+    ).resolves.toBeUndefined();
+    expect(escalationRespondCalls).toHaveLength(0);
+  });
+
+  it("does not route replies when enableInbound is false", async () => {
+    const ctx = mockCtx();
+    (ctx.state.get as ReturnType<typeof vi.fn>).mockImplementation(async (key: { stateKey: string }) => {
+      if (key.stateKey === `chat_${LINKED_CHAT_ID}`) return { companyId: COMPANY_ID };
+      if (key.stateKey === `msg_${LINKED_CHAT_ID}_500`) {
+        return { entityId: "esc-1", entityType: "escalation", companyId: COMPANY_ID };
+      }
+      return null;
+    });
+    const disabledInbound = { ...config, enableInbound: false } as Parameters<typeof handleUpdate>[2];
+
+    await handleUpdate(ctx, "token", disabledInbound, replyUpdate(43, 500, "should not route"), baseUrl);
+    expect(escalationRespondCalls).toHaveLength(0);
+  });
+});

--- a/tests/worker-interaction-routing.test.ts
+++ b/tests/worker-interaction-routing.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { PluginContext } from "@paperclipai/plugin-sdk";
+
+let sentMessages: Array<{ chatId: string; text: string }> = [];
+let resolveCalls: unknown[][] = [];
+let finalizeCalls: unknown[][] = [];
+let stateStore: Record<string, unknown> = {};
+
+vi.mock("@paperclipai/plugin-sdk", async () => {
+  const actual = await vi.importActual("@paperclipai/plugin-sdk") as Record<string, unknown>;
+  return { ...actual, runWorker: vi.fn() };
+});
+
+vi.mock("../src/telegram-api.js", async () => {
+  const actual = await vi.importActual("../src/telegram-api.js") as Record<string, unknown>;
+  return {
+    ...actual,
+    sendMessage: vi.fn(async (_ctx: unknown, _token: string, chatId: string, text: string) => {
+      sentMessages.push({ chatId, text });
+      return 1;
+    }),
+    sendChatAction: vi.fn(),
+  };
+});
+
+vi.mock("../src/interaction-answers.js", async () => {
+  const actual = await vi.importActual("../src/interaction-answers.js") as Record<string, unknown>;
+  return {
+    ...actual,
+    resolveInteractionAnswerCallback: vi.fn(async (...args: unknown[]) => {
+      resolveCalls.push(args);
+      return true;
+    }),
+    finalizeReplyRejection: vi.fn(async (...args: unknown[]) => {
+      finalizeCalls.push(args);
+    }),
+  };
+});
+
+import { handleUpdate } from "../src/worker.js";
+
+// Mirrors ctx.state's real key shape ({scopeKind, scopeId, stateKey}) closely
+// enough for routing tests: keyed by scopeId+stateKey since the reply mapping
+// is written company-scoped.
+function mockCtx(): PluginContext {
+  return {
+    http: { fetch: vi.fn().mockResolvedValue({ json: () => Promise.resolve({ ok: true }) }) },
+    metrics: { write: vi.fn().mockResolvedValue(undefined) },
+    config: { get: vi.fn().mockResolvedValue({}) },
+    state: {
+      get: vi.fn(async (key: { stateKey: string; scopeId?: string }) => stateStore[`${key.scopeId ?? ""}:${key.stateKey}`] ?? null),
+      set: vi.fn(async (key: { stateKey: string; scopeId?: string }, value: unknown) => {
+        stateStore[`${key.scopeId ?? ""}:${key.stateKey}`] = value;
+      }),
+      delete: vi.fn(async (key: { stateKey: string; scopeId?: string }) => {
+        delete stateStore[`${key.scopeId ?? ""}:${key.stateKey}`];
+      }),
+    },
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    companies: { get: vi.fn().mockResolvedValue(null) },
+    issues: { list: vi.fn().mockResolvedValue([]), createComment: vi.fn() },
+  } as unknown as PluginContext;
+}
+
+const config = { enableCommands: true, enableInbound: true } as Parameters<typeof handleUpdate>[2];
+const baseUrl = "http://localhost:3100";
+
+beforeEach(() => {
+  sentMessages = [];
+  resolveCalls = [];
+  finalizeCalls = [];
+  stateStore = {};
+});
+
+describe("handleUpdate — interaction-answer callback routing", () => {
+  it("routes an int_-prefixed callback_query to resolveInteractionAnswerCallback", async () => {
+    const ctx = mockCtx();
+    const update = {
+      update_id: 1,
+      callback_query: {
+        id: "cbq-1",
+        from: { id: 1, username: "alice" },
+        message: { message_id: 5, chat: { id: 999 }, text: "Ship it?" },
+        data: "int_abc123_accept",
+      },
+    } as Parameters<typeof handleUpdate>[3];
+
+    await handleUpdate(ctx, "token", config, update, baseUrl);
+
+    expect(resolveCalls).toHaveLength(1);
+    const [, , data, callbackQueryId, , , messageId] = resolveCalls[0]!;
+    expect(data).toBe("int_abc123_accept");
+    expect(callbackQueryId).toBe("cbq-1");
+    expect(messageId).toBe(5);
+  });
+});
+
+describe("handleUpdate — reply-to-reject routing", () => {
+  it("routes a reply to a confirmation prompt to finalizeReplyRejection", async () => {
+    const ctx = mockCtx();
+    stateStore[":chat_777"] = { companyId: "co-1" };
+    stateStore["co-1:msg_777_42"] = {
+      entityId: "int-1",
+      entityType: "interaction_reject_reason",
+      companyId: "co-1",
+      issueId: "issue-1",
+    };
+
+    const update = {
+      update_id: 2,
+      message: {
+        message_id: 43,
+        chat: { id: 777 },
+        from: { id: 1, username: "alice" },
+        text: "not ready for prod",
+        reply_to_message: { message_id: 42, from: { is_bot: true } },
+      },
+    } as Parameters<typeof handleUpdate>[3];
+
+    await handleUpdate(ctx, "token", config, update, baseUrl);
+
+    expect(finalizeCalls).toHaveLength(1);
+    const [, , , , mapping, reasonText, chatId] = finalizeCalls[0]!;
+    expect(mapping).toMatchObject({ entityId: "int-1", issueId: "issue-1" });
+    expect(reasonText).toBe("not ready for prod");
+    expect(chatId).toBe("777");
+  });
+
+  it("does not treat a reply to an unrelated bot message as a rejection reason", async () => {
+    const ctx = mockCtx();
+    stateStore[":chat_778"] = { companyId: "co-1" };
+    stateStore["co-1:msg_778_42"] = { entityId: "issue-1", entityType: "issue", companyId: "co-1" };
+
+    const update = {
+      update_id: 3,
+      message: {
+        message_id: 43,
+        chat: { id: 778 },
+        from: { id: 1, username: "alice" },
+        text: "some comment",
+        reply_to_message: { message_id: 42, from: { is_bot: true } },
+      },
+    } as Parameters<typeof handleUpdate>[3];
+
+    await handleUpdate(ctx, "token", config, update, baseUrl);
+
+    expect(finalizeCalls).toHaveLength(0);
+    expect(ctx.issues.createComment).toHaveBeenCalledWith("issue-1", "some comment", "co-1");
+  });
+});

--- a/tests/worker-startup.test.ts
+++ b/tests/worker-startup.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PluginContext } from "@paperclipai/plugin-sdk";
+import {
+  BOARD_TOKEN_COMMANDS,
+  listCompaniesForStartup,
+  resolveBoardApiToken,
+} from "../src/worker.js";
+
+/**
+ * Regression tests for three fixes that shipped without one.
+ *
+ * All three failed the same way — silently. Nothing threw, nothing logged an
+ * error, and the user saw a plugin that looked connected and did nothing. That
+ * is precisely the failure a test has to hold down, because the next person to
+ * touch this code will get no signal from running it.
+ */
+
+function makeCtx(over: {
+  list?: () => Promise<Array<{ id: string }>>;
+  state?: unknown;
+  resolve?: (ref: unknown, opts: unknown) => Promise<string>;
+} = {}): PluginContext {
+  return {
+    companies: { list: over.list ?? (async () => []) },
+    state: { get: vi.fn(async () => over.state ?? null) },
+    secrets: {
+      resolve: over.resolve ?? vi.fn(async () => "resolved-token"),
+    },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  } as unknown as PluginContext;
+}
+
+describe("listCompaniesForStartup", () => {
+  it("uses companies.list when it returns companies", async () => {
+    const ctx = makeCtx({ list: async () => [{ id: "c1" }, { id: "c2" }] });
+    expect(await listCompaniesForStartup(ctx)).toEqual([{ id: "c1" }, { id: "c2" }]);
+  });
+
+  it("falls back to board-access state when companies.list returns EMPTY", async () => {
+    // The bug: an empty array is the normal result from setup() on a
+    // scope-enforcing host, not an error. Treating only a throw as failure left
+    // the runtime list empty, so long polling never started and every inbound
+    // feature was dead for the worker's life — with no error anywhere.
+    const ctx = makeCtx({ list: async () => [], state: { companyId: "c-fallback" } });
+
+    expect(await listCompaniesForStartup(ctx)).toEqual([{ id: "c-fallback" }]);
+  });
+
+  it("falls back to board-access state when companies.list throws", async () => {
+    const ctx = makeCtx({
+      list: async () => {
+        throw new Error("the worker referenced a missing, expired, or unknown invocation scope");
+      },
+      state: { companyId: "c-fallback" },
+    });
+
+    expect(await listCompaniesForStartup(ctx)).toEqual([{ id: "c-fallback" }]);
+  });
+
+  it("warns rather than returning a phantom company when there is no fallback", async () => {
+    const ctx = makeCtx({ list: async () => [], state: null });
+
+    expect(await listCompaniesForStartup(ctx)).toEqual([]);
+    expect(ctx.logger.warn).toHaveBeenCalled();
+  });
+
+  it("tolerates board-access state being unreadable", async () => {
+    const ctx = makeCtx({ list: async () => [] });
+    (ctx.state.get as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("no state"));
+
+    await expect(listCompaniesForStartup(ctx)).resolves.toEqual([]);
+  });
+});
+
+describe("BOARD_TOKEN_COMMANDS", () => {
+  // The coupling this guards: a command that hits a board-only endpoint but is
+  // missing from this set sends its request unauthenticated, and the user gets
+  // a bare 403 with nothing naming the cause. /decisions shipped that way.
+  it("includes every command whose handler needs the board token", () => {
+    expect(BOARD_TOKEN_COMMANDS.has("decisions")).toBe(true);
+    expect(BOARD_TOKEN_COMMANDS.has("approve")).toBe(true);
+  });
+
+  it("does not resolve a secret for commands that do not need one", () => {
+    // Deliberately on-demand: resolving a secret on every /help would be waste.
+    expect(BOARD_TOKEN_COMMANDS.has("help")).toBe(false);
+    expect(BOARD_TOKEN_COMMANDS.has("start")).toBe(false);
+    expect(BOARD_TOKEN_COMMANDS.has("status")).toBe(false);
+  });
+});
+
+describe("resolveBoardApiToken", () => {
+  const UUID = "11111111-2222-3333-4444-555555555555";
+
+  it("normalizes the bare UUID that board-access state persists", async () => {
+    // The bug: board access stores a bare UUID, but the host rejects anything
+    // other than {type:"secret_ref",secretId}. Passing it through unchanged
+    // surfaced as an unexplained 403 from whatever needed the token.
+    const resolve = vi.fn(async () => "board-token");
+    const ctx = makeCtx({ state: { paperclipBoardApiTokenRef: UUID }, resolve });
+
+    const token = await resolveBoardApiToken(ctx, {} as never, "c1");
+
+    expect(token).toBe("board-token");
+    expect(resolve).toHaveBeenCalledWith(
+      { type: "secret_ref", secretId: UUID },
+      expect.objectContaining({ companyId: "c1" }),
+    );
+  });
+
+  it("passes configPath for the config ref, because the binding is keyed on it", async () => {
+    const resolve = vi.fn(async () => "config-token");
+    const ctx = makeCtx({ state: null, resolve });
+
+    await resolveBoardApiToken(ctx, { paperclipBoardApiTokenRef: UUID } as never, "c1");
+
+    expect(resolve).toHaveBeenCalledWith(
+      { type: "secret_ref", secretId: UUID },
+      expect.objectContaining({ configPath: "paperclipBoardApiTokenRef" }),
+    );
+  });
+
+  it("falls through to the config ref when board-access state fails to resolve", async () => {
+    const other = "99999999-2222-3333-4444-555555555555";
+    const resolve = vi.fn(async (ref: unknown) => {
+      if ((ref as { secretId: string }).secretId === UUID) throw new Error("not bound");
+      return "config-token";
+    });
+    const ctx = makeCtx({ state: { paperclipBoardApiTokenRef: UUID }, resolve });
+
+    const token = await resolveBoardApiToken(
+      ctx,
+      { paperclipBoardApiTokenRef: other } as never,
+      "c1",
+    );
+
+    expect(token).toBe("config-token");
+  });
+
+  it("ignores board-access state belonging to a different company", async () => {
+    const resolve = vi.fn(async () => "board-token");
+    const ctx = makeCtx({
+      state: { paperclipBoardApiTokenRef: UUID, companyId: "c-other" },
+      resolve,
+    });
+
+    expect(await resolveBoardApiToken(ctx, {} as never, "c1")).toBeUndefined();
+    expect(resolve).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined rather than throwing when nothing resolves", async () => {
+    const ctx = makeCtx({ state: null });
+    expect(await resolveBoardApiToken(ctx, {} as never, "c1")).toBeUndefined();
+  });
+
+  it("skips a ref that is not a usable secret reference instead of calling resolve", async () => {
+    const resolve = vi.fn(async () => "never");
+    const ctx = makeCtx({ state: { paperclipBoardApiTokenRef: "not-a-uuid" }, resolve });
+
+    expect(await resolveBoardApiToken(ctx, {} as never, "c1")).toBeUndefined();
+    expect(resolve).not.toHaveBeenCalled();
+    expect(ctx.logger.warn).toHaveBeenCalled();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,22 +23,22 @@ export default defineConfig({
        * currently achieves, so the build fails when coverage DROPS — the
        * failure mode worth catching is a change that quietly ships untested.
        *
-       * The global number is still held down by `worker.ts` (33%) and
-       * `acp-bridge.ts` (71%), both large and still filling in. Raise these
-       * as that changes; do not lower them to make a red build green.
+       * The global number is still held down by `worker.ts` (33%), which is
+       * large and still filling in. Raise these as that changes; do not lower
+       * them to make a red build green.
        */
       thresholds: {
-        statements: 69,
+        statements: 70,
         branches: 76,
-        functions: 86,
-        lines: 69,
+        functions: 88,
+        lines: 70,
 
         // Modules where a regression is a user-visible failure, held higher.
         "src/decisions.ts": { statements: 98, functions: 100 },
         "src/telegram-api.ts": { statements: 88, functions: 88 },
         "src/secret-ref-validation.ts": { statements: 100, functions: 100 },
         "src/allowlist.ts": { statements: 100, functions: 100 },
-        "src/acp-bridge.ts": { statements: 70, functions: 80 },
+        "src/acp-bridge.ts": { statements: 75, functions: 90 },
         "src/adapter.ts": { statements: 100, functions: 100 },
       },
     },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,21 +23,23 @@ export default defineConfig({
        * currently achieves, so the build fails when coverage DROPS — the
        * failure mode worth catching is a change that quietly ships untested.
        *
-       * The global number is low because two large modules are largely
-       * untested (`worker.ts`, `acp-bridge.ts`). Raise these as that changes;
-       * do not lower them to make a red build green.
+       * Raised 53 -> 69 when the acp-bridge, adapter and handleUpdate suites
+       * landed (53.8% -> 70.1%). Raise them again as coverage improves; do not
+       * lower them to make a red build green.
        */
       thresholds: {
-        statements: 53,
-        branches: 74,
-        functions: 73,
-        lines: 53,
+        statements: 69,
+        branches: 76,
+        functions: 86,
+        lines: 69,
 
         // Modules where a regression is a user-visible failure, held higher.
         "src/decisions.ts": { statements: 95, functions: 80 },
         "src/telegram-api.ts": { statements: 85, functions: 85 },
         "src/secret-ref-validation.ts": { statements: 100, functions: 100 },
         "src/allowlist.ts": { statements: 100, functions: 100 },
+        "src/acp-bridge.ts": { statements: 70, functions: 80 },
+        "src/adapter.ts": { statements: 95, functions: 100 },
       },
     },
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,44 @@
+import { defineConfig } from "vitest/config";
+
+/**
+ * Coverage is measured against the modules a bug can actually hide in.
+ *
+ * `src/ui/**` is excluded because it is React rendered by the Paperclip host;
+ * there is no DOM harness here and asserting on it would measure JSX, not
+ * behaviour. `src/index.ts` and `src/manifest.ts` are declaration surfaces —
+ * they are re-exports and a literal, and covering them inflates the number
+ * without testing a decision.
+ */
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json-summary", "html"],
+      reportsDirectory: "./coverage",
+      include: ["src/**/*.ts"],
+      exclude: ["src/ui/**", "src/index.ts", "src/manifest.ts", "src/**/*.d.ts"],
+
+      /**
+       * A ratchet, not a target. These are set just under what the suite
+       * currently achieves, so the build fails when coverage DROPS — the
+       * failure mode worth catching is a change that quietly ships untested.
+       *
+       * The global number is low because two large modules are largely
+       * untested (`worker.ts`, `acp-bridge.ts`). Raise these as that changes;
+       * do not lower them to make a red build green.
+       */
+      thresholds: {
+        statements: 53,
+        branches: 74,
+        functions: 73,
+        lines: 53,
+
+        // Modules where a regression is a user-visible failure, held higher.
+        "src/decisions.ts": { statements: 95, functions: 80 },
+        "src/telegram-api.ts": { statements: 85, functions: 85 },
+        "src/secret-ref-validation.ts": { statements: 100, functions: 100 },
+        "src/allowlist.ts": { statements: 100, functions: 100 },
+      },
+    },
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,21 +23,22 @@ export default defineConfig({
        * currently achieves, so the build fails when coverage DROPS — the
        * failure mode worth catching is a change that quietly ships untested.
        *
-       * The global number is low because two large modules are largely
-       * untested (`worker.ts`, `acp-bridge.ts`). Raise these as that changes;
-       * do not lower them to make a red build green.
+       * The global number is still held down by `worker.ts` (33%) and
+       * `acp-bridge.ts` (71%), both large and still filling in. Raise these
+       * as that changes; do not lower them to make a red build green.
        */
       thresholds: {
-        statements: 53,
-        branches: 74,
-        functions: 73,
-        lines: 53,
+        statements: 69,
+        branches: 76,
+        functions: 86,
+        lines: 69,
 
         // Modules where a regression is a user-visible failure, held higher.
-        "src/decisions.ts": { statements: 95, functions: 80 },
-        "src/telegram-api.ts": { statements: 85, functions: 85 },
+        "src/decisions.ts": { statements: 98, functions: 100 },
+        "src/telegram-api.ts": { statements: 88, functions: 88 },
         "src/secret-ref-validation.ts": { statements: 100, functions: 100 },
         "src/allowlist.ts": { statements: 100, functions: 100 },
+        "src/adapter.ts": { statements: 100, functions: 100 },
       },
     },
   },


### PR DESCRIPTION
## Summary

Supersedes #79 with the missing-default regression fix added to the existing company-scoped startup fallback work.

## Fixes

- Preserve startup polling when `companies.list()` returns an empty array by falling back to the board-access company id.
- Use the current object-shaped secret-reference contract for scoped secret resolution.
- Apply `DEFAULT_CONFIG` before merging scoped config so omitted `enableCommands` and `enableInbound` values default to `true` instead of silently filtering every company out.

## Verification

- `npm test`: 32 files, 426 tests passed
- `npm run build`: passed
- Regression test covers omitted inbound/commands flags remaining enabled and pollable.
