### PR TITLE
fix(commands): validate imported command definitions against their declared shape

### DIFF
--- a/src/command-definition-validation.ts
+++ b/src/command-definition-validation.ts
@@ -1,0 +1,206 @@
+import type { WorkflowStep } from "./command-registry.js";
+
+/**
+ * `JSON.parse` returns `any`, so a `/commands import` payload that parses
+ * cleanly but doesn't match the declared shape (e.g. `{"hello": 1}`) would
+ * otherwise sail through as a `CustomCommand` with `name`/`steps` undefined —
+ * failing later, inside `executeWorkflow`, with no link back to the bad
+ * import. This module is the one place that shape gets checked before a
+ * parsed value is trusted as a command definition.
+ */
+export type ImportedCommandDefinition = {
+  name: string;
+  description: string;
+  steps: WorkflowStep[];
+};
+
+export type CommandDefinitionValidation =
+  | { ok: true; definition: ImportedCommandDefinition }
+  | { ok: false; error: string };
+
+const VALID_STEP_TYPES = [
+  "fetch_issue",
+  "invoke_agent",
+  "http_request",
+  "send_message",
+  "create_issue",
+  "wait_approval",
+  "set_state",
+] as const;
+
+const HTTP_METHODS = ["GET", "POST", "PUT", "DELETE"] as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  return isRecord(value) && Object.values(value).every((v) => typeof v === "string");
+}
+
+function isStepType(value: string): value is WorkflowStep["type"] {
+  return (VALID_STEP_TYPES as readonly string[]).includes(value);
+}
+
+type StepResult = { ok: true; step: WorkflowStep } | { ok: false; error: string };
+
+function validateStep(value: unknown, index: number): StepResult {
+  const position = `Step ${index + 1}`;
+
+  if (!isRecord(value)) {
+    return { ok: false, error: `${position} must be an object.` };
+  }
+
+  const id = value.id;
+  if (!isNonEmptyString(id)) {
+    return { ok: false, error: `${position} must have an 'id' field.` };
+  }
+  const label = `${position} ('${id}')`;
+
+  const type = value.type;
+  if (!isNonEmptyString(type)) {
+    return { ok: false, error: `${label} must have a 'type' field.` };
+  }
+  if (!isStepType(type)) {
+    return { ok: false, error: `Invalid step type: '${type}' (${label}). Valid: ${VALID_STEP_TYPES.join(", ")}` };
+  }
+
+  const name = typeof value.name === "string" ? value.name : undefined;
+  const base = { id, name };
+
+  const missing = (field: string): StepResult => ({
+    ok: false,
+    error: `${label} of type '${type}' must have a '${field}' field.`,
+  });
+  const badType = (field: string, expected: string): StepResult => ({
+    ok: false,
+    error: `${label} of type '${type}': '${field}' must be ${expected}.`,
+  });
+
+  switch (type) {
+    case "fetch_issue": {
+      if (!isNonEmptyString(value.issueId)) return missing("issueId");
+      return { ok: true, step: { ...base, type, issueId: value.issueId } };
+    }
+
+    case "invoke_agent": {
+      if (!isNonEmptyString(value.agentId)) return missing("agentId");
+      if (!isNonEmptyString(value.prompt)) return missing("prompt");
+      return { ok: true, step: { ...base, type, agentId: value.agentId, prompt: value.prompt } };
+    }
+
+    case "http_request": {
+      if (!isNonEmptyString(value.url)) return missing("url");
+      const method = value.method;
+      if (!(HTTP_METHODS as readonly string[]).includes(method as string)) {
+        return badType("method", `one of ${HTTP_METHODS.join(", ")}`);
+      }
+      if (value.headers !== undefined && !isStringRecord(value.headers)) {
+        return badType("headers", "an object of string values");
+      }
+      if (value.body !== undefined && typeof value.body !== "string") {
+        return badType("body", "a string");
+      }
+      return {
+        ok: true,
+        step: {
+          ...base,
+          type,
+          url: value.url,
+          method: method as "GET" | "POST" | "PUT" | "DELETE",
+          headers: value.headers,
+          body: value.body,
+        },
+      };
+    }
+
+    case "send_message": {
+      if (!isNonEmptyString(value.text)) return missing("text");
+      return { ok: true, step: { ...base, type, text: value.text } };
+    }
+
+    case "create_issue": {
+      if (!isNonEmptyString(value.title)) return missing("title");
+      if (value.description !== undefined && typeof value.description !== "string") {
+        return badType("description", "a string");
+      }
+      if (value.projectId !== undefined && typeof value.projectId !== "string") {
+        return badType("projectId", "a string");
+      }
+      if (value.assigneeAgentId !== undefined && typeof value.assigneeAgentId !== "string") {
+        return badType("assigneeAgentId", "a string");
+      }
+      return {
+        ok: true,
+        step: {
+          ...base,
+          type,
+          title: value.title,
+          description: value.description,
+          projectId: value.projectId,
+          assigneeAgentId: value.assigneeAgentId,
+        },
+      };
+    }
+
+    case "wait_approval": {
+      if (!isNonEmptyString(value.prompt)) return missing("prompt");
+      if (value.timeoutMs !== undefined && typeof value.timeoutMs !== "number") {
+        return badType("timeoutMs", "a number");
+      }
+      return { ok: true, step: { ...base, type, prompt: value.prompt, timeoutMs: value.timeoutMs } };
+    }
+
+    case "set_state": {
+      if (!isNonEmptyString(value.key)) return missing("key");
+      if (typeof value.value !== "string") return missing("value");
+      return { ok: true, step: { ...base, type, key: value.key, value: value.value } };
+    }
+  }
+}
+
+/**
+ * Validates a `JSON.parse`d value against the `CustomCommand` shape before
+ * anything downstream (storage, then `executeWorkflow`) trusts it. Every
+ * `steps[]` entry is checked against its declared `type`'s required fields,
+ * not just the `id`/`type` pair — a `send_message` step missing `text`, or an
+ * `http_request` step with a non-string `body`, is rejected here rather than
+ * failing mid-run with no link back to the import.
+ */
+export function validateCommandDefinition(parsed: unknown): CommandDefinitionValidation {
+  if (!isRecord(parsed)) {
+    return { ok: false, error: "Command definition must be a JSON object with 'name' and 'steps' fields." };
+  }
+
+  if (!isNonEmptyString(parsed.name)) {
+    return { ok: false, error: "Command definition must have a 'name' field." };
+  }
+
+  if (parsed.description !== undefined && typeof parsed.description !== "string") {
+    return { ok: false, error: "Command definition 'description' must be a string." };
+  }
+
+  if (!Array.isArray(parsed.steps)) {
+    return { ok: false, error: "Command definition must have a 'steps' array field." };
+  }
+
+  const steps: WorkflowStep[] = [];
+  for (let i = 0; i < parsed.steps.length; i++) {
+    const result = validateStep(parsed.steps[i], i);
+    if (!result.ok) return { ok: false, error: result.error };
+    steps.push(result.step);
+  }
+
+  return {
+    ok: true,
+    definition: {
+      name: parsed.name,
+      description: typeof parsed.description === "string" ? parsed.description : "No description",
+      steps,
+    },
+  };
+}

