### PR TITLE
test: add direct coverage for TelegramAdapter and ACP-bridge session lifecycle

### DIFF
--- a/tests/acp-bridge-agent-resolution.test.ts
+++ b/tests/acp-bridge-agent-resolution.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { PluginContext } from "@paperclipai/plugin-sdk";
+import { handleAcpCommand } from "../src/acp-bridge.js";
+
+let sentMessages: Array<{ chatId: string; text: string }> = [];
+let stateStore: Record<string, unknown> = {};
+let emittedEvents: Array<{ event: string; companyId: string; payload: unknown }> = [];
+
+vi.mock("../src/telegram-api.js", async () => {
+  const actual = await vi.importActual("../src/telegram-api.js") as Record<string, unknown>;
+  return {
+    ...actual,
+    sendMessage: vi.fn(async (_ctx: unknown, _token: string, chatId: string, text: string) => {
+      sentMessages.push({ chatId, text });
+      return 100;
+    }),
+    sendChatAction: vi.fn(),
+  };
+});
+
+function mockCtx(agentsListImpl?: () => Promise<unknown[]>): PluginContext {
+  return {
+    http: { fetch: vi.fn() },
+    metrics: { write: vi.fn() },
+    state: {
+      get: vi.fn(async (key: { stateKey: string }) => stateStore[key.stateKey] ?? null),
+      set: vi.fn(async (key: { stateKey: string }, value: unknown) => {
+        stateStore[key.stateKey] = value;
+      }),
+    },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    events: {
+      emit: vi.fn((event: string, companyId: string, payload: unknown) => {
+        emittedEvents.push({ event, companyId, payload });
+      }),
+      on: vi.fn(),
+    },
+    agents: {
+      get: vi.fn().mockRejectedValue(new Error("agents.get requires a UUID, not a name")),
+      list: vi.fn(agentsListImpl ?? (async () => [])),
+      sessions: {
+        create: vi.fn().mockResolvedValue({ sessionId: "native-session-1" }),
+        sendMessage: vi.fn(),
+        close: vi.fn(),
+      },
+    },
+    issues: {
+      create: vi.fn().mockResolvedValue({ id: "issue-1" }),
+      update: vi.fn().mockResolvedValue({ id: "issue-1" }),
+    },
+    projects: { list: vi.fn().mockResolvedValue([]) },
+  } as unknown as PluginContext;
+}
+
+async function spawn(ctx: PluginContext, agentName: string, chatId = "chat-1", threadId = 42, companyId = "company-1") {
+  await handleAcpCommand(ctx, "token", chatId, `spawn ${agentName}`, threadId, companyId);
+}
+
+function savedSessions(chatId = "chat-1", threadId = 42) {
+  return (stateStore[`sessions_${chatId}_${threadId}`] as Array<Record<string, unknown>>) ?? [];
+}
+
+beforeEach(() => {
+  sentMessages = [];
+  stateStore = {};
+  emittedEvents = [];
+});
+
+describe("agent resolution via /acp spawn (regression: ctx.agents.get() requires a UUID, not a name)", () => {
+  it("resolves the agent by exact name match and creates a native session", async () => {
+    const ctx = mockCtx(async () => [{ id: "uuid-1", name: "builder", urlKey: "builder" }]);
+    await spawn(ctx, "builder");
+
+    // The bug this pins: the plugin must never call ctx.agents.get() with a bare
+    // agent name — that always failed with a Postgres UUID-cast error.
+    expect(ctx.agents.get).not.toHaveBeenCalled();
+    expect(ctx.agents.list).toHaveBeenCalledWith({ companyId: "company-1" });
+    expect(ctx.agents.sessions.create).toHaveBeenCalledWith("uuid-1", "company-1", expect.anything());
+
+    const sessions = savedSessions();
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].transport).toBe("native");
+    expect(sessions[0].agentId).toBe("uuid-1");
+  });
+
+  it("matches by urlKey when the name does not match directly", async () => {
+    const ctx = mockCtx(async () => [{ id: "uuid-2", name: "The Builder", urlKey: "builder-agent" }]);
+    await spawn(ctx, "builder-agent");
+
+    const sessions = savedSessions();
+    expect(sessions[0].transport).toBe("native");
+    expect(sessions[0].agentId).toBe("uuid-2");
+  });
+
+  it("matches case-insensitively", async () => {
+    const ctx = mockCtx(async () => [{ id: "uuid-3", name: "CEO", urlKey: "ceo" }]);
+    await spawn(ctx, "ceo");
+
+    const sessions = savedSessions();
+    expect(sessions[0].transport).toBe("native");
+    expect(sessions[0].agentId).toBe("uuid-3");
+  });
+
+  it("falls back to ACP transport (not a thrown error) when no agent matches the name", async () => {
+    const ctx = mockCtx(async () => [{ id: "uuid-1", name: "builder", urlKey: "builder" }]);
+    await spawn(ctx, "nonexistent-agent");
+
+    const sessions = savedSessions();
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].transport).toBe("acp");
+    expect(sessions[0].agentId).toBe("");
+    expect(ctx.agents.sessions.create).not.toHaveBeenCalled();
+    expect(emittedEvents.some((e) => e.event === "acp-spawn")).toBe(true);
+  });
+
+  it("falls back to ACP transport (not a thrown error) when ctx.agents.list() itself throws", async () => {
+    const ctx = mockCtx(async () => {
+      throw new Error("no invocation scope");
+    });
+
+    await expect(spawn(ctx, "builder")).resolves.toBeUndefined();
+    const sessions = savedSessions();
+    expect(sessions[0].transport).toBe("acp");
+    expect(ctx.logger.error).toHaveBeenCalledWith(
+      "Failed to resolve agent by name",
+      expect.objectContaining({ agentName: "builder" }),
+    );
+  });
+
+  it("prefers the agentId field over id when agentId looks like a real UUID (regression: SDK returns UUID under different field names)", async () => {
+    const ctx = mockCtx(async () => [
+      { id: "not-a-uuid-slug", agentId: "11111111-2222-3333-4444-555555555555", name: "builder", urlKey: "builder" },
+    ]);
+    await spawn(ctx, "builder");
+
+    expect(ctx.agents.sessions.create).toHaveBeenCalledWith(
+      "11111111-2222-3333-4444-555555555555",
+      "company-1",
+      expect.anything(),
+    );
+  });
+
+  it("falls back to the id field when agentId does not look like a UUID", async () => {
+    const ctx = mockCtx(async () => [
+      { id: "11111111-2222-3333-4444-555555555555", agentId: "not-a-real-uuid", name: "builder", urlKey: "builder" },
+    ]);
+    await spawn(ctx, "builder");
+
+    expect(ctx.agents.sessions.create).toHaveBeenCalledWith(
+      "11111111-2222-3333-4444-555555555555",
+      "company-1",
+      expect.anything(),
+    );
+  });
+
+  it("falls back to ACP transport (without losing the spawn) when native session creation throws after a successful match", async () => {
+    const ctx = mockCtx(async () => [{ id: "uuid-1", name: "builder", urlKey: "builder" }]);
+    (ctx.agents.sessions.create as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("session service down"));
+
+    await spawn(ctx, "builder");
+
+    const sessions = savedSessions();
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].transport).toBe("acp");
+    expect(ctx.logger.error).toHaveBeenCalledWith(
+      "Native session creation failed, falling back to ACP",
+      expect.objectContaining({ agentName: "builder" }),
+    );
+  });
+});
+
+describe("/acp spawn - guard rails", () => {
+  it("rejects spawn/cancel/close on an unlinked chat without ever touching agent resolution", async () => {
+    const ctx = mockCtx();
+    await handleAcpCommand(ctx, "token", "chat-1", "spawn builder", 42, undefined);
+
+    expect(ctx.agents.list).not.toHaveBeenCalled();
+    expect(sentMessages.some((m) => m.text.includes("not linked"))).toBe(true);
+  });
+
+  it("requires a thread — spawning outside a topic thread does not create a session", async () => {
+    const ctx = mockCtx(async () => [{ id: "uuid-1", name: "builder", urlKey: "builder" }]);
+    await handleAcpCommand(ctx, "token", "chat-1", "spawn builder", undefined, "company-1");
+
+    expect(savedSessions()).toHaveLength(0);
+    expect(ctx.agents.list).not.toHaveBeenCalled();
+  });
+
+  it("refuses to spawn a 6th agent when maxAgentsPerThread is 5", async () => {
+    stateStore["sessions_chat-1_42"] = Array.from({ length: 5 }, (_, i) => ({
+      sessionId: `s${i}`,
+      agentId: `a${i}`,
+      agentName: `agent${i}`,
+      agentDisplayName: `Agent${i}`,
+      transport: "acp",
+      spawnedAt: "2026-01-01T00:00:00Z",
+      status: "active",
+      lastActivityAt: "2026-01-01T00:00:00Z",
+    }));
+    const ctx = mockCtx(async () => [{ id: "uuid-x", name: "one-more", urlKey: "one-more" }]);
+    await spawn(ctx, "one-more");
+
+    expect(savedSessions()).toHaveLength(5);
+    expect(sentMessages.some((m) => m.text.includes("already has 5 active agents"))).toBe(true);
+  });
+});

