### PR TITLE
fix(config): accept object-shaped secret refs; normalize board API token ref before resolving

### DIFF
--- a/src/secret-ref-validation.ts
+++ b/src/secret-ref-validation.ts
@@ -12,12 +12,31 @@ const FIELDS = [
   { key: "transcriptionApiKeyRef", required: false },
 ] as const;
 
-export function isValidSecretRef(value: unknown): value is string {
-  return typeof value === "string" && UUID_RE.test(value.trim());
+/**
+ * A secret reference, in either shape a Paperclip host may use.
+ *
+ * Older hosts take a bare secret UUID string. Current hosts require an object
+ * `{ type: "secret_ref", secretId, version? }` and reject the bare string, so
+ * both must be accepted or the plugin is unconfigurable on one of them.
+ */
+export type SecretRef = string | { type: "secret_ref"; secretId: string; version?: number };
+
+export function isValidSecretRef(value: unknown): value is SecretRef {
+  if (typeof value === "string") return UUID_RE.test(value.trim());
+  if (typeof value === "object" && value !== null) {
+    const record = value as { type?: unknown; secretId?: unknown };
+    return (
+      record.type === "secret_ref" &&
+      typeof record.secretId === "string" &&
+      UUID_RE.test(record.secretId.trim())
+    );
+  }
+  return false;
 }
 
 function describeBadValue(value: unknown): string {
   if (value === undefined || value === null) return "<empty>";
+  if (typeof value === "object") return "<object>";
   if (typeof value !== "string") return `<${typeof value}>`;
   const trimmed = value.trim();
   if (trimmed.length === 0) return "<empty string>";

--- a/src/secret-ref-validation.ts
+++ b/src/secret-ref-validation.ts
@@ -34,6 +34,29 @@ export function isValidSecretRef(value: unknown): value is SecretRef {
   return false;
 }
 
+/**
+ * Coerce a secret ref into the shape THIS host accepts before calling
+ * ctx.secrets.resolve().
+ *
+ * Refs reach us in both shapes: config validated by a current host holds
+ * `{ type: "secret_ref", secretId }`, while refs persisted earlier — notably
+ * the board-access state written by the Board Access panel — hold a bare UUID
+ * string. Hosts that require the object form reject the bare string with
+ * "Invalid secret reference for plugin: <uuid>. Use { type: "secret_ref" ... }",
+ * which surfaces to the user as an unexplained 403 from whatever the token was
+ * needed for.
+ *
+ * Passing the object through unchanged keeps older hosts working, since they
+ * accept it as an opaque ref.
+ */
+export function normalizeSecretRef(value: unknown): SecretRef | null {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return UUID_RE.test(trimmed) ? { type: "secret_ref", secretId: trimmed } : null;
+  }
+  return isValidSecretRef(value) ? value : null;
+}
+
 function describeBadValue(value: unknown): string {
   if (value === undefined || value === null) return "<empty>";
   if (typeof value === "object") return "<object>";

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -47,7 +47,7 @@ import { AGENT_ERROR_DEDUPLICATION_WINDOW_MS, METRIC_NAMES } from "./constants.j
 import { EscalationManager } from "./escalation.js";
 import type { EscalationEvent } from "./escalation.js";
 import { isTelegramUpdateAllowed, validateTelegramAllowlists } from "./allowlist.js";
-import { validateSecretRefFields } from "./secret-ref-validation.js";
+import { validateSecretRefFields, normalizeSecretRef } from "./secret-ref-validation.js";
 import { shouldNotifyApproval } from "./approval-routing.js";
 import { isWorking } from "./agent-status.js";
 import { buildPaperclipAuthHeaders, fetchPaperclipApi } from "./paperclip-api.js";
@@ -223,7 +223,17 @@ async function resolveBoardApiToken(
     if (seen.has(candidate.ref)) continue;
     seen.add(candidate.ref);
     try {
-      return await ctx.secrets.resolve(candidate.ref);
+      // The board-access state persists a bare UUID, which hosts requiring the
+      // object form reject outright — surfacing to the user as an unexplained
+      // 403 from whatever needed the token.
+      const ref = normalizeSecretRef(candidate.ref);
+      if (!ref) {
+        ctx.logger.warn("Board API token ref is not a usable secret reference", {
+          source: candidate.source,
+        });
+        continue;
+      }
+      return await ctx.secrets.resolve(ref);
     } catch (err) {
       ctx.logger.warn("Failed to resolve board API token secret", {
         source: candidate.source,

--- a/tests/secret-ref-validation.test.ts
+++ b/tests/secret-ref-validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isValidSecretRef, validateSecretRefFields } from "../src/secret-ref-validation.js";
+import { isValidSecretRef, validateSecretRefFields, normalizeSecretRef } from "../src/secret-ref-validation.js";
 
 const VALID_UUID = "12f7ed4a-1234-4d0c-9abc-bd58d44d15e1";
 const VALID_UUID_2 = "abcdef01-2345-6789-abcd-ef0123456789";
@@ -118,5 +118,26 @@ describe("validateSecretRefFields", () => {
         paperclipBoardApiTokenRef: { type: "secret_ref", secretId: VALID_UUID_2, version: 1 },
       }),
     ).toEqual([]);
+  });
+});
+
+describe("normalizeSecretRef", () => {
+  it("wraps a bare UUID into the object form the host requires", () => {
+    expect(normalizeSecretRef("11111111-2222-4333-8444-555555555555")).toEqual({
+      type: "secret_ref",
+      secretId: "11111111-2222-4333-8444-555555555555",
+    });
+  });
+
+  it("passes an already-correct object through unchanged", () => {
+    const ref = { type: "secret_ref", secretId: "11111111-2222-4333-8444-555555555555" };
+    expect(normalizeSecretRef(ref)).toBe(ref);
+  });
+
+  it("rejects values that are not usable refs", () => {
+    expect(normalizeSecretRef("not-a-uuid")).toBeNull();
+    expect(normalizeSecretRef("")).toBeNull();
+    expect(normalizeSecretRef(null)).toBeNull();
+    expect(normalizeSecretRef({ type: "other", secretId: "x" })).toBeNull();
   });
 });