--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -1,26 +1,27 @@
 import type { PluginContext } from "@paperclipai/plugin-sdk";
 import { sendMessage, escapeMarkdownV2, sendChatAction } from "./telegram-api.js";
 import { METRIC_NAMES } from "./constants.js";
+import { validateCommandDefinition } from "./command-definition-validation.js";
 
 // --- Types ---
 
-type WorkflowStepBase = {
+export type WorkflowStepBase = {
   id: string;
   name?: string;
 };
 
-type FetchIssueStep = WorkflowStepBase & {
+export type FetchIssueStep = WorkflowStepBase & {
   type: "fetch_issue";
   issueId: string; // supports {{arg1}} template
 };
 
-type InvokeAgentStep = WorkflowStepBase & {
+export type InvokeAgentStep = WorkflowStepBase & {
   type: "invoke_agent";
   agentId: string;
   prompt: string; // supports {{prev.result}}, {{arg1}} etc.
 };
 
-type HttpRequestStep = WorkflowStepBase & {
+export type HttpRequestStep = WorkflowStepBase & {
   type: "http_request";
   url: string;
   method: "GET" | "POST" | "PUT" | "DELETE";
@@ -28,12 +29,12 @@ type HttpRequestStep = WorkflowStepBase & {
   body?: string;
 };
 
-type SendMessageStep = WorkflowStepBase & {
+export type SendMessageStep = WorkflowStepBase & {
   type: "send_message";
   text: string;
 };
 
-type CreateIssueStep = WorkflowStepBase & {
+export type CreateIssueStep = WorkflowStepBase & {
   type: "create_issue";
   title: string;
   description?: string;
@@ -41,19 +42,19 @@ type CreateIssueStep = WorkflowStepBase & {
   assigneeAgentId?: string;
 };
 
-type WaitApprovalStep = WorkflowStepBase & {
+export type WaitApprovalStep = WorkflowStepBase & {
   type: "wait_approval";
   prompt: string;
   timeoutMs?: number;
 };
 
-type SetStateStep = WorkflowStepBase & {
+export type SetStateStep = WorkflowStepBase & {
   type: "set_state";
   key: string;
   value: string;
 };
 
-type WorkflowStep =
+export type WorkflowStep =
   | FetchIssueStep
   | InvokeAgentStep
   | HttpRequestStep
@@ -62,7 +63,7 @@ type WorkflowStep =
   | WaitApprovalStep
   | SetStateStep;
 
-type CustomCommand = {
+export type CustomCommand = {
   name: string;
   description: string;
   steps: WorkflowStep[];
@@ -196,35 +197,24 @@ async function importCommand(
     return;
   }
 
-  let definition: { name: string; description: string; steps: WorkflowStep[] };
+  let parsed: unknown;
   try {
-    definition = JSON.parse(jsonStr);
+    parsed = JSON.parse(jsonStr);
   } catch {
     await sendMessage(ctx, token, chatId, "Invalid JSON. Please provide a valid command definition.", { messageThreadId });
     return;
   }
 
-  if (!definition.name || !definition.steps || !Array.isArray(definition.steps)) {
-    await sendMessage(ctx, token, chatId, "Command definition must have 'name' and 'steps' fields.", { messageThreadId });
+  const validation = validateCommandDefinition(parsed);
+  if (!validation.ok) {
+    await sendMessage(ctx, token, chatId, validation.error, { messageThreadId });
     return;
   }
+  const definition = validation.definition;
 
   if (BUILTIN_COMMANDS.has(definition.name)) {
     await sendMessage(ctx, token, chatId, `Cannot override built-in command: /${definition.name}`, { messageThreadId });
     return;
-  }
-
-  // Validate steps
-  for (const step of definition.steps) {
-    if (!step.type || !step.id) {
-      await sendMessage(ctx, token, chatId, "Each step must have 'type' and 'id' fields.", { messageThreadId });
-      return;
-    }
-    const validTypes = ["fetch_issue", "invoke_agent", "http_request", "send_message", "create_issue", "wait_approval", "set_state"];
-    if (!validTypes.includes(step.type)) {
-      await sendMessage(ctx, token, chatId, `Invalid step type: ${step.type}. Valid: ${validTypes.join(", ")}`, { messageThreadId });
-      return;
-    }
   }
 
   const resolvedCompanyId = companyId ?? chatId;
@@ -234,7 +224,7 @@ async function importCommand(
   const existingIdx = commands.findIndex((c) => c.name === definition.name);
   const newCmd: CustomCommand = {
     name: definition.name,
-    description: definition.description ?? "No description",
+    description: definition.description,
     steps: definition.steps,
     createdBy: `telegram:${chatId}`,
     createdAt: new Date().toISOString(),

--- a/tests/command-registry.test.ts
+++ b/tests/command-registry.test.ts
@@ -259,6 +259,82 @@ describe("Command import validation", () => {
     expect(sentMessages[0].text).toContain("Invalid step type");
   });
 
+  it("rejects well-formed JSON that doesn't match the command definition shape", async () => {
+    const ctx = mockCtx();
+    // Parses fine, but is not a command definition: no 'name', no 'steps'.
+    // Distinct from "Invalid JSON" — the JSON itself is valid.
+    await handleCommandsCommand(ctx, "token", "123", `import ${JSON.stringify({ hello: 1 })}`, undefined, "co-1");
+    expect(sentMessages[0].text).not.toContain("Invalid JSON");
+    expect(sentMessages[0].text).toContain("'name'");
+  });
+
+  it("rejects a definition whose 'steps' field is not an array", async () => {
+    const ctx = mockCtx();
+    const cmd = JSON.stringify({ name: "bad", description: "bad", steps: "not-an-array" });
+    await handleCommandsCommand(ctx, "token", "123", `import ${cmd}`, undefined, "co-1");
+    expect(sentMessages[0].text).toContain("'steps'");
+  });
+
+  it("rejects a send_message step missing 'text'", async () => {
+    const ctx = mockCtx();
+    const cmd = JSON.stringify({
+      name: "bad",
+      description: "bad",
+      steps: [{ id: "s1", type: "send_message" }],
+    });
+    await handleCommandsCommand(ctx, "token", "123", `import ${cmd}`, undefined, "co-1");
+    expect(sentMessages[0].text).toContain("'text'");
+
+    // Rejected at import time, not stored — nothing for executeWorkflow to
+    // half-run later.
+    const stored = stateStore["commands_co-1"] as Array<{ name: string }> | undefined;
+    expect(stored).toBeUndefined();
+  });
+
+  it("rejects a fetch_issue step missing 'issueId'", async () => {
+    const ctx = mockCtx();
+    const cmd = JSON.stringify({
+      name: "bad",
+      description: "bad",
+      steps: [{ id: "s1", type: "fetch_issue" }],
+    });
+    await handleCommandsCommand(ctx, "token", "123", `import ${cmd}`, undefined, "co-1");
+    expect(sentMessages[0].text).toContain("'issueId'");
+  });
+
+  it("rejects an http_request step with an invalid method", async () => {
+    const ctx = mockCtx();
+    const cmd = JSON.stringify({
+      name: "bad",
+      description: "bad",
+      steps: [{ id: "s1", type: "http_request", url: "https://example.com", method: "PATCH" }],
+    });
+    await handleCommandsCommand(ctx, "token", "123", `import ${cmd}`, undefined, "co-1");
+    expect(sentMessages[0].text).toContain("'method'");
+  });
+
+  it("rejects an http_request step whose headers are not string values", async () => {
+    const ctx = mockCtx();
+    const cmd = JSON.stringify({
+      name: "bad",
+      description: "bad",
+      steps: [{ id: "s1", type: "http_request", url: "https://example.com", method: "GET", headers: { "X-Test": 1 } }],
+    });
+    await handleCommandsCommand(ctx, "token", "123", `import ${cmd}`, undefined, "co-1");
+    expect(sentMessages[0].text).toContain("'headers'");
+  });
+
+  it("accepts a fully-specified http_request step", async () => {
+    const ctx = mockCtx();
+    const cmd = JSON.stringify({
+      name: "webhook",
+      description: "Call a webhook",
+      steps: [{ id: "s1", type: "http_request", url: "https://example.com", method: "POST", headers: { "Content-Type": "application/json" }, body: "{}" }],
+    });
+    await handleCommandsCommand(ctx, "token", "123", `import ${cmd}`, undefined, "co-1");
+    expect(sentMessages[0].text).toContain("imported");
+  });
+
   it("updates existing command on re-import", async () => {
     stateStore["commands_co-1"] = [{
       name: "deploy",


### PR DESCRIPTION
## Problem

`JSON.parse` returns `any`, so `/commands import` trusted the parsed value to already match `{name, description, steps}`. Well-formed JSON of the wrong shape sailed through with those fields undefined, failing later inside `executeWorkflow` with no link back to the bad import. Per-step validation only checked `id`/`type`, not each step type's required fields, so a malformed step could still reach execution missing data it needs.

## Fix

New validation module checks the top-level shape and every step against its declared type before anything is stored, and separates "not valid JSON" from "not a command definition" so the user gets a message naming the actual problem.

## Testing

Verified against a clean merge onto current `main`: typecheck clean, 256/256 tests passing.