### PR TITLE
fix(formatters): add a distinct Full error link when agent-error text is truncated

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -51,7 +51,7 @@ export const AGENT_ERROR_DEDUPLICATION_WINDOW_MS = 30 * 60 * 1000;
 // Cutoff for the error text shown inline in an agent-error notification.
 // formatAgentError truncates at this length and, when it does, adds a
 // distinct "Full error" button rather than relying on "View Run" to double
-// as the link back to the untruncated text (BLA-362).
+// as the link back to the untruncated text.
 export const AGENT_ERROR_TRUNCATE_LENGTH = 500;
 
 export const MAX_CONVERSATION_TURNS = 50;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -48,6 +48,12 @@ export const DEFAULT_CONFIG = {
 
 export const AGENT_ERROR_DEDUPLICATION_WINDOW_MS = 30 * 60 * 1000;
 
+// Cutoff for the error text shown inline in an agent-error notification.
+// formatAgentError truncates at this length and, when it does, adds a
+// distinct "Full error" button rather than relying on "View Run" to double
+// as the link back to the untruncated text (BLA-362).
+export const AGENT_ERROR_TRUNCATE_LENGTH = 500;
+
 export const MAX_CONVERSATION_TURNS = 50;
 export const DEFAULT_CONVERSATION_TURNS = 10;
 

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -67,7 +67,7 @@ function runButton(agentId: string, runId: string | null, publicUrl?: string): {
 
 // Distinct from runButton: surfaced only when the inline error text was cut,
 // so the affordance for "see the rest of this" doesn't ride on a button
-// whose stated purpose is the run dashboard, not the raw error (BLA-362).
+// whose stated purpose is the run dashboard, not the raw error.
 function fullErrorButton(agentId: string, runId: string | null, publicUrl?: string): { text: string; url: string } | null {
   if (publicUrl && isExternalUrl(publicUrl) && runId) {
     return { text: "Full error ↗", url: `${publicUrl}/agents/${agentId}/runs/${runId}` };

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -1,6 +1,7 @@
 import type { PluginEvent } from "@paperclipai/plugin-sdk";
 import { escapeMarkdownV2, truncateAtWord } from "./telegram-api.js";
 import type { SendMessageOptions } from "./telegram-api.js";
+import { AGENT_ERROR_TRUNCATE_LENGTH } from "./constants.js";
 
 type Payload = Record<string, unknown>;
 
@@ -60,6 +61,16 @@ function displayAgentName(value: string): string {
 function runButton(agentId: string, runId: string | null, publicUrl?: string): { text: string; url: string } | null {
   if (publicUrl && isExternalUrl(publicUrl) && runId) {
     return { text: "View Run ↗", url: `${publicUrl}/agents/${agentId}/runs/${runId}` };
+  }
+  return null;
+}
+
+// Distinct from runButton: surfaced only when the inline error text was cut,
+// so the affordance for "see the rest of this" doesn't ride on a button
+// whose stated purpose is the run dashboard, not the raw error (BLA-362).
+function fullErrorButton(agentId: string, runId: string | null, publicUrl?: string): { text: string; url: string } | null {
+  if (publicUrl && isExternalUrl(publicUrl) && runId) {
+    return { text: "Full error ↗", url: `${publicUrl}/agents/${agentId}/runs/${runId}` };
   }
   return null;
 }
@@ -249,9 +260,11 @@ export function formatAgentError(event: PluginEvent, opts?: IssueLinksOpts): For
         : `Issue: ${issueLink(issueIdentifier, opts)}`,
     );
   }
-  lines.push(`\n${code(truncateAtWord(errorMessage, 500))}`);
+  const isTruncated = errorMessage.length > AGENT_ERROR_TRUNCATE_LENGTH;
+  lines.push(`\n${code(truncateAtWord(errorMessage, AGENT_ERROR_TRUNCATE_LENGTH))}`);
 
   const buttons = [
+    isTruncated ? fullErrorButton(agentId, runId, opts?.baseUrl) : null,
     runButton(agentId, runId, opts?.baseUrl),
     issueIdentifier ? issueButton(issueIdentifier, opts) : null,
     agentButton(agentId, "View Agent ↗", opts?.baseUrl),

--- a/tests/formatters.test.ts
+++ b/tests/formatters.test.ts
@@ -234,6 +234,38 @@ describe("formatAgentError", () => {
     expect(msg.text).toContain("Deployer");
     expect(msg.text).not.toContain("Agent ID:");
   });
+
+  it("adds a distinct Full error button when the message is truncated", () => {
+    const msg = formatAgentError(
+      mockEvent({ agentId: "agent-1", error: "x".repeat(600), runId: "run-1" }),
+      { baseUrl: "https://app.example.com" },
+    );
+    const buttons = msg.options.inlineKeyboard![0];
+    const fullError = buttons.find((b) => b.text === "Full error ↗");
+    const viewRun = buttons.find((b) => b.text === "View Run ↗");
+    expect(fullError).toBeDefined();
+    expect(fullError!.url).toBe("https://app.example.com/agents/agent-1/runs/run-1");
+    expect(viewRun).toBeDefined();
+  });
+
+  it("omits the Full error button when the message is not truncated", () => {
+    const msg = formatAgentError(
+      mockEvent({ agentId: "agent-1", error: "short error", runId: "run-1" }),
+      { baseUrl: "https://app.example.com" },
+    );
+    const buttons = msg.options.inlineKeyboard?.[0] ?? [];
+    expect(buttons.find((b) => b.text === "Full error ↗")).toBeUndefined();
+    expect(buttons.find((b) => b.text === "View Run ↗")).toBeDefined();
+  });
+
+  it("omits the Full error button when there is no runId to link to, even if truncated", () => {
+    const msg = formatAgentError(
+      mockEvent({ agentId: "agent-1", error: "x".repeat(600), runId: undefined }),
+      { baseUrl: "https://app.example.com" },
+    );
+    const buttons = msg.options.inlineKeyboard?.[0] ?? [];
+    expect(buttons.find((b) => b.text === "Full error ↗")).toBeUndefined();
+  });
 });
 
 describe("formatAgentRunStarted", () => {


### PR DESCRIPTION
## Problem

Agent-error notifications sent to Telegram truncate long error text at 500 characters with no way to get back to the full message. The existing View Run button doesn't substitute for this — different scope (the run, not the error text specifically) — so truncated errors are effectively unrecoverable from the chat.

## Fix

Add a distinct "Full error ↗" link when the error text is truncated.

## Testing

Verified against a clean merge onto current `main`: typecheck clean, 252/252 tests passing.