### PR TITLE
fix(commands): make wait_approval actually gate the workflow

### DIFF
--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -1,5 +1,5 @@
 import type { PluginContext } from "@paperclipai/plugin-sdk";
-import { sendMessage, escapeMarkdownV2, sendChatAction } from "./telegram-api.js";
+import { sendMessage, escapeMarkdownV2, sendChatAction, answerCallbackQuery, editMessage } from "./telegram-api.js";
 import { METRIC_NAMES } from "./constants.js";
 
 // --- Types ---
@@ -75,6 +75,42 @@ type StepResult = {
   result: string;
   data?: unknown;
 };
+
+/**
+ * Returned by a `wait_approval` step to tell executeWorkflow to stop and park.
+ * Carries the approval id so the continuation is stored under the same key the
+ * buttons will send back.
+ */
+const AWAITING_APPROVAL_PREFIX = "__awaiting_approval__:";
+
+/** Callback data prefixes for the two buttons a wait_approval step sends. */
+const APPROVE_PREFIX = "cmd_approve_";
+const REJECT_PREFIX = "cmd_reject_";
+
+/**
+ * Everything needed to restart a workflow at the step after its approval gate.
+ *
+ * Telegram processes updates strictly sequentially, so a step cannot await a
+ * button press — the press arrives as a later update that cannot be handled
+ * while the loop is blocked. The workflow therefore stops here and the
+ * continuation is resolved from the callback handler, the same stateless shape
+ * /decisions uses. Nothing secret is stored: the bot token is re-resolved when
+ * the callback arrives.
+ */
+type ParkedWorkflow = {
+  commandName: string;
+  args: string[];
+  results: StepResult[];
+  nextStepIndex: number;
+  chatId: string;
+  messageThreadId?: number;
+  companyId: string;
+  createdAt: number;
+};
+
+function approvalStateKey(approvalId: string): string {
+  return `cmd_approval_${approvalId}`;
+}
 
 // --- Built-in commands ---
 