--- a/tests/acp-bridge-handoff.test.ts
+++ b/tests/acp-bridge-handoff.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { PluginContext } from "@paperclipai/plugin-sdk";
+import { handleHandoffApproval, handleHandoffRejection } from "../src/acp-bridge.js";
+
+let sentMessages: Array<{ chatId: string; text: string }> = [];
+let stateStore: Record<string, unknown> = {};
+let emittedEvents: Array<{ event: string; companyId: string; payload: unknown }> = [];
+
+vi.mock("../src/telegram-api.js", async () => {
+  const actual = await vi.importActual("../src/telegram-api.js") as Record<string, unknown>;
+  return {
+    ...actual,
+    sendMessage: vi.fn(async (_ctx: unknown, _token: string, chatId: string, text: string) => {
+      sentMessages.push({ chatId, text });
+      return 100;
+    }),
+  };
+});
+
+function mockCtx(agentsListImpl?: () => Promise<unknown[]>): PluginContext {
+  return {
+    http: { fetch: vi.fn() },
+    metrics: { write: vi.fn() },
+    state: {
+      get: vi.fn(async (key: { stateKey: string }) => stateStore[key.stateKey] ?? null),
+      set: vi.fn(async (key: { stateKey: string }, value: unknown) => {
+        stateStore[key.stateKey] = value;
+      }),
+    },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    events: { emit: vi.fn((e: string, c: string, p: unknown) => emittedEvents.push({ event: e, companyId: c, payload: p })), on: vi.fn() },
+    agents: {
+      list: vi.fn(agentsListImpl ?? (async () => [])),
+      sessions: { create: vi.fn().mockResolvedValue({ sessionId: "native-2" }), close: vi.fn() },
+    },
+    issues: {
+      create: vi.fn().mockResolvedValue({ id: "issue-1" }),
+      update: vi.fn().mockResolvedValue({ id: "issue-1" }),
+    },
+    projects: { list: vi.fn().mockResolvedValue([]) },
+  } as unknown as PluginContext;
+}
+
+function pendingHandoff(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    handoffId: "h1",
+    sourceSessionId: "s1",
+    sourceAgent: "Builder",
+    targetAgent: "tester",
+    reason: "needs testing",
+    contextSummary: "code is ready",
+    chatId: "chat-1",
+    threadId: 42,
+    companyId: "company-1",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  sentMessages = [];
+  stateStore = {};
+  emittedEvents = [];
+});
+
+describe("handleHandoffApproval", () => {
+  it("does nothing when the handoff id has no pending record (expired or already resolved)", async () => {
+    const ctx = mockCtx();
+    await handleHandoffApproval(ctx, "token", "missing-id", "alice", "cb-1", "chat-1", 99);
+    expect(sentMessages).toHaveLength(0);
+    expect(emittedEvents).toHaveLength(0);
+  });
+
+  it("routes to the existing target session when one is already active, without auto-spawning", async () => {
+    stateStore["handoff_h1"] = pendingHandoff();
+    stateStore["sessions_chat-1_42"] = [
+      { sessionId: "s1", agentId: "a1", agentName: "builder", agentDisplayName: "Builder", transport: "native", spawnedAt: "2026-01-01T00:00:00Z", status: "active", lastActivityAt: "2026-01-01T00:00:00Z" },
+      { sessionId: "s2", agentId: "a2", agentName: "tester", agentDisplayName: "Tester", transport: "native", spawnedAt: "2026-01-01T00:00:00Z", status: "active", lastActivityAt: "2026-01-01T00:00:00Z" },
+    ];
+    const ctx = mockCtx();
+
+    await handleHandoffApproval(ctx, "token", "h1", "alice", "cb-1", "chat-1", 99);
+
+    // No auto-spawn message because "tester" already has an active session
+    expect(sentMessages.some((m) => m.text.includes("Auto") && m.text.includes("spawned"))).toBe(false);
+    expect(ctx.issues.create).toHaveBeenCalledWith(expect.objectContaining({ assigneeAgentId: "a2" }));
+    // Pending handoff record must be cleared so a duplicate button press is a no-op
+    expect(stateStore["handoff_h1"]).toBeNull();
+  });
+
+  it("auto-spawns the target agent by resolved UUID (not by name) when no session exists yet", async () => {
+    stateStore["handoff_h1"] = pendingHandoff();
+    const ctx = mockCtx(async () => [{ id: "uuid-tester", name: "tester", urlKey: "tester" }]);
+
+    await handleHandoffApproval(ctx, "token", "h1", "alice", "cb-1", "chat-1", 99);
+
+    expect(ctx.agents.sessions.create).toHaveBeenCalledWith("uuid-tester", "company-1", expect.anything());
+    const sessions = stateStore["sessions_chat-1_42"] as Array<Record<string, unknown>>;
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].transport).toBe("native");
+    expect(sentMessages.some((m) => m.text.includes("Auto") && m.text.includes("spawned"))).toBe(true);
+  });
+
+  it("falls back to ACP transport when the target agent cannot be resolved by name", async () => {
+    stateStore["handoff_h1"] = pendingHandoff();
+    const ctx = mockCtx(async () => []);
+
+    await handleHandoffApproval(ctx, "token", "h1", "alice", "cb-1", "chat-1", 99);
+
+    const sessions = stateStore["sessions_chat-1_42"] as Array<Record<string, unknown>>;
+    expect(sessions[0].transport).toBe("acp");
+    expect(emittedEvents.some((e) => (e.payload as { type: string }).type === "spawn")).toBe(true);
+  });
+});
+
+describe("handleHandoffRejection", () => {
+  it("does nothing when the handoff id has no pending record", async () => {
+    const ctx = mockCtx();
+    await handleHandoffRejection(ctx, "token", "missing-id", "alice", "cb-1", "chat-1", 99);
+    expect(sentMessages).toHaveLength(0);
+  });
+
+  it("notifies the chat and clears the pending handoff so it cannot be approved after rejection", async () => {
+    stateStore["handoff_h1"] = pendingHandoff();
+    const ctx = mockCtx();
+
+    await handleHandoffRejection(ctx, "token", "h1", "alice", "cb-1", "chat-1", 99);
+
+    expect(sentMessages[0].text).toContain("rejected");
+    expect(stateStore["handoff_h1"]).toBeNull();
+  });
+});

