### PR TITLE
fix(commands): cap /agents list to stay under Telegram's 4096-char limit

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -10,6 +10,10 @@ type BotCommand = {
   description: string;
 };
 
+// Leaves headroom below Telegram's 4096-char hard limit for /agents so a
+// company with many agents doesn't produce a message the API silently drops.
+const AGENTS_MESSAGE_CHAR_BUDGET = 3500;
+
 type TopicMappingRecord = {
   projectId?: string;
   projectName: string;
@@ -223,14 +227,25 @@ async function handleAgents(
     const hasLinks = isExternalUrl(publicUrl);
     const statusEmoji: Record<string, string> = { active: "🟢", error: "🔴", paused: "🟡", idle: "⚪", running: "🔵" };
     const lines = [escapeMarkdownV2("🤖") + " *Agents*", ""];
+    let shown = 0;
     for (const agent of agents) {
       const emoji = statusEmoji[agent.status] ?? "⚪";
-      if (hasLinks) {
-        const url = `${publicUrl}/agents/${agent.id}`;
-        lines.push(`${escapeMarkdownV2(emoji)} [${escapeMarkdownV2(agent.name)}](${url}) \\- ${escapeMarkdownV2(agent.status)}`);
-      } else {
-        lines.push(`${escapeMarkdownV2(emoji)} *${escapeMarkdownV2(agent.name)}* \\- ${escapeMarkdownV2(agent.status)}`);
-      }
+      const line = hasLinks
+        ? `${escapeMarkdownV2(emoji)} [${escapeMarkdownV2(agent.name)}](${publicUrl}/agents/${agent.id}) \\- ${escapeMarkdownV2(agent.status)}`
+        : `${escapeMarkdownV2(emoji)} *${escapeMarkdownV2(agent.name)}* \\- ${escapeMarkdownV2(agent.status)}`;
+
+      // Stop before the message grows past Telegram's 4096-char hard limit,
+      // leaving room for a trailing "and N more" line.
+      const projected = lines.join("\n").length + 1 + line.length;
+      if (shown > 0 && projected > AGENTS_MESSAGE_CHAR_BUDGET) break;
+
+      lines.push(line);
+      shown++;
+    }
+
+    const remaining = agents.length - shown;
+    if (remaining > 0) {
+      lines.push("", escapeMarkdownV2(`…and ${remaining} more`));
     }
 
     await sendMessage(ctx, token, chatId, lines.join("\n"), {

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -199,6 +199,23 @@ describe("handleCommand", () => {
     expect(sentMessages[0].text).toContain("Tester");
   });
 
+  it("/agents caps the message under Telegram's 4096-char limit for large companies", async () => {
+    stateStore["chat_123"] = { companyId: "co-1" };
+    const ctx = mockCtx();
+    const manyAgents = Array.from({ length: 70 }, (_, i) => ({
+      id: `agent-${i}`,
+      name: `Agent With A Fairly Long Descriptive Name Number ${i}`,
+      status: "active",
+    }));
+    (ctx.agents as unknown) = { list: vi.fn().mockResolvedValue(manyAgents) };
+
+    await handleCommand(ctx, "token", "123", "agents", "");
+
+    expect(sentMessages.length).toBe(1);
+    expect(sentMessages[0].text.length).toBeLessThan(4096);
+    expect(sentMessages[0].text).toContain("more");
+  });
+
   it("/create without args shows usage", async () => {
     const ctx = mockCtx();
     await handleCommand(ctx, "token", "123", "create", "");


### PR DESCRIPTION
## Problem

`/agents` builds a single `sendMessage` payload from the full agent list with no length cap. Telegram's `sendMessage` hard-limits text to 4096 characters — once a company has enough agents, the payload exceeds that limit, the Telegram API call fails, and the command silently produces nothing in the chat. `/issues` already guards against this with a limit; `/agents` didn't have an equivalent cap.

## Fix

Cap the agent list the same way `/issues` does.

## Testing

Verified against a clean merge onto current `main`: typecheck clean, 44/44 tests in `tests/commands.test.ts` (250/250 full suite).