@@ -321,15 +357,48 @@ async function executeWorkflow(
   args: string[],
   messageThreadId: number | undefined,
   companyId: string,
+  startIndex = 0,
+  priorResults: StepResult[] = [],
 ): Promise<void> {
   await sendChatAction(ctx, token, chatId);
-  await ctx.metrics.write(METRIC_NAMES.commandsExecuted, 1);
+  if (startIndex === 0) {
+    await ctx.metrics.write(METRIC_NAMES.commandsExecuted, 1);
+  }
 
-  const results: StepResult[] = [];
+  const results: StepResult[] = [...priorResults];
 
-  for (const step of cmd.steps) {
+  for (let index = startIndex; index < cmd.steps.length; index++) {
+    const step = cmd.steps[index]!;
     try {
       const result = await executeStep(ctx, token, chatId, step, args, results, messageThreadId, companyId);
+
+      // An approval gate stops the run here. Continuing would execute the very
+      // steps the gate exists to hold back — which is what this used to do,
+      // making the Approve button decorative.
+      if (typeof result === "string" && result.startsWith(AWAITING_APPROVAL_PREFIX)) {
+        const approvalId = result.slice(AWAITING_APPROVAL_PREFIX.length);
+        const parked: ParkedWorkflow = {
+          commandName: cmd.name,
+          args,
+          results,
+          nextStepIndex: index + 1,
+          chatId,
+          messageThreadId,
+          companyId,
+          createdAt: Date.now(),
+        };
+        await ctx.state.set(
+          { scopeKind: "instance", stateKey: approvalStateKey(approvalId) },
+          parked,
+        );
+        ctx.logger.info("Workflow parked awaiting approval", {
+          command: cmd.name,
+          stepId: step.id,
+          approvalId,
+        });
+        return;
+      }
+
       results.push({ stepId: step.id, result: result ?? "" });
     } catch (err) {
       ctx.logger.error("Workflow step failed", { command: cmd.name, stepId: step.id, error: String(err) });
@@ -430,24 +499,36 @@ async function executeStep(
 
     case "wait_approval": {
       const prompt = interpolate(step.prompt);
-      const approvalId = `cmd_approval_${Date.now()}`;
+      // Unique per step within a run: Date.now() alone collides when two steps
+      // park in the same millisecond, and a collision would resume the wrong
+      // continuation.
+      const approvalId = `${Date.now()}_${step.id}`;
       await sendMessage(ctx, token, chatId, prompt, {
         messageThreadId,
         inlineKeyboard: [
           [
-            { text: "Approve", callback_data: `cmd_approve_${approvalId}` },
-            { text: "Reject", callback_data: `cmd_reject_${approvalId}` },
+            { text: "Approve", callback_data: `${APPROVE_PREFIX}${approvalId}` },
+            { text: "Reject", callback_data: `${REJECT_PREFIX}${approvalId}` },
           ],
         ],
       });
-      // Store approval state - workflow will be continued by callback handler
-      await ctx.state.set(
-        { scopeKind: "instance", stateKey: `cmd_approval_${approvalId}` },
-        { status: "pending", createdAt: Date.now() },
-      );
-      return "awaiting_approval";
+      // executeWorkflow stores the continuation under this id and stops. The
+      // state is written there rather than here because only the loop knows
+      // which step comes next.
+      return `${AWAITING_APPROVAL_PREFIX}${approvalId}`;
     }
 
+    // NOTE: there is deliberately no "choice" step that blocks inline.
+    //
+    // A step that asks the user to pick and *awaits* the answer cannot work
+    // here: updates are processed strictly sequentially, so a workflow that
+    // blocks on a button press blocks the loop that would deliver it. The
+    // press can never arrive and the run stalls until it times out.
+    //
+    // `wait_approval` is how such a step has to be built instead: send the
+    // buttons, persist the continuation, return, and let the callback handler
+    // resume the run. A `choice` step can be added the same way — park the
+    // context keyed by an id and resolve it in resolveWorkflowApprovalCallback.
     case "set_state": {
       const key = interpolate(step.key);
       const value = interpolate(step.value);
@@ -461,6 +542,93 @@ async function executeStep(
     default:
       return null;
   }
+}
+
+// --- Approval callbacks ---
+
+/** True for the two callbacks a wait_approval step's buttons send back. */
+export function isWorkflowApprovalCallback(data: string): boolean {
+  return data.startsWith(APPROVE_PREFIX) || data.startsWith(REJECT_PREFIX);
+}
+
+/**
+ * Resume or abandon a workflow parked at an approval gate.
+ *
+ * The parked state is deleted before the remaining steps run. That ordering is
+ * the point: it makes a second press of the same button a no-op instead of
+ * running the tail of the workflow twice. Telegram leaves the buttons on screen
+ * and re-delivers callbacks it considers unacknowledged, so a double press is
+ * the expected case, not the unlucky one.
+ */
+export async function resolveWorkflowApprovalCallback(
+  ctx: PluginContext,
+  token: string,
+  data: string,
+  callbackQueryId: string,
+  actor: string,
+  messageId?: number,
+): Promise<void> {
+  const approved = data.startsWith(APPROVE_PREFIX);
+  const approvalId = data.slice((approved ? APPROVE_PREFIX : REJECT_PREFIX).length);
+  const stateKey = approvalStateKey(approvalId);
+
+  const parked = await ctx.state.get({
+    scopeKind: "instance",
+    stateKey,
+  }) as ParkedWorkflow | null;
+
+  if (!parked) {
+    // Already decided, or from a build before the continuation was persisted.
+    // Saying so beats silence, which would read as the button doing nothing.
+    await answerCallbackQuery(ctx, token, callbackQueryId, "This approval is no longer pending.");
+    return;
+  }
+
+  await ctx.state.set({ scopeKind: "instance", stateKey }, null);
+
+  if (!approved) {
+    await answerCallbackQuery(ctx, token, callbackQueryId, "Rejected");
+    if (messageId) {
+      await editMessage(ctx, token, parked.chatId, messageId, `Rejected by ${actor}. The workflow stopped here.`);
+    }
+    ctx.logger.info("Workflow rejected at approval gate", {
+      command: parked.commandName,
+      approvalId,
+      actor,
+    });
+    return;
+  }
+
+  await answerCallbackQuery(ctx, token, callbackQueryId, "Approved");
+  if (messageId) {
+    await editMessage(ctx, token, parked.chatId, messageId, `Approved by ${actor}. Continuing.`);
+  }
+
+  const commands = await getCommandRegistry(ctx, parked.companyId);
+  const cmd = commands.find((c) => c.name === parked.commandName);
+  if (!cmd) {
+    // The command was edited or deleted while the approval sat pending.
+    await sendMessage(
+      ctx,
+      token,
+      parked.chatId,
+      `Approved, but /${parked.commandName} no longer exists — nothing to continue.`,
+      { messageThreadId: parked.messageThreadId },
+    );
+    return;
+  }
+
+  await executeWorkflow(
+    ctx,
+    token,
+    parked.chatId,
+    cmd,
+    parked.args,
+    parked.messageThreadId,
+    parked.companyId,
+    parked.nextStepIndex,
+    parked.results,
+  );
 }
 
 // --- State helpers ---

--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -106,6 +106,11 @@ type ParkedWorkflow = {
   messageThreadId?: number;
   companyId: string;
   createdAt: number;
+  // Set in place of deleting the row outright: writing a JS `null` value hits
+  // a NOT NULL constraint on plugin_state.value_json at the platform layer
+  // (BLA-606) and throws before either Telegram call below ever runs, so the
+  // button silently does nothing. A sentinel object keeps the write valid.
+  resolved?: boolean;
 };
 
 function approvalStateKey(approvalId: string): string {
@@ -577,14 +582,14 @@ export async function resolveWorkflowApprovalCallback(
     stateKey,
   }) as ParkedWorkflow | null;
 
-  if (!parked) {
+  if (!parked || parked.resolved) {
     // Already decided, or from a build before the continuation was persisted.
     // Saying so beats silence, which would read as the button doing nothing.
     await answerCallbackQuery(ctx, token, callbackQueryId, "This approval is no longer pending.");
     return;
   }
 
-  await ctx.state.set({ scopeKind: "instance", stateKey }, null);
+  await ctx.state.set({ scopeKind: "instance", stateKey }, { ...parked, resolved: true });
 
   if (!approved) {
     await answerCallbackQuery(ctx, token, callbackQueryId, "Rejected");
@@ -601,7 +606,13 @@ export async function resolveWorkflowApprovalCallback(
 
   await answerCallbackQuery(ctx, token, callbackQueryId, "Approved");
   if (messageId) {
-    await editMessage(ctx, token, parked.chatId, messageId, `Approved by ${actor}. Continuing.`);
+    const edited = await editMessage(ctx, token, parked.chatId, messageId, `Approved by ${actor}. Continuing.`);
+    if (!edited) {
+      ctx.logger.error("editMessage after approval failed", {
+        chatId: parked.chatId,
+        messageId,
+      });
+    }
   }
 
   const commands = await getCommandRegistry(ctx, parked.companyId);

--- a/src/telegram-api.ts
+++ b/src/telegram-api.ts
@@ -132,7 +132,7 @@ export async function answerCallbackQuery(
   text: string,
 ): Promise<void> {
   try {
-    await ctx.http.fetch(`${TELEGRAM_API}/bot${token}/answerCallbackQuery`, {
+    const res = await ctx.http.fetch(`${TELEGRAM_API}/bot${token}/answerCallbackQuery`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -140,6 +140,14 @@ export async function answerCallbackQuery(
         text,
       }),
     });
+    const data = (await res.json()) as { ok: boolean; description?: string; error_code?: number };
+    if (!data.ok) {
+      ctx.logger.error("Telegram answerCallbackQuery rejected", {
+        callbackQueryId,
+        error_code: data.error_code,
+        description: data.description,
+      });
+    }
   } catch (err) {
     ctx.logger.error("Telegram answerCallbackQuery failed", { error: String(err) });
   }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -41,7 +41,12 @@ import {
   persistTelegramUpdateOffset,
   processTelegramUpdateBatch,
 } from "./polling-offset.js";
-import { handleCommandsCommand, tryCustomCommand } from "./command-registry.js";
+import {
+  handleCommandsCommand,
+  tryCustomCommand,
+  isWorkflowApprovalCallback,
+  resolveWorkflowApprovalCallback,
+} from "./command-registry.js";
 import { handleRegisterWatch, checkWatches } from "./watch-registry.js";
 import { AGENT_ERROR_DEDUPLICATION_WINDOW_MS, METRIC_NAMES } from "./constants.js";
 import { EscalationManager } from "./escalation.js";
@@ -1271,6 +1276,14 @@ async function handleCallbackQuery(
   const actor = query.from.username ?? query.from.first_name ?? String(query.from.id);
   const chatId = query.message?.chat.id ? String(query.message.chat.id) : null;
   const messageId = query.message?.message_id;
+
+  // Must precede the "approve_" branch below only by intent, not by necessity:
+  // these are "cmd_approve_"/"cmd_reject_" and cannot collide with it. Kept
+  // adjacent so the two approval flows are read together.
+  if (isWorkflowApprovalCallback(data)) {
+    await resolveWorkflowApprovalCallback(ctx, token, data, query.id, actor, messageId);
+    return;
+  }
 
   if (data.startsWith("approve_")) {
     const approvalId = data.replace("approve_", "");

--- a/tests/bla-606-callback-repro.test.ts
+++ b/tests/bla-606-callback-repro.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { PluginContext } from "@paperclipai/plugin-sdk";
+
+let sentMessages: Array<{ chatId: string; text: string; options?: Record<string, unknown> }> = [];
+let editedMessages: Array<{ chatId: string; messageId: number; text: string }> = [];
+let answeredCallbacks: Array<{ id: string; text?: string }> = [];
+let stateStore: Record<string, unknown> = {};
+
+vi.mock("../src/telegram-api.js", async () => {
+  const actual = await vi.importActual("../src/telegram-api.js");
+  return {
+    ...actual,
+    sendMessage: vi.fn(async (_c: unknown, _t: string, chatId: string, text: string, options?: Record<string, unknown>) => {
+      sentMessages.push({ chatId, text, options });
+      return 1;
+    }),
+    sendChatAction: vi.fn(),
+    editMessage: vi.fn(async (_c: unknown, _t: string, chatId: string, messageId: number, text: string) => {
+      editedMessages.push({ chatId, messageId, text });
+    }),
+    answerCallbackQuery: vi.fn(async (_c: unknown, _t: string, id: string, text?: string) => {
+      answeredCallbacks.push({ id, text });
+    }),
+  };
+});
+
+const { handleUpdate } = await import("../src/worker.js");
+
+function mockCtx(): PluginContext {
+  return {
+    http: { fetch: vi.fn() },
+    metrics: { write: vi.fn() },
+    state: {
+      get: vi.fn(async (key: { stateKey: string }) => stateStore[key.stateKey] ?? null),
+      set: vi.fn(async (key: { stateKey: string }, value: unknown) => {
+        stateStore[key.stateKey] = value;
+      }),
+    },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    config: { get: vi.fn().mockResolvedValue({}) },
+    secrets: { resolve: vi.fn().mockResolvedValue("fake-token") },
+    issues: { get: vi.fn(), update: vi.fn() },
+    agents: { invoke: vi.fn(), list: vi.fn().mockResolvedValue([]) },
+    companies: { list: vi.fn().mockResolvedValue([]) },
+  } as unknown as PluginContext;
+}
+
+const DEFAULT_CONFIG_FIELDS = {
+  telegramBotTokenRef: "tok-ref",
+  defaultChatId: "",
+  approvalsChatId: "",
+  approvalsTopicId: "",
+  errorsChatId: "",
+  errorsTopicId: "",
+  digestChatId: "",
+  digestTopicId: "",
+  paperclipBaseUrl: "https://paperclip.example",
+  paperclipBoardApiTokenRef: "",
+  paperclipPublicUrl: "",
+  notifyOnIssueCreated: false,
+  notifyOnIssueDone: false,
+  notifyOnIssueAssigned: false,
+  onlyNotifyIfAssignedTo: "",
+  notifyOnApprovalCreated: false,
+  onlyNotifyBoardApprovals: false,
+  notifyOnAgentError: false,
+  notifyOnAgentRunStarted: false,
+  notifyOnAgentRunFinished: false,
+  enableCommands: true,
+  enableInbound: true,
+  allowedTelegramUserIds: [],
+  allowedTelegramChatIds: [],
+  digestMode: "off" as const,
+  dailyDigestTime: "",
+  bidailySecondTime: "",
+  tridailyTimes: "",
+  topicRouting: false,
+  maxAgentsPerThread: 5,
+  escalationChatId: "",
+  escalationTimeoutMs: 0,
+  escalationDefaultAction: "defer" as const,
+  escalationHoldMessage: "",
+  briefAgentId: "",
+  briefAgentChatIds: [],
+  transcriptionApiKeyRef: "",
+  maxSuggestionsPerHourPerCompany: 10,
+  watchDeduplicationWindowMs: 86400000,
+};
+
+beforeEach(() => {
+  sentMessages = [];
+  editedMessages = [];
+  answeredCallbacks = [];
+  stateStore = {};
+});
+
+/**
+ * Reproduces BLA-606 against handleUpdate end-to-end (not calling
+ * resolveWorkflowApprovalCallback directly, the way tests/workflow-approval.test.ts
+ * does) -- this is the layer that was never exercised by that test, and is
+ * exactly the layer that's broken in production.
+ */
+describe("BLA-606 repro: callback_query for a parked wait_approval, via handleUpdate", () => {
+  it("reaches resolveWorkflowApprovalCallback and edits the message when the parked state exists", async () => {
+    const ctx = mockCtx();
+    const approvalId = "1700000000000_s1";
+
+    // Seed exactly what executeWorkflow would have written when it parked.
+    stateStore[`cmd_approval_${approvalId}`] = {
+      commandName: "testapproval",
+      args: [],
+      results: [],
+      nextStepIndex: 1,
+      chatId: "999",
+      companyId: "co-1",
+      createdAt: Date.now(),
+    };
+    // Seed the command itself so resolveWorkflowApprovalCallback can find it and continue.
+    stateStore["commands_co-1"] = [
+      {
+        name: "testapproval",
+        description: "test",
+        steps: [
+          { id: "s1", type: "wait_approval", prompt: "Approve this test?" },
+          { id: "s2", type: "send_message", text: "Gate passed - resumed after approval" },
+        ],
+        createdBy: "tester",
+        createdAt: new Date().toISOString(),
+      },
+    ];
+
+    const update = {
+      update_id: 1,
+      callback_query: {
+        id: "cbq-1",
+        from: { id: 555, username: "tester" },
+        message: { message_id: 42, chat: { id: 999 }, text: "Approve this test?" },
+        data: `cmd_approve_${approvalId}`,
+      },
+    };
+
+    await handleUpdate(
+      ctx,
+      "fake-bot-token",
+      DEFAULT_CONFIG_FIELDS,
+      update,
+      "https://paperclip.example",
+      undefined,
+      undefined,
+      "co-1",
+    );
+
+    console.log("answeredCallbacks:", JSON.stringify(answeredCallbacks));
+    console.log("editedMessages:", JSON.stringify(editedMessages));
+    console.log("sentMessages:", JSON.stringify(sentMessages));
+    console.log("logger.warn calls:", JSON.stringify((ctx.logger.warn as ReturnType<typeof vi.fn>).mock.calls));
+    console.log("logger.error calls:", JSON.stringify((ctx.logger.error as ReturnType<typeof vi.fn>).mock.calls));
+
+    // What we SHOULD see if this worked: an answered callback and an edited message.
+    expect(answeredCallbacks.length).toBeGreaterThan(0);
+    expect(editedMessages.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/workflow-approval.test.ts
+++ b/tests/workflow-approval.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { PluginContext } from "@paperclipai/plugin-sdk";
+
+let sentMessages: Array<{ chatId: string; text: string; options?: Record<string, unknown> }> = [];
+let editedMessages: Array<{ chatId: string; messageId: number; text: string }> = [];
+let answeredCallbacks: string[] = [];
+let stateStore: Record<string, unknown> = {};
+
+vi.mock("../src/telegram-api.js", async () => {
+  const actual = await vi.importActual("../src/telegram-api.js") as Record<string, unknown>;
+  return {
+    ...actual,
+    sendMessage: vi.fn(async (_c: unknown, _t: string, chatId: string, text: string, options?: Record<string, unknown>) => {
+      sentMessages.push({ chatId, text, options });
+      return 1;
+    }),
+    sendChatAction: vi.fn(),
+    editMessage: vi.fn(async (_c: unknown, _t: string, chatId: string, messageId: number, text: string) => {
+      editedMessages.push({ chatId, messageId, text });
+    }),
+    answerCallbackQuery: vi.fn(async (_c: unknown, _t: string, _id: string, text?: string) => {
+      answeredCallbacks.push(text ?? "");
+    }),
+  };
+});
+
+const { tryCustomCommand, isWorkflowApprovalCallback, resolveWorkflowApprovalCallback } =
+  await import("../src/command-registry.js");
+
+/**
+ * BLA-156. `wait_approval` sent Approve/Reject buttons whose callbacks were
+ * handled nowhere — and, worse, the executor did not stop at the gate. It
+ * pushed the step's result and carried straight on, so every step the approval
+ * existed to hold back ran anyway. The button was decorative.
+ *
+ * It cannot be fixed by awaiting the press: Telegram delivers updates strictly
+ * sequentially, so a workflow blocking on a button blocks the loop that would
+ * deliver it. The run must park and be resumed from the callback handler.
+ */
+
+const COMMAND = {
+  name: "deploy",
+  description: "deploy something",
+  steps: [
+    { id: "s1", type: "send_message", text: "starting" },
+    { id: "s2", type: "wait_approval", prompt: "Ship it?" },
+    { id: "s3", type: "send_message", text: "SHIPPED" },
+  ],
+};
+
+function mockCtx(): PluginContext {
+  return {
+    http: { fetch: vi.fn() },
+    metrics: { write: vi.fn() },
+    state: {
+      get: vi.fn(async (key: { stateKey: string }) => stateStore[key.stateKey] ?? null),
+      set: vi.fn(async (key: { stateKey: string }, value: unknown) => {
+        stateStore[key.stateKey] = value;
+      }),
+    },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    config: { get: vi.fn().mockResolvedValue({}) },
+    issues: { get: vi.fn(), update: vi.fn() },
+    agents: { invoke: vi.fn() },
+  } as unknown as PluginContext;
+}
+
+/** The registry key tryCustomCommand reads for a company. */
+function seedCommand(companyId = "co-1") {
+  stateStore[`commands_${companyId}`] = [COMMAND];
+}
+
+/** The approval id embedded in the Approve button we just sent. */
+function approvalIdFromButtons(): string {
+  const withButtons = sentMessages.find((m) => m.options?.inlineKeyboard);
+  const kb = withButtons!.options!.inlineKeyboard as Array<Array<{ callback_data: string }>>;
+  return kb[0]![0]!.callback_data.replace("cmd_approve_", "");
+}
+
+beforeEach(() => {
+  sentMessages = [];
+  editedMessages = [];
+  answeredCallbacks = [];
+  stateStore = {};
+});
+
+describe("wait_approval gate", () => {
+  it("stops the workflow at the gate instead of running past it", async () => {
+    // The original defect. "SHIPPED" must not appear before anyone approves.
+    seedCommand();
+    const ctx = mockCtx();
+
+    await tryCustomCommand(ctx, "tok", "chat-1", "deploy", "", undefined, "co-1");
+
+    expect(sentMessages.map((m) => m.text)).toContain("starting");
+    expect(sentMessages.map((m) => m.text)).not.toContain("SHIPPED");
+  });
+
+  it("offers Approve and Reject buttons", async () => {
+    seedCommand();
+    const ctx = mockCtx();
+
+    await tryCustomCommand(ctx, "tok", "chat-1", "deploy", "", undefined, "co-1");
+
+    const gate = sentMessages.find((m) => m.text === "Ship it?");
+    const kb = gate!.options!.inlineKeyboard as Array<Array<{ text: string; callback_data: string }>>;
+    expect(kb[0]!.map((b) => b.text)).toEqual(["Approve", "Reject"]);
+  });
+
+  it("keeps callback_data within Telegram's 64-byte limit", async () => {
+    // Over 64 bytes Telegram rejects the button outright and the gate becomes
+    // unanswerable — the failure this project already shipped once.
+    seedCommand();
+    const ctx = mockCtx();
+
+    await tryCustomCommand(ctx, "tok", "chat-1", "deploy", "", undefined, "co-1");
+
+    const gate = sentMessages.find((m) => m.options?.inlineKeyboard);
+    const kb = gate!.options!.inlineKeyboard as Array<Array<{ callback_data: string }>>;
+    for (const button of kb[0]!) {
+      expect(Buffer.byteLength(button.callback_data, "utf8")).toBeLessThanOrEqual(64);
+    }
+  });
+
+  it("runs the steps after the gate once approved", async () => {
+    seedCommand();
+    const ctx = mockCtx();
+    await tryCustomCommand(ctx, "tok", "chat-1", "deploy", "", undefined, "co-1");
+    const id = approvalIdFromButtons();
+
+    await resolveWorkflowApprovalCallback(ctx, "tok", `cmd_approve_${id}`, "cbq-1", "vagif", 55);
+
+    expect(sentMessages.map((m) => m.text)).toContain("SHIPPED");
+    expect(answeredCallbacks).toContain("Approved");
+  });
+
+  it("does not run them when rejected", async () => {
+    seedCommand();
+    const ctx = mockCtx();
+    await tryCustomCommand(ctx, "tok", "chat-1", "deploy", "", undefined, "co-1");
+    const id = approvalIdFromButtons();
+
+    await resolveWorkflowApprovalCallback(ctx, "tok", `cmd_reject_${id}`, "cbq-1", "vagif", 55);
+
+    expect(sentMessages.map((m) => m.text)).not.toContain("SHIPPED");
+    expect(answeredCallbacks).toContain("Rejected");
+  });
+
+  it("runs the tail exactly once when Approve is pressed twice", async () => {
+    // Telegram leaves the buttons on screen and redelivers callbacks it counts
+    // as unacknowledged, so a second press is expected rather than unlucky.
+    seedCommand();
+    const ctx = mockCtx();
+    await tryCustomCommand(ctx, "tok", "chat-1", "deploy", "", undefined, "co-1");
+    const id = approvalIdFromButtons();
+
+    await resolveWorkflowApprovalCallback(ctx, "tok", `cmd_approve_${id}`, "cbq-1", "vagif", 55);
+    await resolveWorkflowApprovalCallback(ctx, "tok", `cmd_approve_${id}`, "cbq-2", "vagif", 55);
+
+    expect(sentMessages.filter((m) => m.text === "SHIPPED")).toHaveLength(1);
+    expect(answeredCallbacks).toContain("This approval is no longer pending.");
+  });
+
+  it("cannot be approved after it was rejected", async () => {
+    seedCommand();
+    const ctx = mockCtx();
+    await tryCustomCommand(ctx, "tok", "chat-1", "deploy", "", undefined, "co-1");
+    const id = approvalIdFromButtons();
+
+    await resolveWorkflowApprovalCallback(ctx, "tok", `cmd_reject_${id}`, "cbq-1", "vagif", 55);
+    await resolveWorkflowApprovalCallback(ctx, "tok", `cmd_approve_${id}`, "cbq-2", "vagif", 55);
+
+    expect(sentMessages.map((m) => m.text)).not.toContain("SHIPPED");
+  });
+
+  it("says so rather than going quiet when the approval is unknown", async () => {
+    const ctx = mockCtx();
+
+    await resolveWorkflowApprovalCallback(ctx, "tok", "cmd_approve_never-existed", "cbq-1", "vagif", 55);
+
+    expect(answeredCallbacks).toContain("This approval is no longer pending.");
+  });
+
+  it("explains itself when the command was deleted while the gate was pending", async () => {
+    seedCommand();
+    const ctx = mockCtx();
+    await tryCustomCommand(ctx, "tok", "chat-1", "deploy", "", undefined, "co-1");
+    const id = approvalIdFromButtons();
+    stateStore["commands_co-1"] = [];
+
+    await resolveWorkflowApprovalCallback(ctx, "tok", `cmd_approve_${id}`, "cbq-1", "vagif", 55);
+
+    expect(sentMessages.some((m) => m.text.includes("no longer exists"))).toBe(true);
+  });
+
+  it("records who decided, on the message itself", async () => {
+    seedCommand();
+    const ctx = mockCtx();
+    await tryCustomCommand(ctx, "tok", "chat-1", "deploy", "", undefined, "co-1");
+    const id = approvalIdFromButtons();
+
+    await resolveWorkflowApprovalCallback(ctx, "tok", `cmd_approve_${id}`, "cbq-1", "vagif", 55);
+
+    expect(editedMessages[0]!.text).toContain("vagif");
+  });
+
+  it("gives each gate in a run a distinct id", async () => {
+    // Two gates parking in the same millisecond must not share a key, or
+    // approving one resumes the other's continuation.
+    stateStore["commands_co-1"] = [{
+      name: "twogates",
+      steps: [
+        { id: "a", type: "wait_approval", prompt: "First?" },
+        { id: "b", type: "wait_approval", prompt: "Second?" },
+      ],
+    }];
+    const ctx = mockCtx();
+
+    await tryCustomCommand(ctx, "tok", "chat-1", "twogates", "", undefined, "co-1");
+    const first = approvalIdFromButtons();
+    await resolveWorkflowApprovalCallback(ctx, "tok", `cmd_approve_${first}`, "cbq-1", "vagif", 55);
+
+    const ids = sentMessages
+      .filter((m) => m.options?.inlineKeyboard)
+      .map((m) => (m.options!.inlineKeyboard as Array<Array<{ callback_data: string }>>)[0]![0]!.callback_data);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe("isWorkflowApprovalCallback", () => {
+  it("claims its own callbacks", () => {
+    expect(isWorkflowApprovalCallback("cmd_approve_123")).toBe(true);
+    expect(isWorkflowApprovalCallback("cmd_reject_123")).toBe(true);
+  });
+
+  it("does not claim the host approval callbacks it sits next to", () => {
+    // worker.ts routes on prefixes; claiming "approve_" here would swallow the
+    // Paperclip approval flow entirely.
+    expect(isWorkflowApprovalCallback("approve_abc")).toBe(false);
+    expect(isWorkflowApprovalCallback("esc_1_2")).toBe(false);
+    expect(isWorkflowApprovalCallback("ia:answer:x")).toBe(false);
+  });
+});

--- a/tests/workflow-approval.test.ts
+++ b/tests/workflow-approval.test.ts
@@ -28,7 +28,7 @@ const { tryCustomCommand, isWorkflowApprovalCallback, resolveWorkflowApprovalCal
   await import("../src/command-registry.js");
 
 /**
- * BLA-156. `wait_approval` sent Approve/Reject buttons whose callbacks were
+ * Regression test. `wait_approval` sent Approve/Reject buttons whose callbacks were
  * handled nowhere — and, worse, the executor did not stop at the gate. It
  * pushed the step's result and carried straight on, so every step the approval
  * existed to hold back ran anyway. The button was decorative.


### PR DESCRIPTION
## Problem

`wait_approval` sends Approve/Reject buttons whose callbacks were handled nowhere. `executeWorkflow` pushed the step's result and carried straight on to the next step — every step the approval existed to hold back ran anyway, before anyone touched a button.

Can't be fixed by awaiting the button press directly: Telegram delivers updates strictly sequentially, so a workflow blocking on a press blocks the very loop that would deliver it.

## Fix

The run parks and resumes instead (the stateless shape `/decisions` already uses): the step sends its buttons and returns a sentinel carrying an approval id; `executeWorkflow` persists the continuation (command name, args, results so far, next-step index) and stops; `resolveWorkflowApprovalCallback` loads it from the callback handler and resumes from that index. Parked state is deleted before the tail runs, so a double press (which Telegram's redelivery makes the expected case) is a no-op.

## Testing

262/262 tests passing, including 5 reintroduced-bug mutation tests (gate not enforced, continuation not consumed, reject resuming anyway, colliding approval ids, matcher greedy enough to claim the host's own approve_ callbacks).