--- a/tests/acp-bridge-output.test.ts
+++ b/tests/acp-bridge-output.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { PluginContext } from "@paperclipai/plugin-sdk";
+import { handleAcpOutput } from "../src/acp-bridge.js";
+
+let sentMessages: Array<{ chatId: string; text: string; options?: Record<string, unknown> }> = [];
+let stateStore: Record<string, unknown> = {};
+let nextMessageId = 100;
+
+vi.mock("../src/telegram-api.js", async () => {
+  const actual = await vi.importActual("../src/telegram-api.js") as Record<string, unknown>;
+  return {
+    ...actual,
+    sendMessage: vi.fn(async (_ctx: unknown, _token: string, chatId: string, text: string, options?: Record<string, unknown>) => {
+      sentMessages.push({ chatId, text, options });
+      return nextMessageId++;
+    }),
+  };
+});
+
+function mockCtx(): PluginContext {
+  return {
+    state: {
+      get: vi.fn(async (key: { stateKey: string }) => stateStore[key.stateKey] ?? null),
+      set: vi.fn(async (key: { stateKey: string }, value: unknown) => {
+        stateStore[key.stateKey] = value;
+      }),
+    },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    events: { emit: vi.fn(), on: vi.fn() },
+  } as unknown as PluginContext;
+}
+
+function activeSession(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    sessionId: "s1",
+    agentId: "a1",
+    agentName: "builder",
+    agentDisplayName: "Builder",
+    transport: "native",
+    spawnedAt: "2026-01-01T00:00:00Z",
+    status: "active",
+    lastActivityAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  sentMessages = [];
+  stateStore = {};
+  nextMessageId = 100;
+});
+
+describe("handleAcpOutput - chunking (regression: Telegram rejects messages over 4096 chars)", () => {
+  it("splits output longer than the chunk limit into multiple sendMessage calls", async () => {
+    stateStore["sessions_chat-1_42"] = [activeSession()];
+    const ctx = mockCtx();
+    const longText = "line\n".repeat(1000); // ~5000 chars, well over the 4000-char chunk budget
+
+    await handleAcpOutput(ctx, "token", { sessionId: "s1", chatId: "chat-1", threadId: 42, text: longText, done: true });
+
+    expect(sentMessages.length).toBeGreaterThan(1);
+    // No individual chunk may exceed Telegram's hard limit
+    for (const msg of sentMessages) {
+      expect(msg.text.length).toBeLessThanOrEqual(4096);
+    }
+  });
+
+  it("does not split output at or under the limit", async () => {
+    stateStore["sessions_chat-1_42"] = [activeSession()];
+    const ctx = mockCtx();
+    const shortText = "all good here";
+
+    await handleAcpOutput(ctx, "token", { sessionId: "s1", chatId: "chat-1", threadId: 42, text: shortText, done: true });
+
+    expect(sentMessages).toHaveLength(1);
+  });
+
+  it("maps the reply-to state key to the LAST chunk's message id, not the first (regression: multi-chunk replies must route to the same agent)", async () => {
+    stateStore["sessions_chat-1_42"] = [activeSession()];
+    const ctx = mockCtx();
+    const longText = "line\n".repeat(1000);
+
+    await handleAcpOutput(ctx, "token", { sessionId: "s1", chatId: "chat-1", threadId: 42, text: longText, done: true });
+
+    const lastMessageId = nextMessageId - 1;
+    expect(stateStore[`agent_msg_chat-1_${lastMessageId}`]).toEqual({ sessionId: "s1" });
+    // Earlier chunks must NOT have a reply-to mapping — only the final one does
+    for (let id = 100; id < lastMessageId; id++) {
+      expect(stateStore[`agent_msg_chat-1_${id}`]).toBeUndefined();
+    }
+  });
+});
+
+describe("handleAcpOutput - session bookkeeping", () => {
+  it("updates lastActivityAt for the matching session", async () => {
+    stateStore["sessions_chat-1_42"] = [activeSession({ lastActivityAt: "2020-01-01T00:00:00Z" })];
+    const ctx = mockCtx();
+
+    await handleAcpOutput(ctx, "token", { sessionId: "s1", chatId: "chat-1", threadId: 42, text: "hi", done: false });
+
+    const sessions = stateStore["sessions_chat-1_42"] as Array<Record<string, unknown>>;
+    expect(sessions[0].lastActivityAt).not.toBe("2020-01-01T00:00:00Z");
+  });
+
+  it("still sends output under the generic 'Agent' label when the session is unknown", async () => {
+    const ctx = mockCtx();
+    await handleAcpOutput(ctx, "token", { sessionId: "unknown-session", chatId: "chat-1", threadId: 42, text: "hi", done: true });
+
+    expect(sentMessages).toHaveLength(1);
+    expect(sentMessages[0].text).toContain("Agent");
+  });
+});
+
+describe("handleAcpOutput - multi-agent output sequencing (regression: interleaved agent output must not garble the transcript)", () => {
+  it("queues a second agent's output while a first agent is still mid-stream, then flushes it once the first is done", async () => {
+    stateStore["sessions_chat-1_42"] = [
+      activeSession({ sessionId: "s1", agentDisplayName: "Builder" }),
+      activeSession({ sessionId: "s2", agentDisplayName: "Tester" }),
+    ];
+    const ctx = mockCtx();
+
+    // Builder starts speaking (not done yet) — becomes the current speaker.
+    await handleAcpOutput(ctx, "token", { sessionId: "s1", chatId: "chat-1", threadId: 42, text: "building...", done: false });
+    expect(sentMessages).toHaveLength(1);
+    expect(sentMessages[0].text).toContain("Builder");
+
+    // Tester tries to speak while Builder still holds the floor — must be queued, not sent immediately.
+    await handleAcpOutput(ctx, "token", { sessionId: "s2", chatId: "chat-1", threadId: 42, text: "waiting to test", done: false });
+    expect(sentMessages).toHaveLength(1);
+
+    // Builder finishes — this should flush Tester's queued output.
+    await handleAcpOutput(ctx, "token", { sessionId: "s1", chatId: "chat-1", threadId: 42, text: "build complete", done: true });
+
+    expect(sentMessages).toHaveLength(3);
+    // The queued Tester output is flushed as soon as Builder yields the floor,
+    // before Builder's own "done" message is sent.
+    expect(sentMessages[1].text).toContain("Tester");
+    expect(sentMessages[1].text).toContain("waiting to test");
+    expect(sentMessages[2].text).toContain("Builder");
+    expect(sentMessages[2].text).toContain("build complete");
+  });
+
+  it("does not engage sequencing when only one agent is active in the thread", async () => {
+    stateStore["sessions_chat-1_42"] = [activeSession({ sessionId: "s1" })];
+    const ctx = mockCtx();
+
+    await handleAcpOutput(ctx, "token", { sessionId: "s1", chatId: "chat-1", threadId: 42, text: "solo output", done: false });
+
+    expect(sentMessages).toHaveLength(1);
+  });
+});

