### PR TITLE
fix(acp): stop using the Telegram chat id as a Paperclip company id

### DIFF
--- a/src/acp-bridge.ts
+++ b/src/acp-bridge.ts
@@ -76,7 +76,10 @@ export function setupAcpOutputListener(
 ): void {
   ctx.events.on(ACP_OUTPUT_EVENT, async (event) => {
     const payload = event.payload as AcpOutputEvent;
-    await handleAcpOutput(ctx, token, payload);
+    // The envelope's companyId is the host's own; it is already trusted enough
+    // to resolve the bot token. Passing it on keeps the discussion loop from
+    // re-deriving the company from chat state, which is guesswork by comparison.
+    await handleAcpOutput(ctx, token, payload, event.companyId);
   });
 }
 
@@ -277,6 +280,10 @@ async function handleAcpSpawn(
   const trimmedName = agentName.trim();
   const displayName = trimmedName.charAt(0).toUpperCase() + trimmedName.slice(1);
   const resolvedCompanyId = companyId ?? await resolveCompanyIdFromChat(ctx, chatId);
+  if (!resolvedCompanyId) {
+    await sendMessage(ctx, token, chatId, NOT_LINKED_MESSAGE, { messageThreadId });
+    return;
+  }
 
   // Try native session first: resolve agent by name, then create session
   let transport: "native" | "acp" = "acp";
@@ -437,6 +444,10 @@ async function handleAcpCancel(
   )[0]!;
 
   const resolvedCompanyId = companyId ?? await resolveCompanyIdFromChat(ctx, chatId);
+  if (!resolvedCompanyId) {
+    await sendMessage(ctx, token, chatId, NOT_LINKED_MESSAGE, { messageThreadId });
+    return;
+  }
 
   if (target.transport === "native") {
     try {
@@ -517,6 +528,10 @@ async function handleAcpClose(
   }
 
   const resolvedCompanyId = companyId ?? await resolveCompanyIdFromChat(ctx, chatId);
+  if (!resolvedCompanyId) {
+    await sendMessage(ctx, token, chatId, NOT_LINKED_MESSAGE, { messageThreadId });
+    return;
+  }
 
   // Close via the correct transport
   if (targetSession.transport === "native") {
@@ -618,6 +633,12 @@ export async function routeMessageToAgent(
   await saveSessions(ctx, chatId, threadId, sessions);
 
   const resolvedCompanyId = companyId ?? await resolveCompanyIdFromChat(ctx, chatId);
+  if (!resolvedCompanyId) {
+    // Handled: the message was addressed to a live session, so staying silent
+    // here would look like the agent simply ignored it.
+    await sendMessage(ctx, token, chatId, NOT_LINKED_MESSAGE, { messageThreadId: threadId });
+    return true;
+  }
   const projectId = await resolveMappedProjectIdForTopic(ctx, chatId, resolvedCompanyId, threadId);
 
   // Route via correct transport
@@ -665,6 +686,7 @@ export async function handleAcpOutput(
   ctx: PluginContext,
   token: string,
   event: AcpOutputEvent,
+  companyId?: string,
 ): Promise<void> {
   const { sessionId, chatId, threadId, text, done } = event;
 
@@ -696,7 +718,7 @@ export async function handleAcpOutput(
   }
 
   await sendLabeledOutput(ctx, token, chatId, threadId, sessionId, displayName, text, done);
-  await checkConversationLoopContinuation(ctx, token, chatId, threadId, sessionId, text, done);
+  await checkConversationLoopContinuation(ctx, token, chatId, threadId, sessionId, text, done, companyId);
 }
 
 // --- Output sequencing ---
@@ -1276,6 +1298,7 @@ async function checkConversationLoopContinuation(
   sessionId: string,
   text: string,
   done?: boolean,
+  companyId?: string,
 ): Promise<void> {
   const loop = await ctx.state.get({
     scopeKind: "instance",
@@ -1355,7 +1378,25 @@ async function checkConversationLoopContinuation(
     const nextSession = sessions.find((s) => s.sessionId === nextSessionId);
 
     if (nextSession) {
-      const resolvedCompanyId = await resolveCompanyIdFromChat(ctx, chatId);
+      const resolvedCompanyId = companyId ?? await resolveCompanyIdFromChat(ctx, chatId);
+      if (!resolvedCompanyId) {
+        // Pausing beats continuing: this runs once per turn, so an unresolved
+        // company would otherwise be re-spent on every remaining turn of the
+        // discussion, each failing the same way and none of it visible.
+        loop.status = "paused";
+        await ctx.state.set(
+          { scopeKind: "instance", stateKey: `loop_${chatId}_${threadId}` },
+          loop,
+        );
+        await sendMessage(
+          ctx,
+          token,
+          chatId,
+          `${escapeMarkdownV2("⚠️")} *Discussion Paused* \\- ${escapeMarkdownV2("this chat is not linked to a Paperclip company. Use /connect, then send a message to resume.")}`,
+          { parseMode: "MarkdownV2", messageThreadId: threadId },
+        );
+        return;
+      }
 
       if (nextSession.transport === "native") {
         await wakeAgentWithIssue(
@@ -1404,13 +1445,30 @@ async function saveSessions(
   );
 }
 
-async function resolveCompanyIdFromChat(ctx: PluginContext, chatId: string): Promise<string> {
+/**
+ * The company this chat is linked to, or null when it is linked to nothing.
+ *
+ * This used to fall back to the raw `chatId`, which is a Telegram identifier
+ * and never a Paperclip company id. Every caller then spent that fake id on a
+ * host call that could only fail, and because nothing here throws or logs, an
+ * unlinked chat looked exactly like a working one. The discussion loop made it
+ * worse: it re-resolved per turn, so one unlinked chat produced a fake id on
+ * every turn of an agent-to-agent conversation.
+ *
+ * Returning null forces each caller to say why it stopped. `companyName` stays
+ * as a fallback because worker.ts and commands.ts both accept it for chats
+ * linked by older versions; unlike chatId it is at least a company reference.
+ */
+async function resolveCompanyIdFromChat(ctx: PluginContext, chatId: string): Promise<string | null> {
   const mapping = await ctx.state.get({
     scopeKind: "instance",
     stateKey: `chat_${chatId}`,
   }) as { companyId?: string; companyName?: string } | null;
-  return mapping?.companyId ?? mapping?.companyName ?? chatId;
+  return mapping?.companyId ?? mapping?.companyName ?? null;
 }
+
+/** What every call site says when the chat turns out not to be linked. */
+const NOT_LINKED_MESSAGE = "This chat is not linked to a Paperclip company. Use /connect first.";
 
 function simpleHash(text: string): string {
   let hash = 0;

--- a/tests/acp-bridge-company-resolution.test.ts
+++ b/tests/acp-bridge-company-resolution.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { PluginContext } from "@paperclipai/plugin-sdk";
+import { handleAcpOutput, routeMessageToAgent } from "../src/acp-bridge.js";
+import { ACP_SPAWN_EVENT } from "../src/constants.js";
+
+/**
+ * BLA-162: the bridge used to resolve an unlinked chat's company id to the raw
+ * Telegram `chatId`. Nothing threw and nothing logged, so the failure surfaced
+ * only as host calls that could never succeed — and the discussion loop
+ * re-resolved once per turn, spending a fake id on every remaining turn.
+ *
+ * The invariant these tests hold: a Telegram chat id is NEVER used as a
+ * Paperclip company id, and a chat that cannot be resolved says so.
+ */
+
+let sentMessages: Array<{ chatId: string; text: string; options?: Record<string, unknown> }> = [];
+let stateStore: Record<string, unknown> = {};
+
+vi.mock("../src/telegram-api.js", async () => {
+  const actual = await vi.importActual("../src/telegram-api.js") as Record<string, unknown>;
+  return {
+    ...actual,
+    sendMessage: vi.fn(async (_ctx: unknown, _token: string, chatId: string, text: string, options?: Record<string, unknown>) => {
+      sentMessages.push({ chatId, text, options });
+      return 100;
+    }),
+    sendChatAction: vi.fn(async () => undefined),
+  };
+});
+
+function mockCtx(): PluginContext {
+  return {
+    state: {
+      get: vi.fn(async (key: { stateKey: string }) => stateStore[key.stateKey] ?? null),
+      set: vi.fn(async (key: { stateKey: string }, value: unknown) => {
+        stateStore[key.stateKey] = value;
+      }),
+    },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    events: { emit: vi.fn(), on: vi.fn() },
+  } as unknown as PluginContext;
+}
+
+function acpSession(sessionId: string, name: string) {
+  return {
+    sessionId,
+    agentId: `agent-${sessionId}`,
+    agentName: name,
+    agentDisplayName: name,
+    transport: "acp",
+    spawnedAt: "2026-01-01T00:00:00Z",
+    status: "active",
+    lastActivityAt: "2026-01-01T00:00:00Z",
+  };
+}
+
+/** Two ACP sessions mid-discussion, the shape that made this bug expensive. */
+function seedLoop() {
+  stateStore["sessions_chat-1_42"] = [acpSession("s1", "Builder"), acpSession("s2", "Reviewer")];
+  stateStore["loop_chat-1_42"] = {
+    loopId: "loop-1",
+    initiatorSessionId: "s1",
+    targetSessionId: "s2",
+    initiatorAgent: "Builder",
+    targetAgent: "Reviewer",
+    topic: "schema",
+    maxTurns: 6,
+    currentTurn: 0,
+    lastOutputHash: null,
+    previousOutputHash: null,
+    status: "active",
+    chatId: "chat-1",
+    threadId: 42,
+  };
+}
+
+const outputEvent = { sessionId: "s1", chatId: "chat-1", threadId: 42, text: "your turn", done: false };
+
+/** The company id every ACP_SPAWN_EVENT was emitted with. */
+function emittedCompanyIds(ctx: PluginContext): unknown[] {
+  return (ctx.events.emit as unknown as { mock: { calls: unknown[][] } }).mock.calls
+    .filter((c) => c[0] === ACP_SPAWN_EVENT)
+    .map((c) => c[1]);
+}
+
+beforeEach(() => {
+  sentMessages = [];
+  stateStore = {};
+});
+
+describe("discussion loop company resolution", () => {
+  it("routes the next turn with the company id the host put on the event", async () => {
+    seedLoop();
+    // A stale chat mapping is deliberately present and different: the envelope
+    // is the host's own value and must win over anything cached in chat state.
+    stateStore["chat_chat-1"] = { companyId: "stale-company" };
+    const ctx = mockCtx();
+
+    await handleAcpOutput(ctx, "token", outputEvent, "company-from-host");
+
+    expect(emittedCompanyIds(ctx)).toEqual(["company-from-host"]);
+  });
+
+  it("falls back to the chat's linked company when the event carries none", async () => {
+    seedLoop();
+    stateStore["chat_chat-1"] = { companyId: "linked-company" };
+    const ctx = mockCtx();
+
+    await handleAcpOutput(ctx, "token", outputEvent);
+
+    expect(emittedCompanyIds(ctx)).toEqual(["linked-company"]);
+  });
+
+  it("never spends the Telegram chat id as a company id", async () => {
+    // The regression itself. An unlinked chat used to resolve to "chat-1",
+    // which is a Telegram identifier and cannot address any company.
+    seedLoop();
+    const ctx = mockCtx();
+
+    await handleAcpOutput(ctx, "token", outputEvent);
+
+    expect(emittedCompanyIds(ctx)).not.toContain("chat-1");
+  });
+
+  it("pauses the discussion instead of continuing it with an unresolved company", async () => {
+    seedLoop();
+    const ctx = mockCtx();
+
+    await handleAcpOutput(ctx, "token", outputEvent);
+
+    expect(emittedCompanyIds(ctx)).toHaveLength(0);
+    expect((stateStore["loop_chat-1_42"] as { status: string }).status).toBe("paused");
+  });
+
+  it("says why the discussion stopped rather than going quiet", async () => {
+    // Silence here is indistinguishable from the agent having nothing to say.
+    seedLoop();
+    const ctx = mockCtx();
+
+    await handleAcpOutput(ctx, "token", outputEvent);
+
+    const paused = sentMessages.find((m) => m.text.includes("Paused"));
+    expect(paused).toBeDefined();
+    expect(paused!.text).toContain("/connect");
+  });
+
+  it("still routes normally once the chat is linked", async () => {
+    // Guards against "fix" by disabling the feature: the happy path must work.
+    seedLoop();
+    stateStore["chat_chat-1"] = { companyId: "linked-company" };
+    const ctx = mockCtx();
+
+    await handleAcpOutput(ctx, "token", outputEvent);
+
+    expect(emittedCompanyIds(ctx)).toEqual(["linked-company"]);
+    expect((stateStore["loop_chat-1_42"] as { status: string }).status).toBe("active");
+  });
+});
+
+describe("routeMessageToAgent company resolution", () => {
+  beforeEach(() => {
+    stateStore["sessions_chat-1_42"] = [acpSession("s1", "Builder")];
+  });
+
+  it("tells an unlinked chat to /connect instead of routing to a fake company", async () => {
+    const ctx = mockCtx();
+
+    const routed = await routeMessageToAgent(ctx, "token", "chat-1", 42, "do the thing");
+
+    expect(emittedCompanyIds(ctx)).toHaveLength(0);
+    expect(sentMessages[0]?.text).toContain("/connect");
+    // Reported as handled: the message was addressed to a live session, so
+    // falling through would leave the user with no reply at all.
+    expect(routed).toBe(true);
+  });
+
+  it("routes with the caller's company id when one is supplied", async () => {
+    const ctx = mockCtx();
+
+    await routeMessageToAgent(ctx, "token", "chat-1", 42, "do the thing", undefined, "company-abc");
+
+    expect(emittedCompanyIds(ctx)).toEqual(["company-abc"]);
+  });
+});

--- a/tests/acp-bridge-company-resolution.test.ts
+++ b/tests/acp-bridge-company-resolution.test.ts
@@ -4,7 +4,7 @@ import { handleAcpOutput, routeMessageToAgent } from "../src/acp-bridge.js";
 import { ACP_SPAWN_EVENT } from "../src/constants.js";
 
 /**
- * BLA-162: the bridge used to resolve an unlinked chat's company id to the raw
+ * Regression test: the bridge used to resolve an unlinked chat's company id to the raw
  * Telegram `chatId`. Nothing threw and nothing logged, so the failure surfaced
  * only as host calls that could never succeed — and the discussion loop
  * re-resolved once per turn, spending a fake id on every remaining turn.


### PR DESCRIPTION
## Problem

`resolveCompanyIdFromChat` falls back to `?? chatId` when it can't otherwise resolve a company id. A Telegram chat ID is never a valid Paperclip company ID — this fallback is guaranteed to fail, silently, with no error surfaced.

Worse: the live multi-turn agent-discussion path (`checkConversationLoopContinuation`) re-derives this broken fallback ID on every turn, burning the entire remaining turn budget on a discussion that can never succeed once an unlinked chat hits this path.

## Fix

Thread the host's own trusted `companyId` from the ACP event envelope through instead of re-deriving it from chat state.

## Testing

New dedicated test file covering the fallback removal; full suite green.