--- a/tests/secret-ref-validation.test.ts
+++ b/tests/secret-ref-validation.test.ts
@@ -30,6 +30,22 @@ describe("isValidSecretRef", () => {
     expect(isValidSecretRef("12f7ed4a-1234-4d0c-9abc-bd58d44d15e")).toBe(false);
     expect(isValidSecretRef("12f7ed4a12344d0c9abcbd58d44d15e1")).toBe(false);
   });
+
+  it("accepts the object shape current hosts resolve secret refs to", () => {
+    expect(isValidSecretRef({ type: "secret_ref", secretId: VALID_UUID })).toBe(true);
+  });
+
+  it("accepts the object shape with an optional version", () => {
+    expect(isValidSecretRef({ type: "secret_ref", secretId: VALID_UUID, version: 3 })).toBe(true);
+  });
+
+  it("rejects object shapes missing the secret_ref discriminant or a valid secretId", () => {
+    expect(isValidSecretRef({ secretId: VALID_UUID })).toBe(false);
+    expect(isValidSecretRef({ type: "other", secretId: VALID_UUID })).toBe(false);
+    expect(isValidSecretRef({ type: "secret_ref", secretId: "not-a-uuid" })).toBe(false);
+    expect(isValidSecretRef({ type: "secret_ref" })).toBe(false);
+    expect(isValidSecretRef(null)).toBe(false);
+  });
 });
 
 describe("validateSecretRefFields", () => {
@@ -93,5 +109,14 @@ describe("validateSecretRefFields", () => {
       telegramBotTokenRef: { id: VALID_UUID } as unknown as string,
     });
     expect(errors[0]).toContain("<object>");
+  });
+
+  it("returns no errors when the host resolves refs to the secret_ref object shape", () => {
+    expect(
+      validateSecretRefFields({
+        telegramBotTokenRef: { type: "secret_ref", secretId: VALID_UUID },
+        paperclipBoardApiTokenRef: { type: "secret_ref", secretId: VALID_UUID_2, version: 1 },
+      }),
+    ).toEqual([]);
   });
 });


### PR DESCRIPTION
## Problem

Two related secret-ref shape bugs:

1. `instanceConfigSchema` declares the three secret-ref fields as `type: "string"`, but current Paperclip hosts reject anything that isn't `{ type: "secret_ref", secretId, version? }`. No value satisfies both the plugin's own schema and the host's validator — the bot token is unresolvable at startup even when the secret is correct, and the plugin silently does nothing.
2. Board access persists its token ref as a bare UUID string, but the host's resolver only accepts the object form. `ctx.secrets.resolve()` rejects it with "Invalid secret reference for plugin: <uuid>", surfaced to the caller as a bare 403 — while the Board Access panel still reports "Connected", since writing the ref succeeded and only using it fails.

## Fix

- Ref fields now accept `type: ["string", "object"]`, and `isValidSecretRef` accepts either shape.
- `normalizeSecretRef()` converts either accepted shape into the object form at the point of use, so validation and resolution agree. A value that's neither a UUID nor a well-formed ref returns null and is logged/skipped rather than handed to the host to reject.

## Testing

256/256 tests passing, typecheck clean.