--- a/tests/acp-bridge-session-lifecycle.test.ts
+++ b/tests/acp-bridge-session-lifecycle.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { PluginContext } from "@paperclipai/plugin-sdk";
+import { handleAcpCommand } from "../src/acp-bridge.js";
+
+let sentMessages: Array<{ chatId: string; text: string }> = [];
+let stateStore: Record<string, unknown> = {};
+let emittedEvents: Array<{ event: string; companyId: string; payload: unknown }> = [];
+
+vi.mock("../src/telegram-api.js", async () => {
+  const actual = await vi.importActual("../src/telegram-api.js") as Record<string, unknown>;
+  return {
+    ...actual,
+    sendMessage: vi.fn(async (_ctx: unknown, _token: string, chatId: string, text: string) => {
+      sentMessages.push({ chatId, text });
+      return 100;
+    }),
+    sendChatAction: vi.fn(),
+  };
+});
+
+function mockCtx(): PluginContext {
+  return {
+    http: { fetch: vi.fn() },
+    metrics: { write: vi.fn() },
+    state: {
+      get: vi.fn(async (key: { stateKey: string }) => stateStore[key.stateKey] ?? null),
+      set: vi.fn(async (key: { stateKey: string }, value: unknown) => {
+        stateStore[key.stateKey] = value;
+      }),
+    },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    events: { emit: vi.fn((e: string, c: string, p: unknown) => emittedEvents.push({ event: e, companyId: c, payload: p })), on: vi.fn() },
+    agents: {
+      get: vi.fn(),
+      list: vi.fn().mockResolvedValue([]),
+      sessions: { create: vi.fn(), sendMessage: vi.fn(), close: vi.fn().mockResolvedValue(undefined) },
+    },
+    issues: { create: vi.fn(), update: vi.fn() },
+    projects: { list: vi.fn().mockResolvedValue([]) },
+  } as unknown as PluginContext;
+}
+
+function session(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    sessionId: "s1",
+    agentId: "a1",
+    agentName: "builder",
+    agentDisplayName: "Builder",
+    transport: "native",
+    spawnedAt: "2026-01-01T00:00:00Z",
+    status: "active",
+    lastActivityAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  sentMessages = [];
+  stateStore = {};
+  emittedEvents = [];
+});
+
+describe("/acp status", () => {
+  it("asks the user to run it inside a thread when there is no messageThreadId", async () => {
+    const ctx = mockCtx();
+    await handleAcpCommand(ctx, "token", "chat-1", "status", undefined, "company-1");
+    expect(sentMessages[0].text).toContain("inside a thread");
+  });
+
+  it("reports no sessions bound to an empty thread", async () => {
+    const ctx = mockCtx();
+    await handleAcpCommand(ctx, "token", "chat-1", "status", 42, "company-1");
+    expect(sentMessages[0].text).toContain("No agent sessions bound");
+  });
+
+  it("lists only active sessions, not closed ones", async () => {
+    stateStore["sessions_chat-1_42"] = [
+      session({ sessionId: "s1", agentDisplayName: "Builder", status: "active" }),
+      session({ sessionId: "s2", agentDisplayName: "Tester", status: "closed" }),
+    ];
+    const ctx = mockCtx();
+    await handleAcpCommand(ctx, "token", "chat-1", "status", 42, "company-1");
+    expect(sentMessages[0].text).toContain("Builder");
+    expect(sentMessages[0].text).not.toContain("Tester");
+  });
+});
+
+describe("/acp cancel", () => {
+  it("cancels the most recently active native session via ctx.agents.sessions.close", async () => {
+    stateStore["sessions_chat-1_42"] = [
+      session({ sessionId: "older", lastActivityAt: "2026-01-01T00:00:00Z" }),
+      session({ sessionId: "newer", lastActivityAt: "2026-01-02T00:00:00Z" }),
+    ];
+    const ctx = mockCtx();
+    await handleAcpCommand(ctx, "token", "chat-1", "cancel", 42, "company-1");
+
+    expect(ctx.agents.sessions.close).toHaveBeenCalledWith("newer", "company-1");
+  });
+
+  it("emits an acp-spawn cancel event for ACP-transport sessions instead of calling sessions.close", async () => {
+    stateStore["sessions_chat-1_42"] = [session({ transport: "acp" })];
+    const ctx = mockCtx();
+    await handleAcpCommand(ctx, "token", "chat-1", "cancel", 42, "company-1");
+
+    expect(ctx.agents.sessions.close).not.toHaveBeenCalled();
+    expect(emittedEvents.some((e) => e.event === "acp-spawn" && (e.payload as { type: string }).type === "cancel")).toBe(true);
+  });
+
+  it("still answers the user (does not throw) when native session close fails", async () => {
+    stateStore["sessions_chat-1_42"] = [session()];
+    const ctx = mockCtx();
+    (ctx.agents.sessions.close as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("gone"));
+
+    await expect(handleAcpCommand(ctx, "token", "chat-1", "cancel", 42, "company-1")).resolves.toBeUndefined();
+    expect(ctx.logger.error).toHaveBeenCalledWith("Failed to close native session", expect.anything());
+    expect(sentMessages.some((m) => m.text.includes("Cancellation requested"))).toBe(true);
+  });
+});
+
+describe("/acp close", () => {
+  it("closes by exact agent name match, case-insensitively", async () => {
+    stateStore["sessions_chat-1_42"] = [
+      session({ sessionId: "s1", agentName: "builder" }),
+      session({ sessionId: "s2", agentName: "tester" }),
+    ];
+    const ctx = mockCtx();
+    await handleAcpCommand(ctx, "token", "chat-1", "close Builder", 42, "company-1");
+
+    expect(ctx.agents.sessions.close).toHaveBeenCalledWith("s1", "company-1");
+    const sessions = stateStore["sessions_chat-1_42"] as Array<Record<string, unknown>>;
+    expect(sessions.find((s) => s.sessionId === "s1")!.status).toBe("closed");
+    expect(sessions.find((s) => s.sessionId === "s2")!.status).toBe("active");
+  });
+
+  it("closes by partial agent name match when no exact match exists", async () => {
+    stateStore["sessions_chat-1_42"] = [session({ sessionId: "s1", agentName: "codebuilder" })];
+    const ctx = mockCtx();
+    await handleAcpCommand(ctx, "token", "chat-1", "close build", 42, "company-1");
+
+    expect(ctx.agents.sessions.close).toHaveBeenCalledWith("s1", "company-1");
+  });
+
+  it("lists active agents and closes nothing when the requested name matches no one", async () => {
+    stateStore["sessions_chat-1_42"] = [session({ sessionId: "s1", agentName: "builder", agentDisplayName: "Builder" })];
+    const ctx = mockCtx();
+    await handleAcpCommand(ctx, "token", "chat-1", "close nonexistent", 42, "company-1");
+
+    expect(ctx.agents.sessions.close).not.toHaveBeenCalled();
+    expect(sentMessages[0].text).toContain('No agent named "nonexistent" found');
+    expect(sentMessages[0].text).toContain("Builder");
+    const sessions = stateStore["sessions_chat-1_42"] as Array<Record<string, unknown>>;
+    expect(sessions[0].status).toBe("active");
+  });
+
+  it("closes the most recently active session when no name is given", async () => {
+    stateStore["sessions_chat-1_42"] = [
+      session({ sessionId: "older", lastActivityAt: "2026-01-01T00:00:00Z" }),
+      session({ sessionId: "newer", lastActivityAt: "2026-01-02T00:00:00Z" }),
+    ];
+    const ctx = mockCtx();
+    await handleAcpCommand(ctx, "token", "chat-1", "close", 42, "company-1");
+
+    expect(ctx.agents.sessions.close).toHaveBeenCalledWith("newer", "company-1");
+  });
+});

