### PR TITLE
fix: truthful /status and digest agent counts (finalize #81)

### DIFF
--- a/src/agent-status.ts
+++ b/src/agent-status.ts
@@ -1,0 +1,45 @@
+import type { Agent } from "@paperclipai/plugin-sdk";
+
+/**
+ * Agent counting for user-facing readouts (/status, daily digest).
+ *
+ * Availability is decided by a positive filter over the statuses that mean an
+ * agent can take work. The SDK union is
+ * `error | active | idle | paused | running | pending_approval | terminated`,
+ * so subtracting the unavailable ones from the total would count `terminated`
+ * and `pending_approval` agents as available. A positive filter also fails
+ * safe: a status added to the union later is reported as unavailable until
+ * someone decides otherwise, rather than silently inflating the count.
+ *
+ * `active` is a valid value in the union and shared's agent-eligibility treats
+ * it as live, but it is not observed on current hosts. It is counted as working
+ * so a host that does emit it reads correctly.
+ */
+
+export function isWorking(agent: Agent): boolean {
+  return agent.status === "running" || agent.status === "active";
+}
+
+export function isAvailable(agent: Agent): boolean {
+  return isWorking(agent) || agent.status === "idle";
+}
+
+export function isUnavailable(agent: Agent): boolean {
+  return agent.status === "paused" || agent.status === "error";
+}
+
+export type AgentCounts = {
+  total: number;
+  working: number;
+  available: number;
+  unavailable: number;
+};
+
+export function countAgents(agents: Agent[]): AgentCounts {
+  return {
+    total: agents.length,
+    working: agents.filter(isWorking).length,
+    available: agents.filter(isAvailable).length,
+    unavailable: agents.filter(isUnavailable).length,
+  };
+}

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -108,14 +108,23 @@ async function handleStatus(
   try {
     const companyId = resolvedCompanyId ?? await resolveCompanyId(ctx, chatId);
     const agents = await ctx.agents.list({ companyId });
-    const activeAgents = agents.filter((a: Agent) => a.status === "active");
+    // Agents report "running" or "idle" (and "paused"/"error" when unavailable).
+    // Counting `status === "active"` matched nothing, so this line always read
+    // "0/N" no matter how many agents were working.
+    const running = agents.filter((a: Agent) => a.status === "running" || a.status === "active");
+    const unavailable = agents.filter((a: Agent) => a.status === "paused" || a.status === "error");
     const issues = await ctx.issues.list({ companyId, limit: 10 });
     const doneIssues = issues.filter((i: Issue) => i.status === "done");
+
+    const agentLine =
+      `${escapeMarkdownV2("🤖")} Agents: *${running.length}* running, ` +
+      `*${escapeMarkdownV2(String(agents.length - unavailable.length))}* available` +
+      (unavailable.length > 0 ? escapeMarkdownV2(` (${unavailable.length} paused/error)`) : "");
 
     const lines = [
       escapeMarkdownV2("📊") + " *Paperclip Status*",
       "",
-      `${escapeMarkdownV2("🤖")} Active agents: *${activeAgents.length}*/${escapeMarkdownV2(String(agents.length))}`,
+      agentLine,
       `${escapeMarkdownV2("📋")} Recent issues: *${escapeMarkdownV2(String(issues.length))}* \\(${escapeMarkdownV2(String(doneIssues.length))} done\\)`,
     ];
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,6 +1,7 @@
 import type { PluginContext, PluginEvent, Agent, Issue, Project } from "@paperclipai/plugin-sdk";
 import { sendMessage, escapeMarkdownV2, sendChatAction } from "./telegram-api.js";
 import { METRIC_NAMES } from "./constants.js";
+import { countAgents } from "./agent-status.js";
 import { handleAcpCommand } from "./acp-bridge.js";
 import { buildPaperclipAuthHeaders, fetchPaperclipApi } from "./paperclip-api.js";
 
@@ -109,17 +110,16 @@ async function handleStatus(
     const companyId = resolvedCompanyId ?? await resolveCompanyId(ctx, chatId);
     const agents = await ctx.agents.list({ companyId });
     // Agents report "running" or "idle" (and "paused"/"error" when unavailable).
-    // Counting `status === "active"` matched nothing, so this line always read
-    // "0/N" no matter how many agents were working.
-    const running = agents.filter((a: Agent) => a.status === "running" || a.status === "active");
-    const unavailable = agents.filter((a: Agent) => a.status === "paused" || a.status === "error");
+    // Counting `status === "active"` matched nothing on current hosts, so this
+    // line always read "0/N" no matter how many agents were working.
+    const counts = countAgents(agents);
     const issues = await ctx.issues.list({ companyId, limit: 10 });
     const doneIssues = issues.filter((i: Issue) => i.status === "done");
 
     const agentLine =
-      `${escapeMarkdownV2("🤖")} Agents: *${running.length}* running, ` +
-      `*${escapeMarkdownV2(String(agents.length - unavailable.length))}* available` +
-      (unavailable.length > 0 ? escapeMarkdownV2(` (${unavailable.length} paused/error)`) : "");
+      `${escapeMarkdownV2("🤖")} Agents: *${counts.working}* running, ` +
+      `*${escapeMarkdownV2(String(counts.available))}* available` +
+      (counts.unavailable > 0 ? escapeMarkdownV2(` (${counts.unavailable} paused/error)`) : "");
 
     const lines = [
       escapeMarkdownV2("📊") + " *Paperclip Status*",

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -49,6 +49,7 @@ import type { EscalationEvent } from "./escalation.js";
 import { isTelegramUpdateAllowed, validateTelegramAllowlists } from "./allowlist.js";
 import { validateSecretRefFields } from "./secret-ref-validation.js";
 import { shouldNotifyApproval } from "./approval-routing.js";
+import { isWorking } from "./agent-status.js";
 import { buildPaperclipAuthHeaders, fetchPaperclipApi } from "./paperclip-api.js";
 import { resolveStartupTelegramBotToken, type TelegramRuntimeHealth } from "./runtime-token.js";
 
@@ -816,7 +817,9 @@ const plugin = definePlugin({
 
           try {
             const agents = await ctx.agents.list({ companyId: company.id });
-            const activeAgents = agents.filter((a: Agent) => a.status === "active");
+            // Same defect as /status had: `status === "active"` matched nothing on
+            // current hosts, so the digest always reported "0/N" active agents.
+            const workingAgents = agents.filter(isWorking);
             const issues = await ctx.issues.list({ companyId: company.id, limit: 50 });
 
             const now = Date.now();
@@ -841,12 +844,16 @@ const plugin = definePlugin({
               "",
               `${escapeMarkdownV2("\u2705")} Tasks completed: *${completedToday.length}*`,
               `${escapeMarkdownV2("\ud83d\udccb")} Tasks created: *${createdToday.length}*`,
-              `${escapeMarkdownV2("\ud83e\udd16")} Active agents: *${activeAgents.length}*/${escapeMarkdownV2(String(agents.length))}`,
+              `${escapeMarkdownV2("\ud83e\udd16")} Active agents: *${workingAgents.length}*/${escapeMarkdownV2(String(agents.length))}`,
             ];
 
-            if (activeAgents.length > 0) {
-              const topAgent = activeAgents[0]!.name;
-              lines.push(`${escapeMarkdownV2("\u2b50")} Top performer: *${escapeMarkdownV2(topAgent)}*`);
+            // The list is not ranked, so this names an agent that is working, not
+            // the best one. The old "Top performer" label was never seen because
+            // the filter above matched nothing; do not resurrect it as a claim
+            // the data cannot support.
+            if (workingAgents.length > 0) {
+              const workingAgent = workingAgents[0]!.name;
+              lines.push(`${escapeMarkdownV2("\u2b50")} Working: *${escapeMarkdownV2(workingAgent)}*`);
             }
 
             const formatIssueItem = (i: Issue) => {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -848,9 +848,9 @@ const plugin = definePlugin({
             ];
 
             // The list is not ranked, so this names an agent that is working, not
-            // the best one. The old "Top performer" label was never seen because
-            // the filter above matched nothing; do not resurrect it as a claim
-            // the data cannot support.
+            // the best one. The old "Top performer" label went unseen wherever the
+            // filter above found nothing; do not resurrect it as a claim the data
+            // cannot support.
             if (workingAgents.length > 0) {
               const workingAgent = workingAgents[0]!.name;
               lines.push(`${escapeMarkdownV2("\u2b50")} Working: *${escapeMarkdownV2(workingAgent)}*`);

--- a/tests/agent-status.test.ts
+++ b/tests/agent-status.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import type { Agent } from "@paperclipai/plugin-sdk";
+import { countAgents, isAvailable, isUnavailable, isWorking } from "../src/agent-status.js";
+
+function agent(status: string): Agent {
+  return { id: `a-${status}`, name: `Agent ${status}`, status } as Agent;
+}
+
+// The SDK union, so a status added later shows up here as a failing case
+// rather than silently inflating a user-facing count.
+const ALL_STATUSES = [
+  "error",
+  "active",
+  "idle",
+  "paused",
+  "running",
+  "pending_approval",
+  "terminated",
+];
+
+describe("agent status predicates", () => {
+  it("treats running and active as working", () => {
+    expect(ALL_STATUSES.filter((s) => isWorking(agent(s)))).toEqual(["active", "running"]);
+  });
+
+  it("treats working agents and idle ones as available", () => {
+    expect(ALL_STATUSES.filter((s) => isAvailable(agent(s)))).toEqual(["active", "idle", "running"]);
+  });
+
+  it("treats paused and error as unavailable", () => {
+    expect(ALL_STATUSES.filter((s) => isUnavailable(agent(s)))).toEqual(["error", "paused"]);
+  });
+
+  it("excludes terminated and pending_approval from availability", () => {
+    expect(isAvailable(agent("terminated"))).toBe(false);
+    expect(isAvailable(agent("pending_approval"))).toBe(false);
+  });
+
+  it("reports an unknown future status as unavailable rather than available", () => {
+    const unknown = agent("some_new_status_from_a_later_sdk");
+    expect(isWorking(unknown)).toBe(false);
+    expect(isAvailable(unknown)).toBe(false);
+  });
+});
+
+describe("countAgents", () => {
+  it("counts availability positively instead of subtracting paused/error", () => {
+    const counts = countAgents([
+      agent("running"),
+      agent("idle"),
+      agent("paused"),
+      agent("terminated"),
+      agent("pending_approval"),
+    ]);
+    expect(counts).toEqual({ total: 5, working: 1, available: 2, unavailable: 1 });
+  });
+
+  it("counts a working agent as available too", () => {
+    expect(countAgents([agent("running")])).toEqual({
+      total: 1,
+      working: 1,
+      available: 1,
+      unavailable: 0,
+    });
+  });
+
+  it("returns zeroes for an empty company", () => {
+    expect(countAgents([])).toEqual({ total: 0, working: 0, available: 0, unavailable: 0 });
+  });
+});

--- a/tests/status-agents.test.ts
+++ b/tests/status-agents.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { Agent, PluginContext } from "@paperclipai/plugin-sdk";
+
+const sent: string[] = [];
+
+vi.mock("../src/telegram-api.js", () => ({
+  sendMessage: vi.fn(async (_c: unknown, _t: string, _chat: string, text: string) => {
+    sent.push(text);
+    return { ok: true };
+  }),
+  sendChatAction: vi.fn(async () => ({ ok: true })),
+  escapeMarkdownV2: (s: string) => s,
+}));
+
+const { handleCommand } = await import("../src/commands.js");
+
+function agent(status: string): Agent {
+  return { id: `a-${status}-${Math.random()}`, name: `Agent ${status}`, status } as Agent;
+}
+
+function makeCtx(agents: Agent[]): PluginContext {
+  return {
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    metrics: { write: vi.fn(async () => undefined) },
+    agents: { list: vi.fn(async () => agents) },
+    issues: { list: vi.fn(async () => []) },
+    state: { get: vi.fn(async () => null), set: vi.fn(async () => undefined) },
+  } as unknown as PluginContext;
+}
+
+describe("/status agent counts", () => {
+  beforeEach(() => {
+    sent.length = 0;
+  });
+
+  it("counts running agents — the old filter looked for a status that never occurs", async () => {
+    // Agents report "running"/"idle"; nothing is ever "active", so the previous
+    // `status === "active"` filter reported 0 while agents were working.
+    const ctx = makeCtx([agent("running"), agent("idle"), agent("idle")]);
+    await handleCommand(ctx, "tok", "chat-1", "status", "", undefined, undefined, undefined, "company-1");
+    expect(sent.at(-1)).toContain("1* running");
+  });
+
+  it("still counts a legacy 'active' status as running", async () => {
+    const ctx = makeCtx([agent("active"), agent("idle")]);
+    await handleCommand(ctx, "tok", "chat-1", "status", "", undefined, undefined, undefined, "company-1");
+    expect(sent.at(-1)).toContain("1* running");
+  });
+
+  it("reports availability separately from running, and flags paused/error", async () => {
+    const ctx = makeCtx([agent("running"), agent("idle"), agent("paused"), agent("error")]);
+    await handleCommand(ctx, "tok", "chat-1", "status", "", undefined, undefined, undefined, "company-1");
+    const text = sent.at(-1)!;
+    expect(text).toContain("1* running");
+    expect(text).toContain("2* available");
+    expect(text).toContain("2 paused/error");
+  });
+
+  it("omits the paused/error note when everything is healthy", async () => {
+    const ctx = makeCtx([agent("idle"), agent("idle")]);
+    await handleCommand(ctx, "tok", "chat-1", "status", "", undefined, undefined, undefined, "company-1");
+    expect(sent.at(-1)).not.toContain("paused/error");
+  });
+});

--- a/tests/status-agents.test.ts
+++ b/tests/status-agents.test.ts
@@ -33,15 +33,16 @@ describe("/status agent counts", () => {
     sent.length = 0;
   });
 
-  it("counts running agents — the old filter looked for a status that never occurs", async () => {
-    // Agents report "running"/"idle"; nothing is ever "active", so the previous
-    // `status === "active"` filter reported 0 while agents were working.
+  it("counts running agents — the old filter looked for a status current hosts do not emit", async () => {
+    // Agents report "running"/"idle"; "active" is not observed on current hosts,
+    // so the previous `status === "active"` filter reported 0 while agents were
+    // working.
     const ctx = makeCtx([agent("running"), agent("idle"), agent("idle")]);
     await handleCommand(ctx, "tok", "chat-1", "status", "", undefined, undefined, undefined, "company-1");
     expect(sent.at(-1)).toContain("1* running");
   });
 
-  it("still counts a legacy 'active' status as running", async () => {
+  it("still counts an 'active' status as running, in case a host emits it", async () => {
     const ctx = makeCtx([agent("active"), agent("idle")]);
     await handleCommand(ctx, "tok", "chat-1", "status", "", undefined, undefined, undefined, "company-1");
     expect(sent.at(-1)).toContain("1* running");
@@ -54,6 +55,28 @@ describe("/status agent counts", () => {
     expect(text).toContain("1* running");
     expect(text).toContain("2* available");
     expect(text).toContain("2 paused/error");
+  });
+
+  it("does not count terminated or pending_approval agents as available", async () => {
+    // Subtracting paused/error from the total counted these two as available.
+    const ctx = makeCtx([
+      agent("running"),
+      agent("idle"),
+      agent("terminated"),
+      agent("pending_approval"),
+    ]);
+    await handleCommand(ctx, "tok", "chat-1", "status", "", undefined, undefined, undefined, "company-1");
+    const text = sent.at(-1)!;
+    expect(text).toContain("1* running");
+    expect(text).toContain("2* available");
+    expect(text).not.toContain("4* available");
+    expect(text).not.toContain("paused/error");
+  });
+
+  it("counts availability positively, so an unknown future status is not available", async () => {
+    const ctx = makeCtx([agent("idle"), agent("some_new_status_from_a_later_sdk")]);
+    await handleCommand(ctx, "tok", "chat-1", "status", "", undefined, undefined, undefined, "company-1");
+    expect(sent.at(-1)).toContain("1* available");
   });
 
   it("omits the paused/error note when everything is healthy", async () => {


### PR DESCRIPTION
Finalizes #81. @vveliev's commit is preserved at the base of this branch, rebased onto current `main` — this supersedes the PR without losing their authorship.

### What @vveliev's commit brings

`/status` always reported `Active agents: 0/N`. It filtered on `status === "active"`, but agents report `running` or `idle`, so the count was structurally zero regardless of what the company was doing — observed live as `0/21` with an agent mid-run. A count that is always zero is worse than a missing one: it reads as a working readout of an idle company.

The readout now reports running and available separately, and mentions paused/error only when there are any:

```
🤖 Agents: 1 running, 21 available
🤖 Agents: 1 running, 2 available (2 paused/error)
```

### What this finalize adds

**1. Positive availability filter** (review ask 1). `available = agents.length - unavailable.length` subtracted only `paused` and `error`, so `terminated` and `pending_approval` agents were still counted as available — the same class of wrong readout the PR set out to fix. Availability is now decided positively over `idle | running | active`, which also fails safe: a status added to the SDK union later reads as unavailable rather than silently inflating the count.

The counting moved to `src/agent-status.ts` so `/status` and the digest share one definition.

**2. Comment wording** (review ask 2). `"active"` is a valid value in the SDK union and `@paperclipai/shared`'s agent-eligibility treats it as live, so the comments and tests now say it is **not observed on current hosts** rather than that it never occurs. The defensive `|| status === "active"` stays.

**3. Digest carried the same dead filter** (found while verifying #86). `src/worker.ts` had `agents.filter((a) => a.status === "active")` in the daily digest job, so every digest reported `Active agents: 0/N` too. It now counts through the same shared predicate.

⚠️ **Output change worth a look:** fixing that filter wakes up the `⭐ Top performer` line, which has never actually been seen because the filter always returned empty. The agent list is not ranked — that line names whichever working agent comes first — so it is relabelled `⭐ Working:` rather than shipped as a ranking the data cannot support.

### Verification

`npm ci && npm run typecheck && npm test && npm run build` — all exit 0. Tests 235 on `main` → **249** on this branch: +4 from @vveliev's `tests/status-agents.test.ts`, +10 from this finalize (2 more `/status` cases covering `terminated`/`pending_approval` and an unknown future status, plus 8 in the new `tests/agent-status.test.ts`).

The digest job is registered inside `definePlugin`'s `setup()` and gated on the wall clock, so it is not reachable without heavy scaffolding; the counting logic it now depends on is covered directly in `tests/agent-status.test.ts`.

---
<sub><em>**[@superbiche](https://github.com/superbiche)** · co-maintainer · drafted with Claude Fable 5.</em></sub>