--- a/tests/adapter.test.ts
+++ b/tests/adapter.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { PluginContext } from "@paperclipai/plugin-sdk";
+
+let sendMessageCalls: Array<unknown[]> = [];
+let editMessageCalls: Array<unknown[]> = [];
+
+vi.mock("../src/telegram-api.js", async () => {
+  const actual = await vi.importActual("../src/telegram-api.js") as Record<string, unknown>;
+  return {
+    ...actual,
+    sendMessage: vi.fn(async (...args: unknown[]) => {
+      sendMessageCalls.push(args);
+      return 555;
+    }),
+    editMessage: vi.fn(async (...args: unknown[]) => {
+      editMessageCalls.push(args);
+      return true;
+    }),
+  };
+});
+
+import { TelegramAdapter } from "../src/adapter.js";
+
+function mockCtx(): PluginContext {
+  return {} as PluginContext;
+}
+
+beforeEach(() => {
+  sendMessageCalls = [];
+  editMessageCalls = [];
+});
+
+describe("TelegramAdapter", () => {
+  it("reports the telegram platform id", () => {
+    const adapter = new TelegramAdapter(mockCtx(), "token");
+    expect(adapter.platformId).toBe("telegram");
+  });
+
+  it("sendText forwards thread, reply-to, and silent options and returns a MessageRef", async () => {
+    const adapter = new TelegramAdapter(mockCtx(), "token");
+    const ref = await adapter.sendText("chat-1", "42", "hello", { replyTo: "10", silent: true });
+
+    expect(sendMessageCalls).toHaveLength(1);
+    const [, , chatId, text, options] = sendMessageCalls[0] as [unknown, unknown, string, string, Record<string, unknown>];
+    expect(chatId).toBe("chat-1");
+    expect(text).toBe("hello");
+    expect(options.messageThreadId).toBe(42);
+    expect(options.replyToMessageId).toBe(10);
+    expect(options.disableNotification).toBe(true);
+    expect(ref).toEqual({ chatId: "chat-1", threadId: "42", messageId: "555" });
+  });
+
+  it("sendText omits messageThreadId when no thread is given", async () => {
+    const adapter = new TelegramAdapter(mockCtx(), "token");
+    await adapter.sendText("chat-1", undefined, "hello");
+
+    const [, , , , options] = sendMessageCalls[0] as [unknown, unknown, unknown, unknown, Record<string, unknown>];
+    expect(options.messageThreadId).toBeUndefined();
+  });
+
+  it("sendButtons chunks buttons two per row", async () => {
+    const adapter = new TelegramAdapter(mockCtx(), "token");
+    await adapter.sendButtons("chat-1", undefined, "pick one", [
+      { label: "A", callbackData: "a" },
+      { label: "B", callbackData: "b" },
+      { label: "C", callbackData: "c" },
+    ]);
+
+    const [, , , , options] = sendMessageCalls[0] as [unknown, unknown, unknown, unknown, { inlineKeyboard: Array<Array<{ text: string }>> }];
+    expect(options.inlineKeyboard).toHaveLength(2);
+    expect(options.inlineKeyboard[0]).toHaveLength(2);
+    expect(options.inlineKeyboard[1]).toHaveLength(1);
+    expect(options.inlineKeyboard[0][0].text).toBe("A");
+    expect(options.inlineKeyboard[1][0].text).toBe("C");
+  });
+
+  it("editMessage passes numeric messageId and rebuilds the keyboard from buttons", async () => {
+    const adapter = new TelegramAdapter(mockCtx(), "token");
+    await adapter.editMessage(
+      { chatId: "chat-1", threadId: "", messageId: "999" },
+      "updated text",
+      [{ label: "OK", callbackData: "ok" }],
+    );
+
+    expect(editMessageCalls).toHaveLength(1);
+    const [, , chatId, messageId, text, options] = editMessageCalls[0] as [
+      unknown, unknown, string, number, string, { inlineKeyboard: Array<Array<{ text: string }>> },
+    ];
+    expect(chatId).toBe("chat-1");
+    expect(messageId).toBe(999);
+    expect(text).toBe("updated text");
+    expect(options.inlineKeyboard[0][0].text).toBe("OK");
+  });
+
+  it("editMessage passes an undefined keyboard when no buttons are given", async () => {
+    const adapter = new TelegramAdapter(mockCtx(), "token");
+    await adapter.editMessage({ chatId: "chat-1", threadId: "", messageId: "999" }, "updated text");
+
+    const [, , , , , options] = editMessageCalls[0] as [unknown, unknown, unknown, unknown, unknown, { inlineKeyboard: unknown }];
+    expect(options.inlineKeyboard).toBeUndefined();
+  });
+
+  it("formatAgentLabel escapes MarkdownV2 special characters", () => {
+    const adapter = new TelegramAdapter(mockCtx(), "token");
+    expect(adapter.formatAgentLabel("builder-agent")).toBe("*\\[builder\\-agent\\]*");
+  });
+
+  it("formatMention escapes the user id", () => {
+    const adapter = new TelegramAdapter(mockCtx(), "token");
+    expect(adapter.formatMention("user.name")).toBe("@user\\.name");
+  });
+
+  it("formatCodeBlock wraps with a language fence when given", () => {
+    const adapter = new TelegramAdapter(mockCtx(), "token");
+    expect(adapter.formatCodeBlock("const x = 1;", "ts")).toBe("```ts\nconst x = 1;\n```");
+  });
+
+  it("formatCodeBlock wraps without a language fence when omitted", () => {
+    const adapter = new TelegramAdapter(mockCtx(), "token");
+    expect(adapter.formatCodeBlock("plain text")).toBe("```\nplain text\n```");
+  });
+});


### PR DESCRIPTION
## What

Two pure test-only commits, no production code touched:

- Direct coverage for `TelegramAdapter" (was 0% — nothing imported it directly).
- Coverage for ACP-bridge agent resolution, session lifecycle, handoff, and multi-agent output sequencing.

## Why

Zero behavioral risk, purely additive, independent of any in-flight architecture change.

## Testing

Verified against a clean merge onto current `main`: typecheck clean, 293/293 tests passing, no conflicts.